### PR TITLE
Integrate bookmark mixed content and sync

### DIFF
--- a/apps/app/src/app/api.extension.bookmarks.ts
+++ b/apps/app/src/app/api.extension.bookmarks.ts
@@ -14,6 +14,10 @@ import { InvalidBookmarkUrlError } from "~/server/bookmarks/url";
 import { findExtensionSession } from "~/server/auth/extension";
 import { db } from "~/server/db";
 import { user } from "~/server/db/schema";
+import {
+  publishBookmarkDeletion,
+  publishBookmarkUpsert,
+} from "~/server/mixed-content/sync";
 
 const RESPONSE_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -84,11 +88,29 @@ async function authenticatedExtensionUser(request: Request) {
 type ExtensionBookmarkRouteDependencies = {
   authenticate: typeof authenticatedExtensionUser;
   save: typeof saveBookmarkFromExtension;
+  notify?: (
+    userId: string,
+    result: Awaited<ReturnType<typeof saveBookmarkFromExtension>>,
+  ) => Promise<void>;
 };
 
 const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
   authenticate: authenticatedExtensionUser,
   save: saveBookmarkFromExtension,
+  notify: async (userId, result) => {
+    if (result.removedBookmarkId) {
+      await publishBookmarkDeletion({
+        userId,
+        id: result.removedBookmarkId,
+        canonicalUrl: result.bookmark.canonicalUrl,
+      });
+    }
+    await publishBookmarkUpsert({
+      database: db,
+      userId,
+      bookmarkId: result.bookmark.id,
+    });
+  },
 };
 
 export async function saveExtensionBookmark(
@@ -164,6 +186,7 @@ export async function saveExtensionBookmark(
           ? "invalid_capture"
           : undefined,
     });
+    await dependencies.notify?.(authenticatedUser.id, result);
     return jsonResponse(result, result.disposition === "created" ? 201 : 200);
   } catch (error) {
     if (error instanceof RangeError) {

--- a/apps/app/src/lib/data/atoms.ts
+++ b/apps/app/src/lib/data/atoms.ts
@@ -7,6 +7,8 @@ import { feedCategoriesStore } from "./feed-categories/store";
 import { viewFeedsStore } from "./view-feeds/store";
 import { viewsStore } from "./views/store";
 import { feedsStore } from "./feeds/store";
+import { bookmarksStore } from "./bookmarks/store";
+import { mixedContentStore } from "./mixed-content/store";
 import type { ApplicationView } from "~/server/db/schema";
 
 export const viewsAtom = atom<ApplicationView[]>([]);
@@ -35,6 +37,8 @@ export const useClearAllUserData = () => {
   const resetViewFeeds = viewFeedsStore.useReset();
   const resetViews = viewsStore.useReset();
   const setViewsAtom = useSetAtom(viewsAtom);
+  const resetBookmarks = bookmarksStore.useReset();
+  const resetMixedContent = mixedContentStore.useReset();
 
   return () => {
     resetFeeds();
@@ -43,6 +47,8 @@ export const useClearAllUserData = () => {
     resetFeedCategories();
     resetViewFeeds();
     resetViews();
+    resetBookmarks();
+    resetMixedContent();
     setViewsAtom([]);
     // Wipe all persisted state from IndexedDB immediately.
     // The reset() calls handle in-memory state but write through a 2-second

--- a/apps/app/src/lib/data/bookmarks/manifest.ts
+++ b/apps/app/src/lib/data/bookmarks/manifest.ts
@@ -1,0 +1,14 @@
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+
+export function bookmarkManifestValue(bookmark: ApplicationBookmark) {
+  return [
+    bookmark.updatedAt.toISOString(),
+    bookmark.savedUpdatedAt.toISOString(),
+    bookmark.readUpdatedAt.toISOString(),
+    bookmark.progressUpdatedAt.toISOString(),
+    bookmark.captureHash ?? "",
+    bookmark.capturedAt?.toISOString() ?? "",
+    bookmark.viewIds.join(","),
+    bookmark.tagIds.join(","),
+  ].join("|");
+}

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -1,0 +1,63 @@
+import { createStore } from "zustand";
+import { persist } from "zustand/middleware";
+import { createIDBStorage } from "../idb-storage";
+import { createSelectorHooks } from "../createSelectorHooks";
+import { bookmarkManifestValue } from "./manifest";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type {
+  BookmarkDiffEntry,
+  BookmarkManifestEntry,
+} from "~/server/mixed-content/sync";
+
+type BookmarkStore = {
+  bookmarksDict: Record<string, ApplicationBookmark>;
+  reset: () => void;
+  upsert: (bookmark: ApplicationBookmark) => void;
+  remove: (id: string) => void;
+  applyDiff: (diff: BookmarkDiffEntry[]) => void;
+  manifest: () => BookmarkManifestEntry[];
+};
+
+const vanillaBookmarkStore = createStore<BookmarkStore>()(
+  persist(
+    (set, get) => ({
+      bookmarksDict: {},
+      reset: () => set({ bookmarksDict: {} }),
+      upsert: (bookmark) =>
+        set({
+          bookmarksDict: {
+            ...get().bookmarksDict,
+            [bookmark.id]: bookmark,
+          },
+        }),
+      remove: (id) => {
+        const { [id]: _removed, ...bookmarksDict } = get().bookmarksDict;
+        void _removed;
+        set({ bookmarksDict });
+      },
+      applyDiff: (diff) => {
+        const bookmarksDict = { ...get().bookmarksDict };
+        for (const entry of diff) {
+          if (entry.status === "new" || entry.status === "updated") {
+            bookmarksDict[entry.bookmark.id] = entry.bookmark;
+          } else if (entry.status === "deleted") {
+            delete bookmarksDict[entry.id];
+          }
+        }
+        set({ bookmarksDict });
+      },
+      manifest: () =>
+        Object.values(get().bookmarksDict).map((bookmark) => ({
+          id: bookmark.id,
+          version: bookmarkManifestValue(bookmark),
+        })),
+    }),
+    {
+      name: "serial-bookmarks-store",
+      storage: createIDBStorage(),
+      partialize: (state) => ({ bookmarksDict: state.bookmarksDict }),
+    },
+  ),
+);
+
+export const bookmarksStore = createSelectorHooks(vanillaBookmarkStore);

--- a/apps/app/src/lib/data/hydration.ts
+++ b/apps/app/src/lib/data/hydration.ts
@@ -5,6 +5,8 @@ import { viewFeedsStore } from "./view-feeds/store";
 import { contentCategoriesStore } from "./content-categories/store";
 import { feedCategoriesStore } from "./feed-categories/store";
 import { createHydrationHook } from "./useStoreHydration";
+import { bookmarksStore } from "./bookmarks/store";
+import { mixedContentStore } from "./mixed-content/store";
 
 /**
  * Returns `true` once every persisted Zustand store has finished rehydrating
@@ -18,4 +20,6 @@ export const useStoresHydrated = createHydrationHook(
   viewFeedsStore,
   contentCategoriesStore,
   feedCategoriesStore,
+  bookmarksStore,
+  mixedContentStore,
 );

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -1,0 +1,80 @@
+import { setBulkWatchedValue } from "../feed-items/mutations";
+import { bookmarksStore } from "../bookmarks/store";
+import { feedItemsStore } from "../store";
+import { viewsStore } from "../views/store";
+import { mixedContentStore } from "./store";
+import type { MixedContentReference } from "~/server/mixed-content/projection";
+import { orpcRouterClient } from "~/lib/orpc";
+
+export function partitionMixedReadTargets(references: MixedContentReference[]) {
+  return references.reduce(
+    (targets, reference) => {
+      if (reference.entityKind === "bookmark") {
+        targets.bookmarkIds.push(reference.entityId);
+        return targets;
+      }
+      const item = feedItemsStore.getState().feedItemsDict[reference.entityId];
+      if (item) targets.feedItems.push({ id: item.id, feedId: item.feedId });
+      return targets;
+    },
+    {
+      bookmarkIds: [] as string[],
+      feedItems: [] as Array<{ id: string; feedId: number }>,
+    },
+  );
+}
+
+export async function setMixedReadValue(input: {
+  references: MixedContentReference[];
+  isRead: boolean;
+}) {
+  const targets = partitionMixedReadTargets(input.references);
+  const previousBookmarks = targets.bookmarkIds
+    .map((id) => bookmarksStore.getState().bookmarksDict[id])
+    .filter((bookmark) => bookmark !== undefined);
+  const now = new Date();
+
+  for (const bookmark of previousBookmarks) {
+    const optimisticBookmark = {
+      ...bookmark,
+      isRead: input.isRead,
+      readUpdatedAt: now,
+      updatedAt: now,
+    };
+    bookmarksStore.getState().upsert(optimisticBookmark);
+    mixedContentStore.getState().reprojectUpsert({
+      bookmark: optimisticBookmark,
+      feedItems: feedItemsStore.getState().feedItemsDict,
+      views: viewsStore.getState().views,
+    });
+  }
+
+  try {
+    await Promise.all([
+      targets.bookmarkIds.length > 0
+        ? orpcRouterClient.bookmark.setBulkReadValue({
+            bookmarkIds: targets.bookmarkIds,
+            isRead: input.isRead,
+          })
+        : Promise.resolve([]),
+      targets.feedItems.length > 0
+        ? setBulkWatchedValue({
+            items: targets.feedItems,
+            isWatched: input.isRead,
+          })
+        : Promise.resolve(),
+    ]);
+  } catch (error) {
+    for (const bookmark of previousBookmarks) {
+      bookmarksStore.getState().upsert(bookmark);
+      mixedContentStore.getState().reprojectUpsert({
+        bookmark,
+        feedItems: feedItemsStore.getState().feedItemsDict,
+        views: viewsStore.getState().views,
+      });
+    }
+    throw error;
+  }
+
+  return targets;
+}

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -1,0 +1,291 @@
+import { createStore } from "zustand";
+import { persist } from "zustand/middleware";
+import { createIDBStorage } from "../idb-storage";
+import { createSelectorHooks } from "../createSelectorHooks";
+import type { VisibilityFilter } from "../atoms";
+import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
+import type {
+  ApplicationBookmark,
+  MixedContentCursor,
+  MixedContentPage,
+  MixedContentReference,
+  MixedContentScope,
+} from "~/server/mixed-content/projection";
+
+export type LoadedMixedScope = {
+  scope: MixedContentScope;
+  visibility: VisibilityFilter;
+  references: MixedContentReference[];
+  cursor: MixedContentCursor;
+  hasMore: boolean;
+};
+
+type SuppressedReferences = Record<
+  string,
+  Record<string, MixedContentReference[]>
+>;
+
+type MixedContentStore = {
+  scopes: Record<string, LoadedMixedScope>;
+  suppressedReferences: SuppressedReferences;
+  reset: () => void;
+  applyPage: (input: {
+    scope: MixedContentScope;
+    visibility: VisibilityFilter;
+    page: MixedContentPage;
+    replacesScope: boolean;
+  }) => void;
+  reprojectUpsert: (input: {
+    bookmark: ApplicationBookmark;
+    feedItems: Record<string, ApplicationFeedItem>;
+    views: ApplicationView[];
+  }) => LoadedMixedScope[];
+  reprojectDeletion: (bookmarkId: string) => LoadedMixedScope[];
+};
+
+export function getMixedScopeKey(
+  scope: MixedContentScope,
+  visibility: VisibilityFilter,
+) {
+  return scope.type === "view"
+    ? `view:${scope.viewId}:${visibility}`
+    : `tag:${scope.tagId}:${visibility}`;
+}
+
+function compareReferences(
+  left: MixedContentReference,
+  right: MixedContentReference,
+) {
+  const leftPlacement = left.sectionPlacement ?? 0;
+  const rightPlacement = right.sectionPlacement ?? 0;
+  if (leftPlacement !== rightPlacement) return leftPlacement - rightPlacement;
+  const timeDifference =
+    right.normalizedAt.getTime() - left.normalizedAt.getTime();
+  if (timeDifference !== 0) return timeDifference;
+  const kindDifference = left.entityKind.localeCompare(right.entityKind);
+  if (kindDifference !== 0) return kindDifference;
+  return right.entityId.localeCompare(left.entityId);
+}
+
+function matchesVisibility(
+  bookmark: ApplicationBookmark,
+  visibility: VisibilityFilter,
+) {
+  if (visibility === "later") return bookmark.isSaved;
+  if (bookmark.isSaved) return false;
+  return visibility === "read" ? bookmark.isRead : !bookmark.isRead;
+}
+
+function matchesScope(
+  bookmark: ApplicationBookmark,
+  scope: MixedContentScope,
+  views: ApplicationView[],
+) {
+  const bookmarkTagIds = new Set(bookmark.tagIds);
+  const bookmarkViewIds = new Set(bookmark.viewIds);
+  if (scope.type === "tag") return bookmarkTagIds.has(scope.tagId);
+  const customViews = views.filter((view) => view.id >= 0);
+  if (scope.viewId < 0) {
+    return !customViews.some(
+      (view) =>
+        (view.contentType === "all" || view.contentType === "longform") &&
+        (bookmarkViewIds.has(view.id) ||
+          view.categoryIds.some((tagId) => bookmarkTagIds.has(tagId)) ||
+          (view.feedIds.length === 0 && view.categoryIds.length === 0)),
+    );
+  }
+  const view = customViews.find((candidate) => candidate.id === scope.viewId);
+  if (
+    !view ||
+    (view.contentType !== "all" && view.contentType !== "longform")
+  ) {
+    return false;
+  }
+  return (
+    bookmarkViewIds.has(view.id) ||
+    view.categoryIds.some((tagId) => bookmarkTagIds.has(tagId)) ||
+    (view.feedIds.length === 0 && view.categoryIds.length === 0)
+  );
+}
+
+function bookmarkReference(
+  bookmark: ApplicationBookmark,
+  scopeState: LoadedMixedScope,
+  views: ApplicationView[],
+): MixedContentReference {
+  const scope = scopeState.scope;
+  const bookmarkTagIds = new Set(bookmark.tagIds);
+  const view =
+    scope.type === "view"
+      ? views.find((candidate) => candidate.id === scope.viewId)
+      : undefined;
+  const hasSections =
+    scopeState.visibility !== "read" && (view?.viewSections.length ?? 0) > 0;
+  const matchingPlacements =
+    view?.viewSections
+      .filter(
+        (section) =>
+          section.itemType === "tag" && bookmarkTagIds.has(section.itemId),
+      )
+      .map((section) => section.placement) ?? [];
+  const normalizedAt =
+    scopeState.visibility === "later"
+      ? bookmark.savedUpdatedAt
+      : scopeState.visibility === "read"
+        ? bookmark.readUpdatedAt
+        : bookmark.createdAt;
+  return {
+    entityKind: "bookmark",
+    entityId: bookmark.id,
+    sectionPlacement: hasSections
+      ? matchingPlacements.length > 0
+        ? Math.min(...matchingPlacements)
+        : 999_999
+      : null,
+    normalizedAt,
+  };
+}
+
+function uniqueReferences(references: MixedContentReference[]) {
+  const byKey = new Map(
+    references.map((reference) => [
+      `${reference.entityKind}:${reference.entityId}`,
+      reference,
+    ]),
+  );
+  return [...byKey.values()].sort(compareReferences);
+}
+
+const vanillaMixedContentStore = createStore<MixedContentStore>()(
+  persist(
+    (set, get) => ({
+      scopes: {},
+      suppressedReferences: {},
+      reset: () => set({ scopes: {}, suppressedReferences: {} }),
+      applyPage: ({ scope, visibility, page, replacesScope }) => {
+        const key = getMixedScopeKey(scope, visibility);
+        const existing = get().scopes[key];
+        set({
+          scopes: {
+            ...get().scopes,
+            [key]: {
+              scope,
+              visibility,
+              references: uniqueReferences(
+                replacesScope
+                  ? page.references
+                  : [...(existing?.references ?? []), ...page.references],
+              ),
+              cursor: page.cursor,
+              hasMore: page.hasMore,
+            },
+          },
+        });
+      },
+      reprojectUpsert: ({ bookmark, feedItems, views }) => {
+        const scopes = { ...get().scopes };
+        const suppressedReferences = { ...get().suppressedReferences };
+        const bookmarkSuppressed = {
+          ...(suppressedReferences[bookmark.id] ?? {}),
+        };
+        const affected: LoadedMixedScope[] = [];
+
+        for (const [key, scopeState] of Object.entries(scopes)) {
+          const newlySuppressed = scopeState.references.filter((reference) => {
+            if (reference.entityKind !== "feed-item") return false;
+            const item = feedItems[reference.entityId];
+            return item?.url
+              ? canonicalize(item.url) === bookmark.canonicalUrl
+              : false;
+          });
+          if (newlySuppressed.length > 0) {
+            bookmarkSuppressed[key] = uniqueReferences([
+              ...(bookmarkSuppressed[key] ?? []),
+              ...newlySuppressed,
+            ]);
+          }
+          const newlySuppressedKeys = new Set(
+            newlySuppressed.map(
+              (reference) => `${reference.entityKind}:${reference.entityId}`,
+            ),
+          );
+          let references = scopeState.references.filter(
+            (reference) =>
+              reference.entityId !== bookmark.id &&
+              !newlySuppressedKeys.has(
+                `${reference.entityKind}:${reference.entityId}`,
+              ),
+          );
+          if (
+            matchesVisibility(bookmark, scopeState.visibility) &&
+            matchesScope(bookmark, scopeState.scope, views)
+          ) {
+            references = [
+              ...references,
+              bookmarkReference(bookmark, scopeState, views),
+            ];
+          }
+          const nextScope = {
+            ...scopeState,
+            references: uniqueReferences(references),
+          };
+          scopes[key] = nextScope;
+          affected.push(nextScope);
+        }
+        suppressedReferences[bookmark.id] = bookmarkSuppressed;
+        set({ scopes, suppressedReferences });
+        return affected;
+      },
+      reprojectDeletion: (bookmarkId) => {
+        const scopes = { ...get().scopes };
+        const suppressedForBookmark =
+          get().suppressedReferences[bookmarkId] ?? {};
+        const affected: LoadedMixedScope[] = [];
+        for (const [key, scopeState] of Object.entries(scopes)) {
+          const nextScope = {
+            ...scopeState,
+            references: uniqueReferences([
+              ...scopeState.references.filter(
+                (reference) =>
+                  !(
+                    reference.entityKind === "bookmark" &&
+                    reference.entityId === bookmarkId
+                  ),
+              ),
+              ...(suppressedForBookmark[key] ?? []),
+            ]),
+          };
+          scopes[key] = nextScope;
+          affected.push(nextScope);
+        }
+        const { [bookmarkId]: _removed, ...suppressedReferences } =
+          get().suppressedReferences;
+        void _removed;
+        set({ scopes, suppressedReferences });
+        return affected;
+      },
+    }),
+    {
+      name: "serial-mixed-content-store",
+      storage: createIDBStorage(),
+      partialize: (state) => ({
+        scopes: state.scopes,
+        suppressedReferences: state.suppressedReferences,
+      }),
+    },
+  ),
+);
+
+function canonicalize(url: string) {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    if (parsed.protocol === "http:" && parsed.port === "80") parsed.port = "";
+    if (parsed.protocol === "https:" && parsed.port === "443") parsed.port = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+export const mixedContentStore = createSelectorHooks(vanillaMixedContentStore);

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -1,0 +1,64 @@
+import { bookmarksStore } from "./bookmarks/store";
+import { feedItemsStore } from "./store";
+import { mixedContentStore } from "./mixed-content/store";
+import { viewsStore } from "./views/store";
+import type { LoadedMixedScope } from "./mixed-content/store";
+import type { PublishedChunk } from "~/server/api/publisher";
+
+export function processPublishedChunks(payloads: PublishedChunk[]) {
+  const feedPayloads = payloads.filter(
+    (payload) => payload.source !== "bookmark" && payload.source !== "mixed",
+  );
+  if (feedPayloads.length > 0)
+    feedItemsStore.getState().processChunks(feedPayloads);
+
+  const affectedScopes = new Map<string, LoadedMixedScope>();
+  for (const payload of payloads) {
+    if (payload.source === "mixed") {
+      const { chunk } = payload;
+      for (const bookmark of chunk.page.bookmarks) {
+        bookmarksStore.getState().upsert(bookmark);
+      }
+      for (const item of chunk.page.feedItems) {
+        feedItemsStore.getState().setFeedItem(item.id, item);
+      }
+      mixedContentStore.getState().applyPage({
+        scope: chunk.scope,
+        visibility: chunk.visibility,
+        page: chunk.page,
+        replacesScope: chunk.replacesScope,
+      });
+      continue;
+    }
+    if (payload.source !== "bookmark") continue;
+    const { chunk } = payload;
+    if (chunk.type === "bookmark-diff") {
+      bookmarksStore.getState().applyDiff(chunk.diff);
+      continue;
+    }
+    if (chunk.type === "bookmark-upsert") {
+      bookmarksStore.getState().upsert(chunk.bookmark);
+      const affected = mixedContentStore.getState().reprojectUpsert({
+        bookmark: chunk.bookmark,
+        feedItems: feedItemsStore.getState().feedItemsDict,
+        views: viewsStore.getState().views,
+      });
+      for (const scope of affected) {
+        affectedScopes.set(
+          JSON.stringify([scope.scope, scope.visibility]),
+          scope,
+        );
+      }
+      continue;
+    }
+    bookmarksStore.getState().remove(chunk.id);
+    const affected = mixedContentStore.getState().reprojectDeletion(chunk.id);
+    for (const scope of affected) {
+      affectedScopes.set(
+        JSON.stringify([scope.scope, scope.visibility]),
+        scope,
+      );
+    }
+  }
+  return [...affectedScopes.values()];
+}

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -6,7 +6,8 @@ import { orpcRouterClient } from "../orpc";
 import { getDataSubscriptionClientId } from "./clientChannel";
 import { combineAbortSignals } from "./combineAbortSignals";
 import { loadingActor } from "./loading-machine";
-import { feedItemsStore } from "./store";
+import { bookmarksStore } from "./bookmarks/store";
+import { processPublishedChunks } from "./subscriptionCoordinator";
 import { shouldAlwaysKeepSSEConnectionAlive } from "./atoms";
 import type { PublishedChunk } from "~/server/api/publisher";
 import type { VisibilityFilter } from "./atoms";
@@ -63,8 +64,16 @@ export function useDataSubscription() {
     const chunks = chunkBufferRef.current;
     if (chunks.length === 0) return;
     chunkBufferRef.current = [];
-    feedItemsStore.getState().processChunks(chunks);
-  }, []);
+    const affectedScopes = processPublishedChunks(chunks);
+    for (const scope of affectedScopes) {
+      void orpcRouterClient.mixedContent.requestPage({
+        clientId,
+        scope: scope.scope,
+        visibility: scope.visibility,
+        cursor: null,
+      });
+    }
+  }, [clientId]);
 
   // Cleanup aborts the stream and removes both direct subscriptions. The
   // subscription loop also combines its connection signal with this abort.
@@ -112,9 +121,13 @@ export function useDataSubscription() {
           // refresh if the cooldown elapsed while the tab was hidden.
           if (visibilityReconnect) {
             visibilityReconnect = false;
-            void orpcRouterClient.initial.requestInitialData({
-              clientId,
-            });
+            void Promise.all([
+              orpcRouterClient.initial.requestInitialData({ clientId }),
+              orpcRouterClient.mixedContent.synchronize({
+                clientId,
+                bookmarkManifest: bookmarksStore.getState().manifest(),
+              }),
+            ]);
           }
 
           for await (const payload of iterator as AsyncIterable<PublishedChunk>) {
@@ -211,7 +224,7 @@ export function useDataSubscription() {
       }
       // Flush remaining chunks synchronously on unmount
       if (chunkBufferRef.current.length > 0) {
-        feedItemsStore.getState().processChunks(chunkBufferRef.current);
+        processPublishedChunks(chunkBufferRef.current);
         chunkBufferRef.current = [];
       }
     };
@@ -219,9 +232,13 @@ export function useDataSubscription() {
 
   // Request methods that trigger data fetching via the publisher
   const requestInitialData = useCallback(() => {
-    return orpcRouterClient.initial.requestInitialData({
-      clientId,
-    });
+    return Promise.all([
+      orpcRouterClient.initial.requestInitialData({ clientId }),
+      orpcRouterClient.mixedContent.synchronize({
+        clientId,
+        bookmarkManifest: bookmarksStore.getState().manifest(),
+      }),
+    ]);
   }, [clientId]);
 
   const requestFullTextForItems = useCallback(
@@ -305,10 +322,32 @@ export function useDataSubscription() {
  */
 export const dataSubscriptionActions = {
   requestInitialData: () => {
-    return orpcRouterClient.initial.requestInitialData({
-      clientId: getDataSubscriptionClientId(),
-    });
+    const clientId = getDataSubscriptionClientId();
+    return Promise.all([
+      orpcRouterClient.initial.requestInitialData({ clientId }),
+      orpcRouterClient.mixedContent.synchronize({
+        clientId,
+        bookmarkManifest: bookmarksStore.getState().manifest(),
+      }),
+    ]);
   },
+  requestMixedContentPage: (
+    scope: Parameters<
+      typeof orpcRouterClient.mixedContent.requestPage
+    >[0]["scope"],
+    visibility: VisibilityFilter,
+    cursor?: Parameters<
+      typeof orpcRouterClient.mixedContent.requestPage
+    >[0]["cursor"],
+    limit?: number,
+  ) =>
+    orpcRouterClient.mixedContent.requestPage({
+      clientId: getDataSubscriptionClientId(),
+      scope,
+      visibility,
+      cursor,
+      limit,
+    }),
   requestFullTextForItems: (itemIds: string[]) => {
     return orpcRouterClient.initial.requestFullTextForItems({
       itemIds,

--- a/apps/app/src/server/api/publisher.ts
+++ b/apps/app/src/server/api/publisher.ts
@@ -6,6 +6,10 @@ import type {
   GetItemsByVisibilityChunk,
   RevalidateViewChunk,
 } from "./routers/initialRouter";
+import type {
+  BookmarkSyncChunk,
+  MixedContentChunk,
+} from "~/server/mixed-content/sync";
 import { env } from "~/env";
 import { logError, logMessage } from "~/server/logger";
 
@@ -14,7 +18,9 @@ export type PublishedChunk =
   | { source: "revalidate"; chunk: RevalidateViewChunk }
   | { source: "visibility"; chunk: GetItemsByVisibilityChunk }
   | { source: "feed"; chunk: GetItemsByFeedChunk }
-  | { source: "category"; chunk: GetItemsByCategoryIdChunk };
+  | { source: "category"; chunk: GetItemsByCategoryIdChunk }
+  | { source: "bookmark"; chunk: BookmarkSyncChunk }
+  | { source: "mixed"; chunk: MixedContentChunk };
 
 const RESUME_RETENTION_SECONDS = 60 * 2;
 const REDIS_KEY_PREFIX = "serial:pub:";

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -9,6 +9,10 @@ import {
   updateBookmarkState,
 } from "~/server/bookmarks/service";
 import { normalizeBookmarkUrl } from "~/server/bookmarks/url";
+import {
+  publishBookmarkDeletion,
+  publishBookmarkUpsert,
+} from "~/server/mixed-content/sync";
 
 const bookmarkIdSchema = z.string().min(1);
 const bookmarkUrlSchema = z.string().superRefine((value, context) => {
@@ -29,13 +33,26 @@ export const save = protectedProcedure
       bookmarkId: bookmarkIdSchema.optional(),
     }),
   )
-  .handler(({ context, input }) =>
-    saveBookmarkFromApp({
+  .handler(async ({ context, input }) => {
+    const result = await saveBookmarkFromApp({
       database: context.db,
       userId: context.user.id,
       ...input,
-    }),
-  );
+    });
+    if (result.removedBookmarkId) {
+      await publishBookmarkDeletion({
+        userId: context.user.id,
+        id: result.removedBookmarkId,
+        canonicalUrl: result.bookmark.canonicalUrl,
+      });
+    }
+    await publishBookmarkUpsert({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: result.bookmark.id,
+    });
+    return result;
+  });
 
 export const getCapture = protectedProcedure
   .input(
@@ -68,13 +85,19 @@ export const updateState = protectedProcedure
         { message: "Progress and duration must be updated together" },
       ),
   )
-  .handler(({ context, input }) =>
-    updateBookmarkState({
+  .handler(async ({ context, input }) => {
+    const bookmark = await updateBookmarkState({
       database: context.db,
       userId: context.user.id,
       ...input,
-    }),
-  );
+    });
+    await publishBookmarkUpsert({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: bookmark.id,
+    });
+    return bookmark;
+  });
 
 export const setView = protectedProcedure
   .input(
@@ -84,13 +107,18 @@ export const setView = protectedProcedure
       assigned: z.boolean(),
     }),
   )
-  .handler(({ context, input }) =>
-    setBookmarkView({
+  .handler(async ({ context, input }) => {
+    await setBookmarkView({
       database: context.db,
       userId: context.user.id,
       ...input,
-    }),
-  );
+    });
+    await publishBookmarkUpsert({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
+  });
 
 export const setTag = protectedProcedure
   .input(
@@ -100,20 +128,61 @@ export const setTag = protectedProcedure
       assigned: z.boolean(),
     }),
   )
-  .handler(({ context, input }) =>
-    setBookmarkTag({
+  .handler(async ({ context, input }) => {
+    await setBookmarkTag({
       database: context.db,
       userId: context.user.id,
       ...input,
+    });
+    await publishBookmarkUpsert({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
+  });
+
+export const setBulkReadValue = protectedProcedure
+  .input(
+    z.object({
+      bookmarkIds: z.array(bookmarkIdSchema).max(500),
+      isRead: z.boolean(),
     }),
-  );
+  )
+  .handler(async ({ context, input }) => {
+    const updated = await Promise.all(
+      input.bookmarkIds.map((bookmarkId) =>
+        updateBookmarkState({
+          database: context.db,
+          userId: context.user.id,
+          bookmarkId,
+          isRead: input.isRead,
+        }),
+      ),
+    );
+    await Promise.all(
+      updated.map((bookmark) =>
+        publishBookmarkUpsert({
+          database: context.db,
+          userId: context.user.id,
+          bookmarkId: bookmark.id,
+        }),
+      ),
+    );
+    return updated;
+  });
 
 export const remove = protectedProcedure
   .input(z.object({ bookmarkId: bookmarkIdSchema }))
-  .handler(({ context, input }) =>
-    deleteBookmark({
+  .handler(async ({ context, input }) => {
+    const deleted = await deleteBookmark({
       database: context.db,
       userId: context.user.id,
       ...input,
-    }),
-  );
+    });
+    await publishBookmarkDeletion({
+      userId: context.user.id,
+      id: deleted.id,
+      canonicalUrl: deleted.canonicalUrl,
+    });
+    return deleted;
+  });

--- a/apps/app/src/server/api/routers/initialRouter.ts
+++ b/apps/app/src/server/api/routers/initialRouter.ts
@@ -6,6 +6,7 @@ import {
   getTableColumns,
   gt,
   inArray,
+  isNull,
   lt,
   or,
   sql,
@@ -37,6 +38,10 @@ import type {
 } from "~/server/db/schema";
 import type { ORPCContext } from "~/server/orpc/base";
 import type { FetchFeedsStatus } from "~/server/rss/fetchFeeds";
+import type {
+  BookmarkSyncChunk,
+  MixedContentChunk,
+} from "~/server/mixed-content/sync";
 import { captureException, logDebug, logError } from "~/server/logger";
 import {
   checkUserRefreshEligibility,
@@ -82,6 +87,7 @@ export type PaginationCursor = {
   postedAt: Date;
   id: string;
   isWatchedUpdatedAt?: Date | null;
+  isWatchLaterUpdatedAt?: Date | null;
 } | null;
 
 export type ClientManifestEntry = {
@@ -197,7 +203,9 @@ type RouterPublishedChunk =
   | { source: "revalidate"; chunk: RevalidateViewChunk }
   | { source: "visibility"; chunk: GetItemsByVisibilityChunk }
   | { source: "feed"; chunk: GetItemsByFeedChunk }
-  | { source: "category"; chunk: GetItemsByCategoryIdChunk };
+  | { source: "category"; chunk: GetItemsByCategoryIdChunk }
+  | { source: "bookmark"; chunk: BookmarkSyncChunk }
+  | { source: "mixed"; chunk: MixedContentChunk };
 
 type ChannelSubscription = {
   channel: string;
@@ -699,6 +707,7 @@ function processPaginationResults<
     id: string;
     placement?: number;
     isWatchedUpdatedAt?: Date | null;
+    isWatchLaterUpdatedAt?: Date | null;
   },
 >(itemsData: T[], limit: number): PaginationResult<T> {
   const hasMore = itemsData.length > limit;
@@ -712,6 +721,7 @@ function processPaginationResults<
           postedAt: lastItem.postedAt,
           id: lastItem.id,
           isWatchedUpdatedAt: lastItem.isWatchedUpdatedAt ?? undefined,
+          isWatchLaterUpdatedAt: lastItem.isWatchLaterUpdatedAt ?? undefined,
         }
       : null;
 
@@ -818,13 +828,20 @@ function buildPaginatedFeedItemQuery({
   const filterConditions = [
     ...scopeFilterConditions,
     buildVisibilityFilter(visibilityFilter),
-    buildCursorCondition(cursor, placementExpr),
+    buildCursorCondition(cursor, visibilityFilter, placementExpr),
   ].filter((f): f is NonNullable<typeof f> => f !== undefined);
 
   return {
     filter: filterConditions.length > 0 ? and(...filterConditions) : undefined,
     orderBy: placementExpr
-      ? [asc(placementExpr), desc(feedItems.postedAt), desc(feedItems.id)]
+      ? visibilityFilter === "later"
+        ? [
+            asc(placementExpr),
+            desc(feedItems.isWatchLaterUpdatedAt),
+            desc(feedItems.postedAt),
+            desc(feedItems.id),
+          ]
+        : [asc(placementExpr), desc(feedItems.postedAt), desc(feedItems.id)]
       : buildFlatItemsOrderBy(visibilityFilter),
     placementExpr,
   };
@@ -2264,6 +2281,7 @@ const cursorSchema = z
     postedAt: z.coerce.date(),
     id: z.string(),
     isWatchedUpdatedAt: z.coerce.date().nullable().optional(),
+    isWatchLaterUpdatedAt: z.coerce.date().nullable().optional(),
   })
   .nullable();
 
@@ -2278,10 +2296,33 @@ function buildCursorCondition(
     postedAt: Date;
     id: string;
     isWatchedUpdatedAt?: Date | null;
+    isWatchLaterUpdatedAt?: Date | null;
   } | null,
+  visibilityFilter: VisibilityFilter,
   placementColumn?: SQL<number>,
 ) {
   if (!cursor) return undefined;
+
+  if (visibilityFilter === "later") {
+    const savedAt = cursor.isWatchLaterUpdatedAt ?? null;
+    const postedAtCondition = or(
+      lt(feedItems.postedAt, cursor.postedAt),
+      and(eq(feedItems.postedAt, cursor.postedAt), lt(feedItems.id, cursor.id)),
+    );
+    const timeCondition = savedAt
+      ? or(
+          lt(feedItems.isWatchLaterUpdatedAt, savedAt),
+          isNull(feedItems.isWatchLaterUpdatedAt),
+          and(eq(feedItems.isWatchLaterUpdatedAt, savedAt), postedAtCondition),
+        )
+      : and(isNull(feedItems.isWatchLaterUpdatedAt), postedAtCondition);
+    if (!placementColumn || cursor.placement === undefined)
+      return timeCondition;
+    return or(
+      gt(placementColumn, cursor.placement),
+      and(eq(placementColumn, cursor.placement), timeCondition),
+    );
+  }
 
   // isWatchedUpdatedAt-based cursor for read visibility filter
   if (cursor.isWatchedUpdatedAt) {
@@ -2328,6 +2369,14 @@ function buildFlatItemsOrderBy(visibilityFilter: VisibilityFilter) {
   if (visibilityFilter === "read") {
     return [
       desc(feedItems.isWatchedUpdatedAt),
+      desc(feedItems.postedAt),
+      desc(feedItems.id),
+    ];
+  }
+
+  if (visibilityFilter === "later") {
+    return [
+      desc(feedItems.isWatchLaterUpdatedAt),
       desc(feedItems.postedAt),
       desc(feedItems.id),
     ];

--- a/apps/app/src/server/api/routers/mixedContentRouter.ts
+++ b/apps/app/src/server/api/routers/mixedContentRouter.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import type { MixedContentScope } from "~/server/mixed-content/projection";
+import { getClientChannel } from "~/server/api/channels";
+import { INITIAL_ITEMS_PER_VIEW, ITEMS_PER_PAGE } from "~/server/api/constants";
+import { publisher } from "~/server/api/publisher";
+import { visibilityFilterSchema } from "~/lib/data/atoms";
+import { INBOX_VIEW_ID } from "~/lib/data/views/constants";
+import { views } from "~/server/db/schema";
+import { protectedProcedure } from "~/server/orpc/base";
+import { queryMixedContentPage } from "~/server/mixed-content/projection";
+import { buildBookmarkDiff } from "~/server/mixed-content/sync";
+
+const clientIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
+const scopeSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("view"), viewId: z.number().int() }),
+  z.object({ type: z.literal("tag"), tagId: z.number().int() }),
+]);
+
+const cursorSchema = z
+  .object({
+    sectionPlacement: z.number().nullable(),
+    normalizedAt: z.coerce.date(),
+    entityKind: z.enum(["bookmark", "feed-item"]),
+    entityId: z.string(),
+  })
+  .nullable();
+
+const manifestSchema = z.array(
+  z.object({ id: z.string().min(1), version: z.string() }),
+);
+
+async function publishPage(input: {
+  database: Parameters<typeof queryMixedContentPage>[0]["database"];
+  userId: string;
+  clientId: string;
+  scope: MixedContentScope;
+  visibility: "unread" | "read" | "later";
+  cursor?: Parameters<typeof queryMixedContentPage>[0]["cursor"];
+  limit: number;
+}) {
+  const page = await queryMixedContentPage(input);
+  await publisher.publish(getClientChannel(input.userId, input.clientId), {
+    source: "mixed",
+    chunk: {
+      type: "mixed-content-page",
+      scope: input.scope,
+      visibility: input.visibility,
+      page,
+      replacesScope: !input.cursor,
+    },
+  });
+}
+
+export const requestPage = protectedProcedure
+  .input(
+    z.object({
+      clientId: clientIdSchema,
+      scope: scopeSchema,
+      visibility: visibilityFilterSchema,
+      cursor: cursorSchema.optional(),
+      limit: z.number().int().min(1).max(500).optional(),
+    }),
+  )
+  .handler(async ({ context, input }) => {
+    await publishPage({
+      database: context.db,
+      userId: context.user.id,
+      clientId: input.clientId,
+      scope: input.scope,
+      visibility: input.visibility,
+      cursor: input.cursor,
+      limit: input.limit ?? ITEMS_PER_PAGE,
+    });
+    return { status: "completed" as const };
+  });
+
+export const synchronize = protectedProcedure
+  .input(
+    z.object({
+      clientId: clientIdSchema,
+      bookmarkManifest: manifestSchema.max(10_000).default([]),
+    }),
+  )
+  .handler(async ({ context, input }) => {
+    const userId = context.user.id;
+    const clientChannel = getClientChannel(userId, input.clientId);
+    const [bookmarkDiff, customViews] = await Promise.all([
+      buildBookmarkDiff({
+        database: context.db,
+        userId,
+        clientManifest: input.bookmarkManifest,
+      }),
+      context.db
+        .select({ id: views.id })
+        .from(views)
+        .where(eq(views.userId, userId)),
+    ]);
+    await publisher.publish(clientChannel, {
+      source: "bookmark",
+      chunk: { type: "bookmark-diff", diff: bookmarkDiff },
+    });
+
+    const scopes: MixedContentScope[] = [
+      { type: "view", viewId: INBOX_VIEW_ID },
+      ...customViews.map(({ id }) => ({ type: "view" as const, viewId: id })),
+    ];
+    const visibilities = ["unread", "read", "later"] as const;
+    await Promise.all(
+      scopes.flatMap((scope) =>
+        visibilities.map((visibility) =>
+          publishPage({
+            database: context.db,
+            userId,
+            clientId: input.clientId,
+            scope,
+            visibility,
+            limit: INITIAL_ITEMS_PER_VIEW,
+          }),
+        ),
+      ),
+    );
+    return { status: "completed" as const };
+  });

--- a/apps/app/src/server/bookmarks/service.ts
+++ b/apps/app/src/server/bookmarks/service.ts
@@ -553,7 +553,7 @@ export async function deleteBookmark(input: {
         eq(bookmarks.userId, input.userId),
       ),
     )
-    .returning({ id: bookmarks.id })
+    .returning({ id: bookmarks.id, canonicalUrl: bookmarks.canonicalUrl })
     .get();
   if (!deleted) throw new BookmarkNotFoundError("Bookmark not found");
   return deleted;

--- a/apps/app/src/server/mixed-content/projection.ts
+++ b/apps/app/src/server/mixed-content/projection.ts
@@ -1,0 +1,604 @@
+import { asc, eq, getTableColumns, inArray } from "drizzle-orm";
+import type { VisibilityFilter } from "~/lib/data/atoms";
+import type { db as defaultDatabase } from "~/server/db";
+import type {
+  ApplicationFeedItem,
+  DatabaseBookmark,
+  DatabaseFeed,
+  DatabaseView,
+  DatabaseViewSection,
+} from "~/server/db/schema";
+import { INBOX_VIEW_ID } from "~/lib/data/views/constants";
+import {
+  bookmarks,
+  bookmarkTags,
+  bookmarkViews,
+  contentCategories,
+  feedCategories,
+  feedItems,
+  feeds,
+  pageCaptures,
+  viewCategories,
+  viewFeeds,
+  views,
+  viewSections,
+} from "~/server/db/schema";
+import { normalizeBookmarkUrl } from "~/server/bookmarks/url";
+
+const UNCATEGORIZED_SECTION_PLACEMENT = 999_999;
+const VIDEO_PLATFORMS = new Set(["youtube", "peertube", "nebula"]);
+
+type MixedContentDatabase = typeof defaultDatabase;
+
+export type MixedContentScope =
+  { type: "view"; viewId: number } | { type: "tag"; tagId: number };
+
+export type MixedContentEntityKind = "bookmark" | "feed-item";
+
+export type MixedContentCursor = {
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+  entityKind: MixedContentEntityKind;
+  entityId: string;
+} | null;
+
+export type ApplicationBookmark = DatabaseBookmark & {
+  title: string;
+  author: string | null;
+  publishedAt: Date | null;
+  effectiveUrl: string | null;
+  iconUrl: string | null;
+  representativeImageUrl: string | null;
+  captureHash: string | null;
+  capturedAt: Date | null;
+  viewIds: number[];
+  tagIds: number[];
+};
+
+export type MixedContentReference = {
+  entityKind: MixedContentEntityKind;
+  entityId: string;
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+};
+
+export type MixedContentPage = {
+  references: MixedContentReference[];
+  bookmarks: ApplicationBookmark[];
+  feedItems: ApplicationFeedItem[];
+  cursor: MixedContentCursor;
+  hasMore: boolean;
+};
+
+type ViewDefinition = DatabaseView & {
+  categoryIds: number[];
+  feedIds: number[];
+  categoryIdSet: Set<number>;
+  feedIdSet: Set<number>;
+  sections: DatabaseViewSection[];
+};
+
+type FeedCandidate = {
+  entityKind: "feed-item";
+  entityId: string;
+  item: ApplicationFeedItem;
+  canonicalUrl: string | null;
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+};
+
+type BookmarkCandidate = {
+  entityKind: "bookmark";
+  entityId: string;
+  item: ApplicationBookmark;
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+};
+
+type Candidate = FeedCandidate | BookmarkCandidate;
+
+function titleFromUrl(url: string) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function canonicalizeFeedItemUrl(url: string) {
+  try {
+    return normalizeBookmarkUrl(url);
+  } catch {
+    return null;
+  }
+}
+
+function isBookmarkVisible(
+  bookmark: ApplicationBookmark,
+  visibility: VisibilityFilter,
+) {
+  if (visibility === "later") return bookmark.isSaved;
+  if (bookmark.isSaved) return false;
+  return visibility === "read" ? bookmark.isRead : !bookmark.isRead;
+}
+
+function isFeedItemVisible(
+  item: ApplicationFeedItem,
+  visibility: VisibilityFilter,
+) {
+  if (visibility === "later") return item.isWatchLater;
+  if (item.isWatchLater) return false;
+  return visibility === "read" ? item.isWatched : !item.isWatched;
+}
+
+function isFeedCompatibleWithView(feed: DatabaseFeed, view: DatabaseView) {
+  if (view.contentType === "all" || view.contentType === "longform") {
+    return true;
+  }
+  return VIDEO_PLATFORMS.has(feed.platform);
+}
+
+function doesFeedItemMatchContentType(
+  item: ApplicationFeedItem,
+  view: DatabaseView,
+) {
+  if (view.contentType === "all") return true;
+  if (view.contentType === "longform") return item.orientation !== "vertical";
+  if (!VIDEO_PLATFORMS.has(item.platform)) return false;
+  return view.contentType === "vertical-video"
+    ? item.orientation === "vertical"
+    : item.orientation === "horizontal";
+}
+
+function isBookmarkCompatibleWithView(view: DatabaseView) {
+  return view.contentType === "all" || view.contentType === "longform";
+}
+
+function isInsideTimeWindow(date: Date, daysWindow: number) {
+  if (daysWindow <= 0) return true;
+  return date.getTime() >= Date.now() - daysWindow * 24 * 60 * 60 * 1_000;
+}
+
+function feedBelongsToCustomView(input: {
+  feed: DatabaseFeed;
+  feedTagIds: Set<number>;
+  view: ViewDefinition;
+}) {
+  const { feed, feedTagIds, view } = input;
+  if (!isFeedCompatibleWithView(feed, view)) return false;
+  if (view.feedIdSet.has(feed.id)) return true;
+  if (
+    [...view.categoryIdSet].some((categoryId) => feedTagIds.has(categoryId))
+  ) {
+    return true;
+  }
+  return view.feedIds.length === 0 && view.categoryIds.length === 0;
+}
+
+function bookmarkBelongsToCustomView(
+  bookmarkTagIds: Set<number>,
+  bookmarkViewIds: Set<number>,
+  view: ViewDefinition,
+) {
+  if (!isBookmarkCompatibleWithView(view)) return false;
+  if (bookmarkViewIds.has(view.id)) return true;
+  if (
+    [...view.categoryIdSet].some((categoryId) => bookmarkTagIds.has(categoryId))
+  ) {
+    return true;
+  }
+  return view.feedIds.length === 0 && view.categoryIds.length === 0;
+}
+
+function feedBelongsToScope(input: {
+  item: ApplicationFeedItem;
+  feed: DatabaseFeed;
+  feedTagIds: Set<number>;
+  scope: MixedContentScope;
+  targetView: ViewDefinition | null;
+  customViews: ViewDefinition[];
+}) {
+  const { item, feed, feedTagIds, scope, targetView, customViews } = input;
+  if (scope.type === "tag") return feedTagIds.has(scope.tagId);
+  if (scope.viewId === INBOX_VIEW_ID) {
+    return !customViews.some((view) =>
+      feedBelongsToCustomView({ feed, feedTagIds, view }),
+    );
+  }
+  if (!targetView) return false;
+  return (
+    feedBelongsToCustomView({ feed, feedTagIds, view: targetView }) &&
+    doesFeedItemMatchContentType(item, targetView) &&
+    isInsideTimeWindow(item.postedAt, targetView.daysWindow)
+  );
+}
+
+function bookmarkBelongsToScope(input: {
+  bookmark: ApplicationBookmark;
+  bookmarkTagIds: Set<number>;
+  bookmarkViewIds: Set<number>;
+  scope: MixedContentScope;
+  targetView: ViewDefinition | null;
+  customViews: ViewDefinition[];
+}) {
+  const {
+    bookmark,
+    bookmarkTagIds,
+    bookmarkViewIds,
+    scope,
+    targetView,
+    customViews,
+  } = input;
+  if (scope.type === "tag") return bookmarkTagIds.has(scope.tagId);
+  if (scope.viewId === INBOX_VIEW_ID) {
+    return !customViews.some((view) =>
+      bookmarkBelongsToCustomView(bookmarkTagIds, bookmarkViewIds, view),
+    );
+  }
+  if (!targetView) return false;
+  return (
+    bookmarkBelongsToCustomView(bookmarkTagIds, bookmarkViewIds, targetView) &&
+    isInsideTimeWindow(bookmark.createdAt, targetView.daysWindow)
+  );
+}
+
+function sectionPlacementForFeed(
+  item: ApplicationFeedItem,
+  feedTagIds: Set<number>,
+  sections: DatabaseViewSection[],
+) {
+  let feedPlacement = Infinity;
+  let tagPlacement = Infinity;
+  for (const section of sections) {
+    if (section.itemType === "feed" && section.itemId === item.feedId) {
+      feedPlacement = Math.min(feedPlacement, section.placement);
+    }
+    if (section.itemType === "tag" && feedTagIds.has(section.itemId)) {
+      tagPlacement = Math.min(tagPlacement, section.placement);
+    }
+  }
+  if (feedPlacement !== Infinity) return feedPlacement;
+  if (tagPlacement !== Infinity) return tagPlacement;
+  return UNCATEGORIZED_SECTION_PLACEMENT;
+}
+
+function sectionPlacementForBookmark(
+  bookmarkTagIds: Set<number>,
+  sections: DatabaseViewSection[],
+) {
+  const placements = sections
+    .filter(
+      (section) =>
+        section.itemType === "tag" && bookmarkTagIds.has(section.itemId),
+    )
+    .map((section) => section.placement);
+  return placements.length > 0
+    ? Math.min(...placements)
+    : UNCATEGORIZED_SECTION_PLACEMENT;
+}
+
+function normalizedFeedTime(
+  item: ApplicationFeedItem,
+  visibility: VisibilityFilter,
+) {
+  if (visibility === "later")
+    return item.isWatchLaterUpdatedAt ?? item.postedAt;
+  if (visibility === "read") return item.isWatchedUpdatedAt ?? item.postedAt;
+  return item.postedAt;
+}
+
+function normalizedBookmarkTime(
+  bookmark: ApplicationBookmark,
+  visibility: VisibilityFilter,
+) {
+  if (visibility === "later") return bookmark.savedUpdatedAt;
+  if (visibility === "read") return bookmark.readUpdatedAt;
+  return bookmark.createdAt;
+}
+
+function compareCandidates(left: Candidate, right: Candidate) {
+  const leftPlacement = left.sectionPlacement ?? 0;
+  const rightPlacement = right.sectionPlacement ?? 0;
+  if (leftPlacement !== rightPlacement) return leftPlacement - rightPlacement;
+
+  const timeDifference =
+    right.normalizedAt.getTime() - left.normalizedAt.getTime();
+  if (timeDifference !== 0) return timeDifference;
+
+  const kindDifference = left.entityKind.localeCompare(right.entityKind);
+  if (kindDifference !== 0) return kindDifference;
+  return right.entityId.localeCompare(left.entityId);
+}
+
+function candidateFromCursor(
+  cursor: NonNullable<MixedContentCursor>,
+): Candidate {
+  const shared = {
+    entityId: cursor.entityId,
+    sectionPlacement: cursor.sectionPlacement,
+    normalizedAt: cursor.normalizedAt,
+  };
+  return cursor.entityKind === "bookmark"
+    ? {
+        ...shared,
+        entityKind: "bookmark",
+        item: {} as ApplicationBookmark,
+      }
+    : {
+        ...shared,
+        entityKind: "feed-item",
+        item: {} as ApplicationFeedItem,
+        canonicalUrl: null,
+      };
+}
+
+export async function loadApplicationBookmarks(input: {
+  database: MixedContentDatabase;
+  userId: string;
+}): Promise<ApplicationBookmark[]> {
+  const { database, userId } = input;
+  const bookmarkRows = await database
+    .select({
+      bookmark: getTableColumns(bookmarks),
+      capture: getTableColumns(pageCaptures),
+    })
+    .from(bookmarks)
+    .leftJoin(pageCaptures, eq(pageCaptures.bookmarkId, bookmarks.id))
+    .where(eq(bookmarks.userId, userId));
+  const bookmarkIds = bookmarkRows.map(({ bookmark }) => bookmark.id);
+  const [viewRows, tagRows] =
+    bookmarkIds.length === 0
+      ? [[], []]
+      : await Promise.all([
+          database
+            .select()
+            .from(bookmarkViews)
+            .where(inArray(bookmarkViews.bookmarkId, bookmarkIds)),
+          database
+            .select()
+            .from(bookmarkTags)
+            .where(inArray(bookmarkTags.bookmarkId, bookmarkIds)),
+        ]);
+
+  return bookmarkRows.map(({ bookmark, capture }) => ({
+    ...bookmark,
+    title: capture?.title || titleFromUrl(bookmark.sourceUrl),
+    author: capture?.author ?? null,
+    publishedAt: capture?.publishedAt ?? null,
+    effectiveUrl: capture?.effectiveUrl ?? null,
+    iconUrl: capture?.iconUrl ?? null,
+    representativeImageUrl: capture?.representativeImageUrl ?? null,
+    captureHash: capture?.contentHash ?? null,
+    capturedAt: capture?.capturedAt ?? null,
+    viewIds: viewRows
+      .filter((row) => row.bookmarkId === bookmark.id)
+      .map((row) => row.viewId)
+      .sort((left, right) => left - right),
+    tagIds: tagRows
+      .filter((row) => row.bookmarkId === bookmark.id)
+      .map((row) => row.tagId)
+      .sort((left, right) => left - right),
+  }));
+}
+
+async function loadProjectionData(
+  database: MixedContentDatabase,
+  userId: string,
+) {
+  const [feedRows, bookmarkList, viewRows, categoryRows] = await Promise.all([
+    database
+      .select({
+        item: getTableColumns(feedItems),
+        feed: getTableColumns(feeds),
+      })
+      .from(feedItems)
+      .innerJoin(feeds, eq(feedItems.feedId, feeds.id))
+      .where(eq(feeds.userId, userId)),
+    loadApplicationBookmarks({ database, userId }),
+    database
+      .select()
+      .from(views)
+      .where(eq(views.userId, userId))
+      .orderBy(asc(views.placement)),
+    database
+      .select()
+      .from(contentCategories)
+      .where(eq(contentCategories.userId, userId)),
+  ]);
+  const feedIds = [...new Set(feedRows.map(({ feed }) => feed.id))];
+  const viewIds = viewRows.map((view) => view.id);
+  const categoryIds = categoryRows.map((category) => category.id);
+  const [feedTagRows, viewTagRows, viewFeedRows, sectionRows] =
+    await Promise.all([
+      feedIds.length > 0
+        ? database
+            .select()
+            .from(feedCategories)
+            .where(inArray(feedCategories.feedId, feedIds))
+        : Promise.resolve([]),
+      viewIds.length > 0
+        ? database
+            .select()
+            .from(viewCategories)
+            .where(inArray(viewCategories.viewId, viewIds))
+        : Promise.resolve([]),
+      viewIds.length > 0
+        ? database
+            .select()
+            .from(viewFeeds)
+            .where(inArray(viewFeeds.viewId, viewIds))
+        : Promise.resolve([]),
+      viewIds.length > 0
+        ? database
+            .select()
+            .from(viewSections)
+            .where(inArray(viewSections.viewId, viewIds))
+        : Promise.resolve([]),
+    ]);
+
+  const validCategoryIds = new Set(categoryIds);
+  const customViews: ViewDefinition[] = viewRows.map((view) => {
+    const viewCategoryIds = viewTagRows
+      .filter((row) => row.viewId === view.id && row.categoryId !== null)
+      .map((row) => row.categoryId!)
+      .filter((id) => validCategoryIds.has(id));
+    const viewFeedIds = viewFeedRows
+      .filter((row) => row.viewId === view.id)
+      .map((row) => row.feedId);
+    return {
+      ...view,
+      categoryIds: viewCategoryIds,
+      feedIds: viewFeedIds,
+      categoryIdSet: new Set(viewCategoryIds),
+      feedIdSet: new Set(viewFeedIds),
+      sections: sectionRows
+        .filter((row) => row.viewId === view.id)
+        .sort((left, right) => left.placement - right.placement),
+    };
+  });
+
+  return { feedRows, bookmarkList, customViews, feedTagRows };
+}
+
+export async function queryMixedContentPage(input: {
+  database: MixedContentDatabase;
+  userId: string;
+  scope: MixedContentScope;
+  visibility: VisibilityFilter;
+  cursor?: MixedContentCursor;
+  limit: number;
+}): Promise<MixedContentPage> {
+  const { database, userId, scope, visibility, limit } = input;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new Error("Mixed-content page limit must be between 1 and 500");
+  }
+
+  const { feedRows, bookmarkList, customViews, feedTagRows } =
+    await loadProjectionData(database, userId);
+  const targetView =
+    scope.type === "view" && scope.viewId !== INBOX_VIEW_ID
+      ? (customViews.find((view) => view.id === scope.viewId) ?? null)
+      : null;
+  const hasSections =
+    visibility !== "read" &&
+    scope.type === "view" &&
+    targetView !== null &&
+    targetView.sections.length > 0;
+  const canonicalBookmarks = new Set(
+    bookmarkList.map((bookmark) => bookmark.canonicalUrl),
+  );
+  const candidates: Candidate[] = [];
+
+  for (const bookmark of bookmarkList) {
+    if (!isBookmarkVisible(bookmark, visibility)) continue;
+    const bookmarkTagIds = new Set(bookmark.tagIds);
+    const bookmarkViewIds = new Set(bookmark.viewIds);
+    if (
+      !bookmarkBelongsToScope({
+        bookmark,
+        bookmarkTagIds,
+        bookmarkViewIds,
+        scope,
+        targetView,
+        customViews,
+      })
+    ) {
+      continue;
+    }
+    candidates.push({
+      entityKind: "bookmark",
+      entityId: bookmark.id,
+      item: bookmark,
+      normalizedAt: normalizedBookmarkTime(bookmark, visibility),
+      sectionPlacement: hasSections
+        ? sectionPlacementForBookmark(bookmarkTagIds, targetView.sections)
+        : null,
+    });
+  }
+
+  for (const { item, feed } of feedRows) {
+    const canonicalUrl = canonicalizeFeedItemUrl(item.url);
+    if (canonicalUrl && canonicalBookmarks.has(canonicalUrl)) continue;
+    const applicationItem = {
+      ...item,
+      platform: feed.platform,
+    } as ApplicationFeedItem;
+    if (!isFeedItemVisible(applicationItem, visibility)) continue;
+    const feedTagIds = new Set(
+      feedTagRows
+        .filter((row) => row.feedId === feed.id)
+        .map((row) => row.categoryId),
+    );
+    if (
+      !feedBelongsToScope({
+        item: applicationItem,
+        feed,
+        feedTagIds,
+        scope,
+        targetView,
+        customViews,
+      })
+    ) {
+      continue;
+    }
+    candidates.push({
+      entityKind: "feed-item",
+      entityId: item.id,
+      item: applicationItem,
+      canonicalUrl,
+      normalizedAt: normalizedFeedTime(applicationItem, visibility),
+      sectionPlacement: hasSections
+        ? sectionPlacementForFeed(
+            applicationItem,
+            feedTagIds,
+            targetView.sections,
+          )
+        : null,
+    });
+  }
+
+  candidates.sort(compareCandidates);
+  const cursorCandidate = input.cursor
+    ? candidateFromCursor(input.cursor)
+    : null;
+  const afterCursor = cursorCandidate
+    ? candidates.filter(
+        (candidate) => compareCandidates(candidate, cursorCandidate) > 0,
+      )
+    : candidates;
+  const hasMore = afterCursor.length > limit;
+  const pageCandidates = afterCursor.slice(0, limit);
+  const lastCandidate = pageCandidates.at(-1);
+  const cursor: MixedContentCursor =
+    hasMore && lastCandidate
+      ? {
+          sectionPlacement: lastCandidate.sectionPlacement,
+          normalizedAt: lastCandidate.normalizedAt,
+          entityKind: lastCandidate.entityKind,
+          entityId: lastCandidate.entityId,
+        }
+      : null;
+
+  return {
+    references: pageCandidates.map((candidate) => ({
+      entityKind: candidate.entityKind,
+      entityId: candidate.entityId,
+      sectionPlacement: candidate.sectionPlacement,
+      normalizedAt: candidate.normalizedAt,
+    })),
+    bookmarks: pageCandidates
+      .filter(
+        (candidate): candidate is BookmarkCandidate =>
+          candidate.entityKind === "bookmark",
+      )
+      .map((candidate) => candidate.item),
+    feedItems: pageCandidates
+      .filter(
+        (candidate): candidate is FeedCandidate =>
+          candidate.entityKind === "feed-item",
+      )
+      .map((candidate) => candidate.item),
+    cursor,
+    hasMore,
+  };
+}

--- a/apps/app/src/server/mixed-content/sync.ts
+++ b/apps/app/src/server/mixed-content/sync.ts
@@ -1,0 +1,106 @@
+import { loadApplicationBookmarks } from "./projection";
+import type {
+  ApplicationBookmark,
+  MixedContentPage,
+  MixedContentScope,
+} from "./projection";
+import type { db as defaultDatabase } from "~/server/db";
+import type { VisibilityFilter } from "~/lib/data/atoms";
+import { bookmarkManifestValue } from "~/lib/data/bookmarks/manifest";
+import { getUserChannel } from "~/server/api/channels";
+import { publisher } from "~/server/api/publisher";
+
+type MixedContentDatabase = typeof defaultDatabase;
+
+export type BookmarkManifestEntry = {
+  id: string;
+  version: string;
+};
+
+export type BookmarkDiffEntry =
+  | { status: "unchanged"; id: string }
+  | { status: "new" | "updated"; bookmark: ApplicationBookmark }
+  | { status: "deleted"; id: string };
+
+export type BookmarkSyncChunk =
+  | { type: "bookmark-diff"; diff: BookmarkDiffEntry[] }
+  | { type: "bookmark-upsert"; bookmark: ApplicationBookmark }
+  | { type: "bookmark-delete"; id: string; canonicalUrl: string };
+
+export type MixedContentChunk = {
+  type: "mixed-content-page";
+  scope: MixedContentScope;
+  visibility: VisibilityFilter;
+  page: MixedContentPage;
+  replacesScope: boolean;
+};
+
+export function computeBookmarkDiff(
+  serverBookmarks: ApplicationBookmark[],
+  clientManifest: BookmarkManifestEntry[],
+): BookmarkDiffEntry[] {
+  const clientVersions = new Map(
+    clientManifest.map((entry) => [entry.id, entry.version]),
+  );
+  const serverIds = new Set(serverBookmarks.map((bookmark) => bookmark.id));
+  const diff: BookmarkDiffEntry[] = serverBookmarks.map((bookmark) => {
+    const clientVersion = clientVersions.get(bookmark.id);
+    if (clientVersion === undefined) return { status: "new", bookmark };
+    if (clientVersion === bookmarkManifestValue(bookmark)) {
+      return { status: "unchanged", id: bookmark.id };
+    }
+    return { status: "updated", bookmark };
+  });
+
+  for (const entry of clientManifest) {
+    if (!serverIds.has(entry.id))
+      diff.push({ status: "deleted", id: entry.id });
+  }
+  return diff;
+}
+
+export async function buildBookmarkDiff(input: {
+  database: MixedContentDatabase;
+  userId: string;
+  clientManifest: BookmarkManifestEntry[];
+}) {
+  const serverBookmarks = await loadApplicationBookmarks(input);
+  return computeBookmarkDiff(serverBookmarks, input.clientManifest);
+}
+
+export async function loadApplicationBookmark(input: {
+  database: MixedContentDatabase;
+  userId: string;
+  bookmarkId: string;
+}) {
+  const bookmarks = await loadApplicationBookmarks(input);
+  return bookmarks.find((bookmark) => bookmark.id === input.bookmarkId) ?? null;
+}
+
+export async function publishBookmarkUpsert(input: {
+  database: MixedContentDatabase;
+  userId: string;
+  bookmarkId: string;
+}) {
+  const bookmark = await loadApplicationBookmark(input);
+  if (!bookmark) return;
+  await publisher.publish(getUserChannel(input.userId), {
+    source: "bookmark",
+    chunk: { type: "bookmark-upsert", bookmark },
+  });
+}
+
+export async function publishBookmarkDeletion(input: {
+  userId: string;
+  id: string;
+  canonicalUrl: string;
+}) {
+  await publisher.publish(getUserChannel(input.userId), {
+    source: "bookmark",
+    chunk: {
+      type: "bookmark-delete",
+      id: input.id,
+      canonicalUrl: input.canonicalUrl,
+    },
+  });
+}

--- a/apps/app/src/server/orpc/router.ts
+++ b/apps/app/src/server/orpc/router.ts
@@ -11,6 +11,7 @@ import * as viewRouter from "~/server/api/routers/viewRouter";
 import * as viewFeedsRouter from "~/server/api/routers/viewFeedsRouter";
 import * as subscriptionRouter from "~/server/api/routers/subscriptionRouter";
 import * as bookmarkRouter from "~/server/api/routers/bookmarkRouter";
+import * as mixedContentRouter from "~/server/api/routers/mixedContentRouter";
 
 export const orpcRouter = {
   admin: adminRouter,
@@ -26,4 +27,5 @@ export const orpcRouter = {
   viewFeeds: viewFeedsRouter,
   subscription: subscriptionRouter,
   bookmark: bookmarkRouter,
+  mixedContent: mixedContentRouter,
 };

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -86,6 +86,66 @@ export async function setFeedItemAsYouTubeVideo(
   client.close();
 }
 
+export async function seedBookmarkProjectionData(
+  tursoPort: number,
+  email: string,
+  feedItemId: string,
+) {
+  const { db, client } = getDb(tursoPort);
+  const [testUser, item, userView] = await Promise.all([
+    db.select().from(schema.user).where(eq(schema.user.email, email)).get(),
+    db
+      .select()
+      .from(schema.feedItems)
+      .where(eq(schema.feedItems.id, feedItemId))
+      .get(),
+    db
+      .select()
+      .from(schema.views)
+      .innerJoin(schema.user, eq(schema.views.userId, schema.user.id))
+      .where(eq(schema.user.email, email))
+      .get(),
+  ]);
+  if (!testUser || !item || !userView) {
+    client.close();
+    throw new Error("Bookmark projection seed prerequisites were not found");
+  }
+
+  const bookmarkId = `bookmark-${uniqueId()}`;
+  const now = new Date();
+  await db.insert(schema.bookmarks).values({
+    id: bookmarkId,
+    userId: testUser.id,
+    sourceUrl: item.url,
+    canonicalUrl: item.url,
+    isSaved: true,
+    isRead: false,
+    createdAt: now,
+    updatedAt: now,
+    savedUpdatedAt: now,
+    readUpdatedAt: now,
+    progressUpdatedAt: now,
+  });
+  await db.insert(schema.bookmarkViews).values({
+    bookmarkId,
+    viewId: userView.views.id,
+  });
+  await db.insert(schema.pageCaptures).values({
+    bookmarkId,
+    title: "Captured Bookmark",
+    author: "Bookmark Author",
+    contentHtml: "<p>Captured Bookmark body</p>",
+    effectiveUrl: item.url,
+    contentHash: `hash-${bookmarkId}`,
+    captureSource: "extension-live-dom",
+    extractorVersion: "playwright-fixture",
+    sanitizerPolicyVersion: 1,
+    capturedAt: now,
+  });
+  client.close();
+  return { bookmarkId, viewId: userView.views.id };
+}
+
 export async function getViewsForUser(tursoPort: number, email: string) {
   const { db, client } = getDb(tursoPort);
   const userViews = await db

--- a/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import {
+  SELF_HOSTED_APP_PORT,
+  SELF_HOSTED_TURSO_PORT,
+} from "../fixtures/ports";
+import {
+  cleanupUser,
+  seedArticleData,
+  seedBookmarkProjectionData,
+} from "../fixtures/seed-db";
+import { signIn } from "../fixtures/auth";
+import type { Page } from "@playwright/test";
+
+async function persistedStore(page: Page, key: string) {
+  return page.evaluate(async (storeKey) => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("keyval-store");
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+    try {
+      return await new Promise<unknown>((resolve, reject) => {
+        const transaction = database.transaction("keyval", "readonly");
+        const request = transaction.objectStore("keyval").get(storeKey);
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => resolve(request.result);
+      });
+    } finally {
+      database.close();
+    }
+  }, key);
+}
+
+test.describe("Bookmark mixed-content synchronization", () => {
+  let testEmail: string;
+
+  test.afterEach(async () => {
+    if (testEmail) await cleanupUser(SELF_HOSTED_TURSO_PORT, testEmail);
+  });
+
+  test("hydrates separate Bookmark and mixed caches with canonical suppression", async ({
+    page,
+  }) => {
+    const { email, password, feedItemId } = await seedArticleData(
+      SELF_HOSTED_TURSO_PORT,
+      SELF_HOSTED_APP_PORT,
+    );
+    testEmail = email;
+    const { bookmarkId, viewId } = await seedBookmarkProjectionData(
+      SELF_HOSTED_TURSO_PORT,
+      email,
+      feedItemId,
+    );
+
+    await signIn({ page, email, password });
+
+    await expect
+      .poll(
+        async () => {
+          const bookmarkCache = (await persistedStore(
+            page,
+            "serial-bookmarks-store",
+          )) as {
+            state?: { bookmarksDict?: Record<string, { captureHash: string }> };
+          } | null;
+          return bookmarkCache?.state?.bookmarksDict?.[bookmarkId]?.captureHash;
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(`hash-${bookmarkId}`);
+
+    await expect
+      .poll(
+        async () => {
+          const mixedCache = (await persistedStore(
+            page,
+            "serial-mixed-content-store",
+          )) as {
+            state?: {
+              scopes?: Record<
+                string,
+                { references: Array<{ entityKind: string; entityId: string }> }
+              >;
+            };
+          } | null;
+          const scopes = mixedCache?.state?.scopes;
+          return {
+            saved:
+              scopes?.[`view:${viewId}:later`]?.references.map(
+                ({ entityKind, entityId }) => ({ entityKind, entityId }),
+              ) ?? null,
+            unread:
+              scopes?.[`view:${viewId}:unread`]?.references.map(
+                ({ entityKind, entityId }) => ({ entityKind, entityId }),
+              ) ?? null,
+          };
+        },
+        { timeout: 30_000 },
+      )
+      .toEqual({
+        saved: [{ entityKind: "bookmark", entityId: bookmarkId }],
+        unread: [],
+      });
+  });
+});

--- a/apps/app/tests/unit/bookmarks/mixed-content-projection.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-projection.test.ts
@@ -1,0 +1,474 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBookmarkTestDatabase } from "./database";
+import type { MixedContentCursor } from "~/server/mixed-content/projection";
+import { INBOX_VIEW_ID } from "~/lib/data/views/constants";
+import {
+  bookmarks,
+  bookmarkTags,
+  bookmarkViews,
+  contentCategories,
+  feedCategories,
+  feedItems,
+  feeds,
+  pageCaptures,
+  user,
+  viewCategories,
+  viewFeeds,
+  views,
+  viewSections,
+} from "~/server/db/schema";
+import { queryMixedContentPage } from "~/server/mixed-content/projection";
+
+type TestDatabase = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["database"];
+type Cleanup = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["cleanup"];
+
+let database: TestDatabase;
+let cleanup: Cleanup;
+
+const NOW = new Date("2026-07-30T12:00:00.000Z");
+
+async function seedUser(id = "user-one") {
+  await database.insert(user).values({
+    id,
+    name: id,
+    email: `${id}@example.com`,
+    emailVerified: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+}
+
+async function seedFeed(
+  id: number,
+  overrides: Partial<typeof feeds.$inferInsert> = {},
+) {
+  await database.insert(feeds).values({
+    id,
+    userId: "user-one",
+    name: `Feed ${id}`,
+    url: `https://feeds.example/${id}.xml`,
+    platform: "website",
+    ...overrides,
+  });
+}
+
+async function seedFeedItem(input: {
+  id: string;
+  feedId: number;
+  url: string;
+  postedAt?: Date;
+  isWatched?: boolean;
+  isWatchLater?: boolean;
+  isWatchedUpdatedAt?: Date | null;
+  isWatchLaterUpdatedAt?: Date | null;
+}) {
+  await database.insert(feedItems).values({
+    id: input.id,
+    feedId: input.feedId,
+    contentId: input.id,
+    title: input.id,
+    author: "Author",
+    url: input.url,
+    postedAt: input.postedAt ?? NOW,
+    createdAt: input.postedAt ?? NOW,
+    updatedAt: NOW,
+    orientation: "horizontal",
+    isWatched: input.isWatched ?? false,
+    isWatchLater: input.isWatchLater ?? false,
+    isWatchedUpdatedAt: input.isWatchedUpdatedAt ?? null,
+    isWatchLaterUpdatedAt: input.isWatchLaterUpdatedAt ?? null,
+  });
+}
+
+async function seedBookmark(input: {
+  id: string;
+  canonicalUrl?: string;
+  isSaved?: boolean;
+  isRead?: boolean;
+  createdAt?: Date;
+  savedUpdatedAt?: Date;
+  readUpdatedAt?: Date;
+  userId?: string;
+}) {
+  const canonicalUrl =
+    input.canonicalUrl ?? `https://bookmarks.example/${input.id}`;
+  await database.insert(bookmarks).values({
+    id: input.id,
+    userId: input.userId ?? "user-one",
+    sourceUrl: canonicalUrl,
+    canonicalUrl,
+    isSaved: input.isSaved ?? true,
+    isRead: input.isRead ?? false,
+    createdAt: input.createdAt ?? NOW,
+    savedUpdatedAt: input.savedUpdatedAt ?? NOW,
+    readUpdatedAt: input.readUpdatedAt ?? NOW,
+    progressUpdatedAt: NOW,
+    updatedAt: NOW,
+  });
+}
+
+async function seedView(id: number, name: string) {
+  await database.insert(views).values({
+    id,
+    userId: "user-one",
+    name,
+    contentType: "longform",
+    layout: "list",
+  });
+}
+
+beforeEach(async () => {
+  ({ database, cleanup } = await createBookmarkTestDatabase());
+  await seedUser();
+});
+
+afterEach(() => cleanup());
+
+describe("mixed-content projection", () => {
+  it("suppresses every canonical Feed item before mixed membership while preserving Feed-only access and independent deletion", async () => {
+    await seedFeed(1);
+    await seedFeed(2);
+    await seedView(10, "Feed view");
+    await seedView(11, "Bookmark view");
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 1 });
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 2 });
+
+    const canonicalUrl = "https://example.com/article";
+    await seedFeedItem({
+      id: "feed-match-one",
+      feedId: 1,
+      url: `${canonicalUrl}#feed-one`,
+    });
+    await seedFeedItem({
+      id: "feed-match-two",
+      feedId: 2,
+      url: `${canonicalUrl}#feed-two`,
+    });
+    await seedFeedItem({
+      id: "feed-other",
+      feedId: 1,
+      url: "https://example.com/other",
+    });
+    await seedBookmark({ id: "bookmark-match", canonicalUrl });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "bookmark-match", viewId: 11 });
+
+    const mixedFeedView = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "unread",
+      limit: 20,
+    });
+    expect(
+      mixedFeedView.references.map((reference) => reference.entityId),
+    ).toEqual(["feed-other"]);
+
+    const feedOnlyItems = await database
+      .select()
+      .from(feedItems)
+      .where(eq(feedItems.feedId, 1));
+    expect(feedOnlyItems.map((item) => item.id).sort()).toEqual([
+      "feed-match-one",
+      "feed-other",
+    ]);
+
+    await database.delete(feeds).where(eq(feeds.id, 1));
+    expect(await database.select().from(bookmarks)).toHaveLength(1);
+    await database.delete(bookmarks).where(eq(bookmarks.id, "bookmark-match"));
+
+    const restored = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "unread",
+      limit: 20,
+    });
+    expect(restored.references.map((reference) => reference.entityId)).toEqual([
+      "feed-match-two",
+    ]);
+  });
+
+  it("uses Bookmark-owned Views and Tags, earliest ordered Tag sections, and Uncategorized membership", async () => {
+    await seedFeed(1);
+    await seedFeedItem({
+      id: "tagged-feed",
+      feedId: 1,
+      url: "https://feeds.example/tagged",
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: NOW,
+    });
+    await seedView(10, "Ordered");
+    await database.insert(contentCategories).values([
+      { id: 1, userId: "user-one", name: "First" },
+      { id: 2, userId: "user-one", name: "Second" },
+    ]);
+    await database.insert(viewCategories).values([
+      { viewId: 10, categoryId: 1 },
+      { viewId: 10, categoryId: 2 },
+    ]);
+    await database.insert(viewSections).values([
+      { viewId: 10, placement: 1, itemType: "tag", itemId: 1 },
+      { viewId: 10, placement: 2, itemType: "tag", itemId: 2 },
+    ]);
+    await database.insert(feedCategories).values({ feedId: 1, categoryId: 2 });
+    await seedBookmark({ id: "both-tags" });
+    await seedBookmark({ id: "direct-only" });
+    await seedBookmark({ id: "uncategorized" });
+    await database.insert(bookmarkTags).values([
+      { bookmarkId: "both-tags", tagId: 1 },
+      { bookmarkId: "both-tags", tagId: 2 },
+    ]);
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "direct-only", viewId: 10 });
+
+    const ordered = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "later",
+      limit: 20,
+    });
+    expect(
+      ordered.references.map(({ entityId, sectionPlacement }) => ({
+        entityId,
+        sectionPlacement,
+      })),
+    ).toEqual([
+      { entityId: "both-tags", sectionPlacement: 1 },
+      { entityId: "tagged-feed", sectionPlacement: 2 },
+      { entityId: "direct-only", sectionPlacement: 999_999 },
+    ]);
+
+    const uncategorized = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: INBOX_VIEW_ID },
+      visibility: "later",
+      limit: 20,
+    });
+    expect(
+      uncategorized.references.map((reference) => reference.entityId),
+    ).toEqual(["uncategorized"]);
+
+    const tagScope = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "tag", tagId: 2 },
+      visibility: "later",
+      limit: 20,
+    });
+    expect(
+      tagScope.references.map((reference) => reference.entityId).sort(),
+    ).toEqual(["both-tags", "tagged-feed"]);
+  });
+
+  it("applies Saved dominance and visibility-specific normalized ordering to both entity kinds", async () => {
+    await seedView(10, "Everything");
+    await seedFeed(1);
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 1 });
+    await seedFeedItem({
+      id: "recently-saved-old-feed",
+      feedId: 1,
+      url: "https://example.com/old",
+      postedAt: new Date("2020-01-01T00:00:00Z"),
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: new Date("2026-07-30T11:00:00Z"),
+    });
+    await seedFeedItem({
+      id: "earlier-saved-new-feed",
+      feedId: 1,
+      url: "https://example.com/new",
+      postedAt: new Date("2026-07-30T11:59:00Z"),
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: new Date("2026-07-30T09:00:00Z"),
+    });
+    await seedBookmark({
+      id: "saved-and-read",
+      isSaved: true,
+      isRead: true,
+      savedUpdatedAt: new Date("2026-07-30T10:00:00Z"),
+    });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "saved-and-read", viewId: 10 });
+    await seedBookmark({ id: "unsaved-unread", isSaved: false, isRead: false });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "unsaved-unread", viewId: 10 });
+    await seedBookmark({ id: "unsaved-read", isSaved: false, isRead: true });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "unsaved-read", viewId: 10 });
+
+    const saved = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "later",
+      limit: 20,
+    });
+    expect(saved.references.map((reference) => reference.entityId)).toEqual([
+      "recently-saved-old-feed",
+      "saved-and-read",
+      "earlier-saved-new-feed",
+    ]);
+
+    const unread = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "unread",
+      limit: 20,
+    });
+    expect(unread.references.map((reference) => reference.entityId)).toContain(
+      "unsaved-unread",
+    );
+    expect(
+      unread.references.map((reference) => reference.entityId),
+    ).not.toContain("saved-and-read");
+
+    const archived = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "read",
+      limit: 20,
+    });
+    expect(archived.references.map((reference) => reference.entityId)).toEqual([
+      "unsaved-read",
+    ]);
+  });
+
+  it("paginates without duplicates or gaps across section, timestamp, kind, and id boundaries", async () => {
+    await seedView(10, "Ordered");
+    await database.insert(contentCategories).values({
+      id: 1,
+      userId: "user-one",
+      name: "Section",
+    });
+    await database.insert(viewCategories).values({ viewId: 10, categoryId: 1 });
+    await database.insert(viewSections).values({
+      viewId: 10,
+      placement: 1,
+      itemType: "tag",
+      itemId: 1,
+    });
+    await seedFeed(1);
+    await database.insert(feedCategories).values({ feedId: 1, categoryId: 1 });
+    await seedFeedItem({
+      id: "feed-a",
+      feedId: 1,
+      url: "https://example.com/feed-a",
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: NOW,
+    });
+    await seedFeedItem({
+      id: "feed-b",
+      feedId: 1,
+      url: "https://example.com/feed-b",
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: NOW,
+    });
+    for (const id of ["bookmark-a", "bookmark-b"]) {
+      await seedBookmark({ id, savedUpdatedAt: NOW });
+      await database.insert(bookmarkTags).values({ bookmarkId: id, tagId: 1 });
+    }
+    await seedBookmark({
+      id: "bookmark-trailing",
+      savedUpdatedAt: new Date("2026-07-30T11:00:00Z"),
+    });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "bookmark-trailing", viewId: 10 });
+
+    const fullPage = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "later",
+      limit: 20,
+    });
+    const expectedIds = fullPage.references.map(
+      (reference) => reference.entityId,
+    );
+    const pagedIds: string[] = [];
+    let cursor: MixedContentCursor = null;
+    do {
+      const page = await queryMixedContentPage({
+        database,
+        userId: "user-one",
+        scope: { type: "view", viewId: 10 },
+        visibility: "later",
+        cursor,
+        limit: 1,
+      });
+      pagedIds.push(...page.references.map((reference) => reference.entityId));
+      cursor = page.cursor;
+    } while (cursor);
+
+    expect(pagedIds).toEqual(expectedIds);
+    expect(new Set(pagedIds).size).toBe(pagedIds.length);
+    expect(pagedIds).toHaveLength(5);
+  });
+
+  it("synchronizes capture metadata and isolates another user's canonical Bookmark", async () => {
+    await seedUser("user-two");
+    await seedView(10, "Everything");
+    await seedFeed(1);
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 1 });
+    await seedFeedItem({
+      id: "owned-feed",
+      feedId: 1,
+      url: "https://example.com/shared",
+      isWatchLater: true,
+      isWatchLaterUpdatedAt: NOW,
+    });
+    await seedBookmark({
+      id: "foreign-bookmark",
+      canonicalUrl: "https://example.com/shared",
+      userId: "user-two",
+    });
+    await seedBookmark({ id: "captured-bookmark" });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "captured-bookmark", viewId: 10 });
+    await database.insert(pageCaptures).values({
+      bookmarkId: "captured-bookmark",
+      title: "Captured",
+      author: "Writer",
+      contentHtml: "<p>Body</p>",
+      effectiveUrl: "https://bookmarks.example/captured-bookmark",
+      contentHash: "hash",
+      captureSource: "extension-live-dom",
+      extractorVersion: "test",
+      sanitizerPolicyVersion: 1,
+      capturedAt: NOW,
+    });
+
+    const page = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      visibility: "later",
+      limit: 20,
+    });
+    expect(page.feedItems.map((item) => item.id)).toContain("owned-feed");
+    expect(page.bookmarks[0]).toMatchObject({
+      id: "captured-bookmark",
+      title: "Captured",
+      author: "Writer",
+      captureHash: "hash",
+      capturedAt: NOW,
+      viewIds: [10],
+      tagIds: [],
+    });
+  });
+});

--- a/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
+import type {
+  ApplicationBookmark,
+  MixedContentPage,
+  MixedContentReference,
+} from "~/server/mixed-content/projection";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+import { feedItemsStore } from "~/lib/data/store";
+import {
+  getMixedScopeKey,
+  mixedContentStore,
+} from "~/lib/data/mixed-content/store";
+import { viewsStore } from "~/lib/data/views/store";
+import { processPublishedChunks } from "~/lib/data/subscriptionCoordinator";
+import {
+  partitionMixedReadTargets,
+  setMixedReadValue,
+} from "~/lib/data/mixed-content/mutations";
+import { bookmarkManifestValue } from "~/lib/data/bookmarks/manifest";
+import { computeBookmarkDiff } from "~/server/mixed-content/sync";
+
+const NOW = new Date("2026-07-30T12:00:00.000Z");
+
+const orpcMocks = vi.hoisted(() => ({
+  setBookmarkBulkReadValue: vi.fn(),
+  setFeedBulkWatchedValue: vi.fn(),
+}));
+
+vi.mock("~/lib/orpc", () => ({
+  orpc: {},
+  orpcRouterClient: {
+    bookmark: { setBulkReadValue: orpcMocks.setBookmarkBulkReadValue },
+    feedItem: { setBulkWatchedValue: orpcMocks.setFeedBulkWatchedValue },
+  },
+}));
+
+function bookmark(
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  return {
+    id: "bookmark-one",
+    userId: "user-one",
+    sourceUrl: "https://example.com/article",
+    canonicalUrl: "https://example.com/article",
+    isSaved: true,
+    isRead: false,
+    progress: 4,
+    duration: 10,
+    savedUpdatedAt: NOW,
+    readUpdatedAt: NOW,
+    progressUpdatedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    title: "Article",
+    author: "Writer",
+    publishedAt: null,
+    effectiveUrl: "https://example.com/article",
+    iconUrl: null,
+    representativeImageUrl: null,
+    captureHash: "capture-hash",
+    capturedAt: NOW,
+    viewIds: [10],
+    tagIds: [],
+    ...overrides,
+  };
+}
+
+function feedItem(id: string, url: string): ApplicationFeedItem {
+  return {
+    id,
+    feedId: 1,
+    contentId: id,
+    title: id,
+    author: "Author",
+    url,
+    thumbnail: "",
+    content: "",
+    contentSnippet: "",
+    isWatched: false,
+    isWatchLater: false,
+    progress: 0,
+    duration: 0,
+    orientation: "horizontal",
+    postedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    isWatchedUpdatedAt: null,
+    isWatchLaterUpdatedAt: null,
+    contentHash: null,
+    platform: "website",
+  };
+}
+
+function view(): ApplicationView {
+  return {
+    id: 10,
+    userId: "user-one",
+    name: "Reading",
+    daysWindow: 0,
+    readStatus: 0,
+    orientation: "horizontal",
+    contentType: "longform",
+    layout: "list",
+    placement: 0,
+    createdAt: NOW,
+    updatedAt: NOW,
+    categoryIds: [],
+    feedIds: [1],
+    isDefault: false,
+    viewSections: [],
+  };
+}
+
+function reference(
+  entityKind: "bookmark" | "feed-item",
+  entityId: string,
+): MixedContentReference {
+  return { entityKind, entityId, sectionPlacement: null, normalizedAt: NOW };
+}
+
+function page(references: MixedContentReference[]): MixedContentPage {
+  return {
+    references,
+    bookmarks: [],
+    feedItems: [],
+    cursor: null,
+    hasMore: false,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bookmarksStore.getState().reset();
+  feedItemsStore.getState().reset();
+  mixedContentStore.getState().reset();
+  viewsStore.getState().set([view()]);
+});
+
+describe("Bookmark synchronization and local mixed reprojection", () => {
+  it("hydrates Bookmark and Feed-item entities into separate caches from a discriminated page", () => {
+    const savedBookmark = bookmark();
+    const item = feedItem("feed-one", "https://example.com/feed");
+    processPublishedChunks([
+      {
+        source: "mixed",
+        chunk: {
+          type: "mixed-content-page",
+          scope: { type: "view", viewId: 10 },
+          visibility: "later",
+          page: {
+            ...page([
+              reference("bookmark", savedBookmark.id),
+              reference("feed-item", item.id),
+            ]),
+            bookmarks: [savedBookmark],
+            feedItems: [item],
+          },
+          replacesScope: true,
+        },
+      },
+    ]);
+
+    expect(bookmarksStore.getState().bookmarksDict[savedBookmark.id]).toEqual(
+      savedBookmark,
+    );
+    expect(feedItemsStore.getState().feedItemsDict[item.id]).toEqual(item);
+    expect(
+      mixedContentStore.getState().scopes[
+        getMixedScopeKey({ type: "view", viewId: 10 }, "later")
+      ]?.references,
+    ).toHaveLength(2);
+  });
+
+  it("suppresses matching Feed items immediately, moves Bookmark visibility, restores on deletion, and reports scopes for refill", () => {
+    const matchingOne = feedItem(
+      "feed-match-one",
+      "https://example.com/article#fragment",
+    );
+    const matchingTwo = feedItem(
+      "feed-match-two",
+      "https://example.com/article",
+    );
+    const other = feedItem("feed-other", "https://example.com/other");
+    for (const item of [matchingOne, matchingTwo, other]) {
+      feedItemsStore.getState().setFeedItem(item.id, item);
+    }
+    const scope = { type: "view" as const, viewId: 10 };
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "unread",
+      page: page([
+        reference("feed-item", matchingOne.id),
+        reference("feed-item", matchingTwo.id),
+        reference("feed-item", other.id),
+      ]),
+      replacesScope: true,
+    });
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "read",
+      page: page([]),
+      replacesScope: true,
+    });
+
+    const saved = bookmark();
+    const affectedOnSave = processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: { type: "bookmark-upsert", bookmark: saved },
+      },
+    ]);
+    expect(affectedOnSave).toHaveLength(2);
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "unread")]
+        ?.references,
+    ).toEqual([reference("feed-item", other.id)]);
+    expect(feedItemsStore.getState().feedItemsDict[matchingOne.id]).toEqual(
+      matchingOne,
+    );
+
+    const archived = bookmark({ isSaved: false, isRead: true });
+    processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: { type: "bookmark-upsert", bookmark: archived },
+      },
+    ]);
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "read")]
+        ?.references,
+    ).toEqual([reference("bookmark", archived.id)]);
+
+    const affectedOnDelete = processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-delete",
+          id: archived.id,
+          canonicalUrl: archived.canonicalUrl,
+        },
+      },
+    ]);
+    expect(affectedOnDelete).toHaveLength(2);
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "unread")]
+        ?.references,
+    ).toEqual([
+      reference("feed-item", other.id),
+      reference("feed-item", matchingTwo.id),
+      reference("feed-item", matchingOne.id),
+    ]);
+  });
+
+  it("reconciles entity, state, organization, progress, and capture metadata through the manifest", () => {
+    const cached = bookmark();
+    const updated = bookmark({
+      progress: 8,
+      duration: 12,
+      progressUpdatedAt: new Date("2026-07-30T12:01:00Z"),
+      tagIds: [4],
+      captureHash: "new-hash",
+      capturedAt: new Date("2026-07-30T12:02:00Z"),
+      updatedAt: new Date("2026-07-30T12:02:00Z"),
+    });
+    expect(
+      computeBookmarkDiff(
+        [cached],
+        [{ id: cached.id, version: bookmarkManifestValue(cached) }],
+      ),
+    ).toEqual([{ status: "unchanged", id: cached.id }]);
+    expect(
+      computeBookmarkDiff(
+        [updated],
+        [
+          { id: cached.id, version: bookmarkManifestValue(cached) },
+          { id: "deleted-offline", version: "old" },
+        ],
+      ),
+    ).toEqual([
+      { status: "updated", bookmark: updated },
+      { status: "deleted", id: "deleted-offline" },
+    ]);
+  });
+
+  it("marks mixed and section-level references read and supports undo", async () => {
+    const item = feedItem("feed-one", "https://example.com/feed");
+    const archivedBookmark = bookmark({ isSaved: false, isRead: false });
+    feedItemsStore.getState().setFeedItem(item.id, item);
+    bookmarksStore.getState().upsert(archivedBookmark);
+    const scope = { type: "view" as const, viewId: 10 };
+    const references = [
+      reference("bookmark", archivedBookmark.id),
+      reference("feed-item", item.id),
+    ];
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "unread",
+      page: page(references),
+      replacesScope: true,
+    });
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "read",
+      page: page([]),
+      replacesScope: true,
+    });
+    orpcMocks.setBookmarkBulkReadValue.mockResolvedValue([]);
+    orpcMocks.setFeedBulkWatchedValue.mockImplementation(
+      ({ isWatched }: { isWatched: boolean }) =>
+        Promise.resolve([
+          { ...item, isWatched, isWatchedUpdatedAt: NOW, updatedAt: NOW },
+        ]),
+    );
+
+    expect(partitionMixedReadTargets(references)).toEqual({
+      bookmarkIds: [archivedBookmark.id],
+      feedItems: [{ id: item.id, feedId: item.feedId }],
+    });
+
+    await setMixedReadValue({ references, isRead: true });
+    expect(
+      bookmarksStore.getState().bookmarksDict[archivedBookmark.id]?.isRead,
+    ).toBe(true);
+    expect(feedItemsStore.getState().feedItemsDict[item.id]?.isWatched).toBe(
+      true,
+    );
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "unread")]
+        ?.references,
+    ).toEqual([reference("feed-item", item.id)]);
+    expect(
+      mixedContentStore
+        .getState()
+        .scopes[getMixedScopeKey(scope, "read")]?.references.map(
+          ({ entityId }) => entityId,
+        ),
+    ).toEqual([archivedBookmark.id]);
+
+    await setMixedReadValue({ references, isRead: false });
+    expect(
+      bookmarksStore.getState().bookmarksDict[archivedBookmark.id]?.isRead,
+    ).toBe(false);
+    expect(feedItemsStore.getState().feedItemsDict[item.id]?.isWatched).toBe(
+      false,
+    );
+    expect(orpcMocks.setBookmarkBulkReadValue).toHaveBeenNthCalledWith(2, {
+      bookmarkIds: [archivedBookmark.id],
+      isRead: false,
+    });
+    expect(orpcMocks.setFeedBulkWatchedValue).toHaveBeenNthCalledWith(2, {
+      items: [{ id: item.id, feedId: item.feedId }],
+      isWatched: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the server-authored mixed Bookmark/Feed-item projection with canonical suppression, membership, visibility, ordering, and cursors
- synchronize Bookmark entities into separate persisted client caches with optimistic reprojection and authoritative refill
- add mixed mark-as-read support plus projection, synchronization, and seeded browser coverage

## Validation
- app unit tests: 26 files, 159 tests
- seeded self-hosted Playwright Bookmark sync scenario
- app lint and typecheck
- production builds for app, extension, website, and edge script
- React Doctor: no issues found