### PR TITLE
Bound legacy and organization server workloads

### DIFF
--- a/apps/app/benchmarks/app-query-inventory.json
+++ b/apps/app/benchmarks/app-query-inventory.json
@@ -7,7 +7,7 @@
     "scripts/**/*.ts(x)"
   ],
   "exclusions": ["node_modules", "src/server/db/migrations"],
-  "accessCount": 410,
+  "accessCount": 441,
   "areas": {
     "Bookmark and capture": 21,
     "administration": 33,
@@ -15,9 +15,9 @@
     "authentication": 17,
     "background and maintenance tasks": 18,
     "database infrastructure": 3,
-    "request procedures": 155,
+    "request procedures": 163,
     "synchronization and projection": 10,
-    "test-only infrastructure": 111
+    "test-only infrastructure": 134
   },
   "entries": [
     {
@@ -583,8 +583,16 @@
     {
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
+      "symbol": "update",
+      "line": 100,
+      "method": "transaction",
+      "expression": "context.db.transaction"
+    },
+    {
+      "file": "src/server/api/routers/contentCategoriesRouter.ts",
+      "area": "request procedures",
       "symbol": "categories",
-      "line": 109,
+      "line": 117,
       "method": "update",
       "expression": "tx\n        .update"
     },
@@ -592,23 +600,23 @@
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 136,
+      "line": 142,
       "method": "insert",
-      "expression": "tx\n              .insert"
+      "expression": "tx\n          .insert"
     },
     {
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 150,
+      "line": 154,
       "method": "delete",
-      "expression": "tx\n              .delete"
+      "expression": "tx\n          .delete"
     },
     {
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "deleteCategory",
-      "line": 168,
+      "line": 170,
       "method": "delete",
       "expression": "context.db\n      .delete"
     },
@@ -616,7 +624,7 @@
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "create",
-      "line": 27,
+      "line": 37,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -624,7 +632,7 @@
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "categories",
-      "line": 47,
+      "line": 57,
       "method": "insert",
       "expression": "tx\n        .insert"
     },
@@ -632,7 +640,7 @@
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "create",
-      "line": 61,
+      "line": 69,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -640,23 +648,15 @@
       "file": "src/server/api/routers/contentCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "contentCategoriesList",
-      "line": 74,
+      "line": 82,
       "method": "select",
       "expression": "context.db\n    .select"
-    },
-    {
-      "file": "src/server/api/routers/contentCategoriesRouter.ts",
-      "area": "request procedures",
-      "symbol": "update",
-      "line": 92,
-      "method": "transaction",
-      "expression": "context.db.transaction"
     },
     {
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "insertedFeeds",
-      "line": 109,
+      "line": 114,
       "method": "insert",
       "expression": "tx\n            .insert"
     },
@@ -664,7 +664,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "results",
-      "line": 122,
+      "line": 127,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -672,7 +672,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "results",
-      "line": 131,
+      "line": 136,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -680,7 +680,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "promiseResults",
-      "line": 203,
+      "line": 209,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -688,7 +688,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "newFeeds",
-      "line": 229,
+      "line": 235,
       "method": "insert",
       "expression": "tx\n                .insert"
     },
@@ -696,7 +696,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "matchingCategories",
-      "line": 249,
+      "line": 255,
       "method": "select",
       "expression": "tx\n                .select"
     },
@@ -704,7 +704,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "matchingCategoryPromises",
-      "line": 272,
+      "line": 278,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -712,7 +712,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "newContentCategoryList",
-      "line": 281,
+      "line": 287,
       "method": "insert",
       "expression": "tx\n                    .insert"
     },
@@ -720,7 +720,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "nonMatchingCategoryPromises",
-      "line": 292,
+      "line": 298,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -728,7 +728,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "deleteFeed",
-      "line": 343,
+      "line": 349,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -736,7 +736,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "deletedFeeds",
-      "line": 344,
+      "line": 350,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -744,7 +744,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "userViews",
-      "line": 351,
+      "line": 357,
       "method": "select",
       "expression": "tx\n        .select"
     },
@@ -752,7 +752,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "deleteFeed",
-      "line": 357,
+      "line": 363,
       "method": "delete",
       "expression": "tx.delete"
     },
@@ -760,7 +760,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "feedsList",
-      "line": 373,
+      "line": 379,
       "method": "findMany",
       "expression": "context.db.query.feeds.findMany"
     },
@@ -768,7 +768,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 397,
+      "line": 403,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -776,7 +776,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "updatedFeeds",
-      "line": 422,
+      "line": 428,
       "method": "update",
       "expression": "tx\n        .update"
     },
@@ -784,7 +784,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 437,
+      "line": 443,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -792,15 +792,15 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 448,
+      "line": 453,
       "method": "insert",
-      "expression": "tx\n            .insert"
+      "expression": "tx\n          .insert"
     },
     {
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 461,
+      "line": 467,
       "method": "delete",
       "expression": "tx.delete"
     },
@@ -808,7 +808,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 463,
+      "line": 469,
       "method": "delete",
       "expression": "tx\n            .delete"
     },
@@ -816,7 +816,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 472,
+      "line": 478,
       "method": "insert",
       "expression": "tx\n            .insert"
     },
@@ -824,7 +824,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "bulkDelete",
-      "line": 534,
+      "line": 540,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -832,7 +832,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "deletedFeeds",
-      "line": 535,
+      "line": 541,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -840,7 +840,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "userViews",
-      "line": 547,
+      "line": 553,
       "method": "select",
       "expression": "tx\n        .select"
     },
@@ -848,7 +848,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "bulkDelete",
-      "line": 553,
+      "line": 559,
       "method": "delete",
       "expression": "tx.delete"
     },
@@ -856,7 +856,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "feed",
-      "line": 574,
+      "line": 580,
       "method": "findFirst",
       "expression": "context.db.query.feeds.findFirst"
     },
@@ -864,7 +864,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "updatedFeeds",
-      "line": 592,
+      "line": 598,
       "method": "update",
       "expression": "context.db\n      .update"
     },
@@ -872,7 +872,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "bulkSetActive",
-      "line": 616,
+      "line": 622,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -880,7 +880,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "activeCountResult",
-      "line": 620,
+      "line": 626,
       "method": "select",
       "expression": "tx\n          .select"
     },
@@ -888,7 +888,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "currentFeeds",
-      "line": 634,
+      "line": 640,
       "method": "findMany",
       "expression": "tx.query.feeds.findMany"
     },
@@ -896,7 +896,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "bulkSetActive",
-      "line": 650,
+      "line": 656,
       "method": "update",
       "expression": "tx\n        .update"
     },
@@ -904,7 +904,7 @@
       "file": "src/server/api/routers/feed-router/index.ts",
       "area": "request procedures",
       "symbol": "results",
-      "line": 69,
+      "line": 74,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -975,8 +975,16 @@
     {
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
+      "symbol": "contentCategoriesList",
+      "line": 10,
+      "method": "select",
+      "expression": "context.db\n    .select"
+    },
+    {
+      "file": "src/server/api/routers/feedCategoriesRouter.ts",
+      "area": "request procedures",
       "symbol": "bulkRemoveFromFeeds",
-      "line": 110,
+      "line": 109,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -984,7 +992,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "bulkRemoveFromFeeds",
-      "line": 123,
+      "line": 122,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -992,7 +1000,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "feedCategoriesList",
-      "line": 18,
+      "line": 19,
       "method": "select",
       "expression": "context.db\n    .select"
     },
@@ -1000,7 +1008,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "assignToFeed",
-      "line": 30,
+      "line": 31,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1008,7 +1016,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "assignToFeed",
-      "line": 41,
+      "line": 42,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -1016,7 +1024,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "removeFromFeed",
-      "line": 51,
+      "line": 52,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1024,7 +1032,7 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "removeFromFeed",
-      "line": 62,
+      "line": 63,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -1032,55 +1040,23 @@
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "bulkAssignToFeeds",
-      "line": 78,
+      "line": 79,
       "method": "transaction",
       "expression": "context.db.transaction"
-    },
-    {
-      "file": "src/server/api/routers/feedCategoriesRouter.ts",
-      "area": "request procedures",
-      "symbol": "contentCategoriesList",
-      "line": 9,
-      "method": "select",
-      "expression": "context.db\n    .select"
     },
     {
       "file": "src/server/api/routers/feedCategoriesRouter.ts",
       "area": "request procedures",
       "symbol": "bulkAssignToFeeds",
-      "line": 93,
+      "line": 92,
       "method": "insert",
-      "expression": "tx\n            .insert"
+      "expression": "tx\n        .insert"
     },
     {
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
-      "symbol": "result",
-      "line": 137,
-      "method": "transaction",
-      "expression": "context.db.transaction"
-    },
-    {
-      "file": "src/server/api/routers/feedItemRouter.ts",
-      "area": "request procedures",
-      "symbol": "result",
+      "symbol": "setBulkWatchedValue",
       "line": 148,
-      "method": "update",
-      "expression": "tx\n        .update"
-    },
-    {
-      "file": "src/server/api/routers/feedItemRouter.ts",
-      "area": "request procedures",
-      "symbol": "setWatchedValue",
-      "line": 188,
-      "method": "select",
-      "expression": "context.db\n        .select"
-    },
-    {
-      "file": "src/server/api/routers/feedItemRouter.ts",
-      "area": "request procedures",
-      "symbol": "setBulkWatchedValue",
-      "line": 235,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1088,7 +1064,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "setBulkWatchedValue",
-      "line": 253,
+      "line": 166,
       "method": "update",
       "expression": "tx\n        .update"
     },
@@ -1096,7 +1072,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "result",
-      "line": 281,
+      "line": 194,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1104,39 +1080,23 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "result",
-      "line": 292,
+      "line": 205,
       "method": "update",
       "expression": "tx\n        .update"
-    },
-    {
-      "file": "src/server/api/routers/feedItemRouter.ts",
-      "area": "request procedures",
-      "symbol": "feedsList",
-      "line": 31,
-      "method": "findMany",
-      "expression": "context.db.query.feeds.findMany"
     },
     {
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "setWatchLaterValue",
-      "line": 332,
+      "line": 245,
       "method": "select",
       "expression": "context.db\n        .select"
     },
     {
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
-      "symbol": "itemsData",
-      "line": 36,
-      "method": "findMany",
-      "expression": "context.db.query.feedItems.findMany"
-    },
-    {
-      "file": "src/server/api/routers/feedItemRouter.ts",
-      "area": "request procedures",
       "symbol": "setProgress",
-      "line": 373,
+      "line": 286,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1144,7 +1104,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "setProgress",
-      "line": 384,
+      "line": 297,
       "method": "update",
       "expression": "tx\n        .update"
     },
@@ -1152,7 +1112,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "item",
-      "line": 400,
+      "line": 313,
       "method": "findFirst",
       "expression": "context.db.query.feedItems.findFirst"
     },
@@ -1160,7 +1120,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "feed",
-      "line": 408,
+      "line": 321,
       "method": "findFirst",
       "expression": "context.db.query.feeds.findFirst"
     },
@@ -1168,7 +1128,7 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "feed",
-      "line": 428,
+      "line": 349,
       "method": "findFirst",
       "expression": "context.db.query.feeds.findFirst"
     },
@@ -1176,7 +1136,55 @@
       "file": "src/server/api/routers/feedItemRouter.ts",
       "area": "request procedures",
       "symbol": "itemsData",
-      "line": 436,
+      "line": 367,
+      "method": "findMany",
+      "expression": "context.db.query.feedItems.findMany"
+    },
+    {
+      "file": "src/server/api/routers/feedItemRouter.ts",
+      "area": "request procedures",
+      "symbol": "result",
+      "line": 42,
+      "method": "transaction",
+      "expression": "context.db.transaction"
+    },
+    {
+      "file": "src/server/api/routers/feedItemRouter.ts",
+      "area": "request procedures",
+      "symbol": "result",
+      "line": 53,
+      "method": "update",
+      "expression": "tx\n        .update"
+    },
+    {
+      "file": "src/server/api/routers/feedItemRouter.ts",
+      "area": "request procedures",
+      "symbol": "setWatchedValue",
+      "line": 93,
+      "method": "select",
+      "expression": "context.db\n        .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "queryLightweightItemsForView",
+      "line": 1109,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "queryLightweightItemsForView",
+      "line": 1116,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "queryFeedItemsForView",
+      "line": 1281,
       "method": "findMany",
       "expression": "context.db.query.feedItems.findMany"
     },
@@ -1184,15 +1192,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "queryFeedItemsForView",
-      "line": 1093,
-      "method": "findMany",
-      "expression": "context.db.query.feedItems.findMany"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "queryFeedItemsForView",
-      "line": 1099,
+      "line": 1287,
       "method": "select",
       "expression": "context.db\n      .select"
     },
@@ -1200,7 +1200,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "insertResult",
-      "line": 1870,
+      "line": 2062,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1208,7 +1208,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "streamingImport",
-      "line": 2010,
+      "line": 2202,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1216,7 +1216,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "existingViews",
-      "line": 2012,
+      "line": 2204,
       "method": "select",
       "expression": "tx\n            .select"
     },
@@ -1224,7 +1224,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "inserted",
-      "line": 2023,
+      "line": 2215,
       "method": "insert",
       "expression": "tx\n              .insert"
     },
@@ -1232,7 +1232,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "existingCategories",
-      "line": 2047,
+      "line": 2239,
       "method": "select",
       "expression": "tx\n                  .select"
     },
@@ -1240,7 +1240,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "insertedCategories",
-      "line": 2065,
+      "line": 2257,
       "method": "insert",
       "expression": "tx\n              .insert"
     },
@@ -1248,7 +1248,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "existingViewSections",
-      "line": 2083,
+      "line": 2275,
       "method": "select",
       "expression": "tx\n                  .select"
     },
@@ -1256,7 +1256,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "streamingImport",
-      "line": 2193,
+      "line": 2385,
       "method": "insert",
       "expression": "tx\n              .insert"
     },
@@ -1264,7 +1264,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "streamingImport",
-      "line": 2200,
+      "line": 2392,
       "method": "insert",
       "expression": "tx\n              .insert"
     },
@@ -1272,7 +1272,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "streamingImport",
-      "line": 2207,
+      "line": 2399,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -1280,7 +1280,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "feed",
-      "line": 2591,
+      "line": 2768,
       "method": "findFirst",
       "expression": "context.db.query.feeds.findFirst"
     },
@@ -1288,7 +1288,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "itemsData",
-      "line": 2615,
+      "line": 2792,
       "method": "findMany",
       "expression": "context.db.query.feedItems.findMany"
     },
@@ -1296,7 +1296,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "category",
-      "line": 2707,
+      "line": 2884,
       "method": "findFirst",
       "expression": "context.db.query.contentCategories.findFirst"
     },
@@ -1304,7 +1304,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "categoryFeedLinks",
-      "line": 2727,
+      "line": 2904,
       "method": "select",
       "expression": "context.db\n      .select"
     },
@@ -1312,7 +1312,7 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "feedsList",
-      "line": 2751,
+      "line": 2928,
       "method": "findMany",
       "expression": "context.db.query.feeds.findMany"
     },
@@ -1320,49 +1320,17 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "itemsData",
-      "line": 2768,
+      "line": 2945,
       "method": "findMany",
       "expression": "context.db.query.feedItems.findMany"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "getItemsByVisibility",
-      "line": 3247,
-      "method": "findMany",
-      "expression": "context.db.query.feedItems.findMany"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "getItemsByVisibility",
-      "line": 3253,
-      "method": "select",
-      "expression": "context.db\n          .select"
     },
     {
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "items",
-      "line": 3332,
+      "line": 3295,
       "method": "select",
       "expression": "context.db\n        .select"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "fetchUserPrerequisiteData",
-      "line": 568,
-      "method": "select",
-      "expression": "context.db\n      .select"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "fetchUserPrerequisiteData",
-      "line": 573,
-      "method": "findMany",
-      "expression": "context.db.query.feeds.findMany"
     },
     {
       "file": "src/server/api/routers/initialRouter.ts",
@@ -1376,49 +1344,145 @@
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "fetchUserPrerequisiteData",
-      "line": 594,
-      "method": "select",
-      "expression": "context.db\n          .select"
+      "line": 581,
+      "method": "findMany",
+      "expression": "context.db.query.feeds.findMany"
     },
     {
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
       "symbol": "fetchUserPrerequisiteData",
-      "line": 600,
-      "method": "select",
-      "expression": "context.db\n          .select"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "fetchUserPrerequisiteData",
-      "line": 606,
-      "method": "select",
-      "expression": "context.db\n          .select"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "fetchUserPrerequisiteData",
-      "line": 612,
-      "method": "select",
-      "expression": "context.db\n          .select"
-    },
-    {
-      "file": "src/server/api/routers/initialRouter.ts",
-      "area": "request procedures",
-      "symbol": "queryLightweightItemsForView",
-      "line": 924,
+      "line": 584,
       "method": "select",
       "expression": "context.db\n      .select"
     },
     {
       "file": "src/server/api/routers/initialRouter.ts",
       "area": "request procedures",
-      "symbol": "queryLightweightItemsForView",
-      "line": 931,
+      "symbol": "fetchUserPrerequisiteData",
+      "line": 602,
+      "method": "select",
+      "expression": "context.db\n          .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchUserPrerequisiteData",
+      "line": 608,
+      "method": "select",
+      "expression": "context.db\n          .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchUserPrerequisiteData",
+      "line": 614,
+      "method": "select",
+      "expression": "context.db\n          .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchUserPrerequisiteData",
+      "line": 620,
+      "method": "select",
+      "expression": "context.db\n          .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "directlyAssignedToCompatibleView",
+      "line": 671,
       "method": "select",
       "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "taggedIntoCompatibleView",
+      "line": 681,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "includedByUnfilteredCompatibleView",
+      "line": 695,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "includedByUnfilteredCompatibleView",
+      "line": 704,
+      "method": "select",
+      "expression": "context.db\n                .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "includedByUnfilteredCompatibleView",
+      "line": 712,
+      "method": "select",
+      "expression": "context.db\n                .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "feedsList",
+      "line": 721,
+      "method": "select",
+      "expression": "context.db\n    .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchScopedViewPageData",
+      "line": 748,
+      "method": "select",
+      "expression": "context.db\n    .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchScopedViewPageData",
+      "line": 756,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchScopedViewPageData",
+      "line": 760,
+      "method": "select",
+      "expression": "context.db.select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "fetchScopedViewPageData",
+      "line": 761,
+      "method": "select",
+      "expression": "context.db\n      .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "taggedFeedFilter",
+      "line": 774,
+      "method": "select",
+      "expression": "context.db\n            .select"
+    },
+    {
+      "file": "src/server/api/routers/initialRouter.ts",
+      "area": "request procedures",
+      "symbol": "feedsList",
+      "line": 792,
+      "method": "select",
+      "expression": "context.db\n    .select"
     },
     {
       "file": "src/server/api/routers/instapaperRouter.ts",
@@ -1560,31 +1624,31 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "bulkAssignToView",
-      "line": 100,
+      "line": 101,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
     {
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
-      "symbol": "userViews",
-      "line": 12,
-      "method": "select",
-      "expression": "context.db\n    .select"
-    },
-    {
-      "file": "src/server/api/routers/viewFeedsRouter.ts",
-      "area": "request procedures",
       "symbol": "bulkAssignToView",
-      "line": 123,
+      "line": 124,
       "method": "insert",
       "expression": "tx\n        .insert"
     },
     {
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
+      "symbol": "userViews",
+      "line": 13,
+      "method": "select",
+      "expression": "context.db\n    .select"
+    },
+    {
+      "file": "src/server/api/routers/viewFeedsRouter.ts",
+      "area": "request procedures",
       "symbol": "bulkRemoveFromView",
-      "line": 140,
+      "line": 141,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1592,7 +1656,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "bulkRemoveFromView",
-      "line": 163,
+      "line": 164,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -1600,7 +1664,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "getAll",
-      "line": 20,
+      "line": 21,
       "method": "select",
       "expression": "context.db\n    .select"
     },
@@ -1608,7 +1672,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "assignToView",
-      "line": 29,
+      "line": 30,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1616,7 +1680,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "assignToView",
-      "line": 50,
+      "line": 51,
       "method": "insert",
       "expression": "tx\n        .insert"
     },
@@ -1624,7 +1688,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "removeFromView",
-      "line": 63,
+      "line": 64,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1632,7 +1696,7 @@
       "file": "src/server/api/routers/viewFeedsRouter.ts",
       "area": "request procedures",
       "symbol": "removeFromView",
-      "line": 84,
+      "line": 85,
       "method": "delete",
       "expression": "tx\n        .delete"
     },
@@ -1640,7 +1704,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 107,
+      "line": 111,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1648,17 +1712,9 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "viewsResult",
-      "line": 132,
+      "line": 136,
       "method": "update",
       "expression": "tx\n        .update"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
-      "symbol": "update",
-      "line": 152,
-      "method": "delete",
-      "expression": "tx\n          .delete"
     },
     {
       "file": "src/server/api/routers/viewRouter.ts",
@@ -1672,23 +1728,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 165,
-      "method": "insert",
-      "expression": "tx\n          .insert"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
-      "symbol": "update",
-      "line": 178,
-      "method": "delete",
-      "expression": "tx.delete"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
-      "symbol": "update",
-      "line": 180,
+      "line": 160,
       "method": "delete",
       "expression": "tx\n          .delete"
     },
@@ -1696,7 +1736,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 189,
+      "line": 169,
       "method": "insert",
       "expression": "tx\n          .insert"
     },
@@ -1704,7 +1744,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 202,
+      "line": 182,
       "method": "delete",
       "expression": "tx.delete"
     },
@@ -1712,7 +1752,31 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "update",
-      "line": 205,
+      "line": 184,
+      "method": "delete",
+      "expression": "tx\n          .delete"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
+      "symbol": "update",
+      "line": 193,
+      "method": "insert",
+      "expression": "tx\n          .insert"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
+      "symbol": "update",
+      "line": 206,
+      "method": "delete",
+      "expression": "tx.delete"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
+      "symbol": "update",
+      "line": 209,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -1720,7 +1784,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "updatePlacement",
-      "line": 231,
+      "line": 242,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
@@ -1728,15 +1792,15 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "updatePlacement",
-      "line": 234,
+      "line": 246,
       "method": "update",
-      "expression": "tx\n            .update"
+      "expression": "tx\n        .update"
     },
     {
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "deleteView",
-      "line": 250,
+      "line": 266,
       "method": "delete",
       "expression": "context.db\n      .delete"
     },
@@ -1744,7 +1808,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "getAll",
-      "line": 257,
+      "line": 273,
       "method": "select",
       "expression": "context.db\n      .select"
     },
@@ -1752,47 +1816,47 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "getAll",
-      "line": 262,
+      "line": 278,
       "method": "select",
       "expression": "context.db\n      .select"
     },
     {
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
+      "symbol": "getAll",
+      "line": 289,
+      "method": "select",
+      "expression": "context.db\n            .select"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
+      "symbol": "getAll",
+      "line": 293,
+      "method": "select",
+      "expression": "context.db\n            .select"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
+      "symbol": "getAll",
+      "line": 297,
+      "method": "select",
+      "expression": "context.db\n            .select"
+    },
+    {
+      "file": "src/server/api/routers/viewRouter.ts",
+      "area": "request procedures",
       "symbol": "create",
-      "line": 27,
+      "line": 31,
       "method": "transaction",
       "expression": "context.db.transaction"
     },
     {
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
-      "symbol": "getAll",
-      "line": 273,
-      "method": "select",
-      "expression": "context.db\n            .select"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
-      "symbol": "getAll",
-      "line": 277,
-      "method": "select",
-      "expression": "context.db\n            .select"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
-      "symbol": "getAll",
-      "line": 281,
-      "method": "select",
-      "expression": "context.db\n            .select"
-    },
-    {
-      "file": "src/server/api/routers/viewRouter.ts",
-      "area": "request procedures",
       "symbol": "viewsResult",
-      "line": 52,
+      "line": 56,
       "method": "insert",
       "expression": "tx\n        .insert"
     },
@@ -1800,7 +1864,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "create",
-      "line": 71,
+      "line": 75,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -1808,7 +1872,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "create",
-      "line": 80,
+      "line": 84,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -1816,7 +1880,7 @@
       "file": "src/server/api/routers/viewRouter.ts",
       "area": "request procedures",
       "symbol": "create",
-      "line": 89,
+      "line": 93,
       "method": "insert",
       "expression": "tx.insert"
     },
@@ -3299,6 +3363,190 @@
       "line": 36,
       "method": "transaction",
       "expression": "session.database.transaction"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 120,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 128,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 137,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 144,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 154,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 160,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 166,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 172,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "measureLaterPage",
+      "line": 180,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 259,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 267,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 276,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 286,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 292,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 300,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 509,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 521,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 530,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 534,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 538,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 54,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 62,
+      "method": "insert",
+      "expression": "session.database.insert"
+    },
+    {
+      "file": "tests/unit/performance/legacy-organization-workloads.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 69,
+      "method": "insert",
+      "expression": "session.database.insert"
     }
   ]
 }

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -125,7 +125,6 @@ export type ApplicationStore = {
   feedStatusDict: Record<number, FetchFeedsStatus>;
   setFeedItemsDict: (itemsDict: Record<string, ApplicationFeedItem>) => void;
   setFeedItem: (id: string, item: ApplicationFeedItem) => void;
-  fetchFeedItems: () => Promise<void>;
   fetchFeedItemsForFeed: (feedId: number) => Promise<void>;
   fetchNewData: () => Promise<void>;
   revalidateView: (viewId: number) => Promise<void>;
@@ -702,83 +701,6 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             },
           });
         }
-      },
-
-      fetchFeedItems: async () => {
-        if (!loadingActor.getSnapshot().matches("idle")) return;
-
-        console.log("FETCHING");
-
-        set({
-          feedStatusDict: {},
-        });
-
-        let lastUpdateTime = 0;
-        const DEBOUNCE_TIME = 1000;
-
-        for await (const incomingChunk of await orpcRouterClient.feedItem.getAll()) {
-          const timeSinceLastUpdate = Date.now() - lastUpdateTime;
-          const timeToWait = DEBOUNCE_TIME - timeSinceLastUpdate;
-          const shouldWaitToRender = timeToWait > 0;
-
-          const feedStatusDict = shouldWaitToRender
-            ? get().feedStatusDict
-            : {
-                ...get().feedStatusDict,
-              };
-
-          const feedItemsDict = shouldWaitToRender
-            ? get().feedItemsDict
-            : {
-                ...get().feedItemsDict,
-              };
-
-          const feedItemsOrder = shouldWaitToRender
-            ? get().feedItemsOrder
-            : [...get().feedItemsOrder];
-          let incomingFeedItems: ApplicationFeedItem[] = [];
-
-          if (incomingChunk.type === "feed-status") {
-            feedStatusDict[incomingChunk.feedId] = incomingChunk.status;
-          } else {
-            incomingFeedItems = incomingChunk.feedItems;
-            const existingIds = new Set(feedItemsOrder);
-
-            incomingFeedItems.forEach((item) => {
-              mergeFeedItemIntoOrder(
-                feedItemsDict,
-                feedItemsOrder,
-                existingIds,
-                item,
-              );
-            });
-          }
-
-          set({
-            feedItemsDict: feedItemsDict,
-            feedItemsOrder,
-            feedStatusDict: feedStatusDict,
-            scopeFeedItemIds:
-              incomingFeedItems.length > 0
-                ? reconcileScopeMembershipsForItems(
-                    get().scopeFeedItemIds,
-                    getMergedFeedItems(feedItemsDict, incomingFeedItems),
-                  )
-                : get().scopeFeedItemIds,
-          });
-
-          if (!shouldWaitToRender) {
-            lastUpdateTime = Date.now();
-          }
-        }
-
-        const finalFeedItemsDict = get().feedItemsDict;
-        set({
-          fetchFeedItemsLastFetchedAt: Date.now(),
-          feedItemsDict: { ...finalFeedItemsDict },
-          feedItemsOrder: [...get().feedItemsOrder],
-          feedStatusDict: { ...get().feedStatusDict },
-        });
       },
 
       fetchFeedItemsForFeed: async (feedId: number) => {

--- a/apps/app/src/lib/schemas/bulk.ts
+++ b/apps/app/src/lib/schemas/bulk.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const MAX_BULK_MUTATION_ITEMS = 500;
+
+export const boundedNumberIdsSchema = z
+  .array(z.number())
+  .max(MAX_BULK_MUTATION_ITEMS)
+  .transform((ids) => [...new Set(ids)]);
+
+export const boundedStringsSchema = z
+  .array(z.string())
+  .max(MAX_BULK_MUTATION_ITEMS)
+  .transform((values) => [...new Set(values)]);
+
+export function deduplicateByLastValue<T, TKey>(
+  values: T[],
+  getKey: (value: T) => TKey,
+): T[] {
+  const valuesByKey = new Map<TKey, T>();
+  for (const value of values) valuesByKey.set(getKey(value), value);
+  return [...valuesByKey.values()];
+}

--- a/apps/app/src/server/api/routers/contentCategoriesRouter.ts
+++ b/apps/app/src/server/api/routers/contentCategoriesRouter.ts
@@ -1,9 +1,13 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { verifyFeedsOwnedByUser } from "./feed-router/utils";
 import { protectedProcedure } from "~/server/orpc/base";
 import { contentCategories, feedCategories } from "~/server/db/schema";
+import {
+  deduplicateByLastValue,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
 const categoryNameSchema = z.string().min(2);
 const feedCategorizationSchema = z.object({
@@ -14,7 +18,13 @@ export type FeedCategorization = Required<
   z.infer<typeof feedCategorizationSchema>
 >;
 
-const feedCategorizationsSchema = z.array(feedCategorizationSchema).optional();
+const feedCategorizationsSchema = z
+  .array(feedCategorizationSchema)
+  .max(MAX_BULK_MUTATION_ITEMS)
+  .transform((values) =>
+    deduplicateByLastValue(values, (value) => value.feedId),
+  )
+  .optional();
 
 export const create = protectedProcedure
   .input(
@@ -56,13 +66,11 @@ export const create = protectedProcedure
       if (!category) return null;
 
       if (feedIdsToCategorize.length > 0) {
-        await Promise.all(
-          feedIdsToCategorize.map(async (feedId) => {
-            return await tx.insert(feedCategories).values({
-              categoryId: category.id,
-              feedId,
-            });
-          }),
+        await tx.insert(feedCategories).values(
+          feedIdsToCategorize.map((feedId) => ({
+            categoryId: category.id,
+            feedId,
+          })),
         );
       }
 
@@ -131,32 +139,26 @@ export const update = protectedProcedure
         .map((categorization) => categorization.feedId);
 
       if (feedIdsToCategorize.length > 0) {
-        await Promise.all(
-          feedIdsToCategorize.map(async (feedId) => {
-            return await tx
-              .insert(feedCategories)
-              .values({
-                categoryId: category.id,
-                feedId,
-              })
-              .onConflictDoNothing();
-          }),
-        );
+        await tx
+          .insert(feedCategories)
+          .values(
+            feedIdsToCategorize.map((feedId) => ({
+              categoryId: category.id,
+              feedId,
+            })),
+          )
+          .onConflictDoNothing();
       }
 
       if (feedIdsToDecategorize.length > 0) {
-        await Promise.all(
-          feedIdsToDecategorize.map(async (feedId) => {
-            return await tx
-              .delete(feedCategories)
-              .where(
-                and(
-                  eq(feedCategories.feedId, feedId),
-                  eq(feedCategories.categoryId, input.id),
-                ),
-              );
-          }),
-        );
+        await tx
+          .delete(feedCategories)
+          .where(
+            and(
+              inArray(feedCategories.feedId, feedIdsToDecategorize),
+              eq(feedCategories.categoryId, input.id),
+            ),
+          );
       }
     });
   });

--- a/apps/app/src/server/api/routers/feed-router/index.ts
+++ b/apps/app/src/server/api/routers/feed-router/index.ts
@@ -32,6 +32,11 @@ import {
 } from "~/server/subscriptions/helpers";
 import { getEffectivePlanConfig } from "~/server/subscriptions/plans";
 import { VIEW_LAYOUT_ITEM_TYPE } from "~/server/db/constants";
+import {
+  boundedNumberIdsSchema,
+  boundedStringsSchema,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
 type BulkImportFromFileSuccess = {
   feedUrl: string;
@@ -50,8 +55,8 @@ export const create = protectedProcedure
   .input(
     z.object({
       url: z.string().min(5),
-      categoryIds: z.number().array(),
-      viewIds: z.number().array().optional(),
+      categoryIds: boundedNumberIdsSchema,
+      viewIds: boundedNumberIdsSchema.optional(),
     }),
   )
   .handler(async ({ context, input }) => {
@@ -168,9 +173,10 @@ export const createFromSubscriptionImport = protectedProcedure
       feeds: z
         .object({
           feedUrl: z.string(),
-          categories: z.string().array(),
+          categories: boundedStringsSchema,
         })
-        .array(),
+        .array()
+        .max(MAX_BULK_MUTATION_ITEMS),
     }),
   )
   .handler(async ({ context, input }): Promise<BulkImportFromFileResult[]> => {
@@ -387,8 +393,8 @@ export const update = protectedProcedure
   .input(
     z.object({
       feedId: z.number(),
-      categoryIds: z.number().array(),
-      viewIds: z.number().array().optional(),
+      categoryIds: boundedNumberIdsSchema,
+      viewIds: boundedNumberIdsSchema.optional(),
       openLocation: openLocationSchema,
       name: z.string().min(1).max(256),
     }),
@@ -443,17 +449,17 @@ export const update = protectedProcedure
           ),
         );
 
-      await Promise.all(
-        input.categoryIds.map(async (categoryId) => {
-          await tx
-            .insert(feedCategories)
-            .values({
+      if (input.categoryIds.length > 0) {
+        await tx
+          .insert(feedCategories)
+          .values(
+            input.categoryIds.map((categoryId) => ({
               feedId: input.feedId,
               categoryId,
-            })
-            .onConflictDoNothing();
-        }),
-      );
+            })),
+          )
+          .onConflictDoNothing();
+      }
 
       // View feeds - sync direct view assignments
       if (input.viewIds !== undefined) {
@@ -527,7 +533,7 @@ async function discoverYouTubeFeeds(url: string) {
 }
 
 export const bulkDelete = protectedProcedure
-  .input(z.object({ feedIds: z.number().array() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 
@@ -602,7 +608,7 @@ export const setActive = protectedProcedure
   });
 
 export const bulkSetActive = protectedProcedure
-  .input(z.object({ feedIds: z.number().array(), isActive: z.boolean() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema, isActive: z.boolean() }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 

--- a/apps/app/src/server/api/routers/feedCategoriesRouter.ts
+++ b/apps/app/src/server/api/routers/feedCategoriesRouter.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { verifyFeedsOwnedByUser } from "./feed-router/utils";
 import { protectedProcedure } from "~/server/orpc/base";
 import { contentCategories, feedCategories } from "~/server/db/schema";
+import { boundedNumberIdsSchema } from "~/lib/schemas/bulk";
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {
   const contentCategoriesList = await context.db
@@ -71,7 +72,7 @@ export const removeFromFeed = protectedProcedure
   });
 
 export const bulkAssignToFeeds = protectedProcedure
-  .input(z.object({ feedIds: z.number().array(), categoryId: z.number() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema, categoryId: z.number() }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 
@@ -88,22 +89,20 @@ export const bulkAssignToFeeds = protectedProcedure
         );
       }
 
-      await Promise.all(
-        input.feedIds.map(async (feedId) => {
-          await tx
-            .insert(feedCategories)
-            .values({
-              feedId,
-              categoryId: input.categoryId,
-            })
-            .onConflictDoNothing();
-        }),
-      );
+      await tx
+        .insert(feedCategories)
+        .values(
+          input.feedIds.map((feedId) => ({
+            feedId,
+            categoryId: input.categoryId,
+          })),
+        )
+        .onConflictDoNothing();
     });
   });
 
 export const bulkRemoveFromFeeds = protectedProcedure
-  .input(z.object({ feedIds: z.number().array(), categoryId: z.number() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema, categoryId: z.number() }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 

--- a/apps/app/src/server/api/routers/feedItemRouter.ts
+++ b/apps/app/src/server/api/routers/feedItemRouter.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, or } from "drizzle-orm";
 import { z } from "zod";
 import { getClientChannel } from "../channels";
 import { verifyFeedsOwnedByUser } from "./feed-router/utils";
@@ -10,118 +10,23 @@ import { publisher } from "~/server/api/publisher";
 import { feedItems, feeds } from "~/server/db/schema";
 import { protectedProcedure } from "~/server/orpc/base";
 import { fetchAndInsertFeedData } from "~/server/rss/fetchFeeds";
+import {
+  deduplicateByLastValue,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
-type GetAllItemsChunk =
+type FeedItemsChunk =
   | {
       type: "feed-items";
       feedItems: ApplicationFeedItem[];
+      hasMore?: boolean;
+      nextCursor?: { postedAt: Date; id: string } | null;
     }
   | {
       type: "feed-status";
       feedId: number;
       status: FetchFeedsStatus;
     };
-
-const GET_ALL_ITEMS_YIELD_BUFFER_MS = 100;
-const GET_ALL_CHUNK_SIZE = 100;
-export const getAll = protectedProcedure.handler(async function* ({
-  context,
-}): AsyncGenerator<GetAllItemsChunk> {
-  // Get existing items, yield
-  const feedsList = await context.db.query.feeds.findMany({
-    where: eq(feeds.userId, context.user.id),
-  });
-  const feedIds = feedsList.map((feed) => feed.id);
-
-  const itemsData = await context.db.query.feedItems.findMany({
-    where: and(inArray(feedItems.feedId, feedIds)),
-    orderBy: desc(feedItems.postedAt),
-  });
-
-  const existingApplicationFeedItems = itemsData.map((item) => {
-    const itemFeed = feedsList.find((f) => f.id === item.feedId);
-
-    return {
-      ...item,
-      platform: itemFeed?.platform ?? "youtube",
-    } as ApplicationFeedItem;
-  });
-
-  // Send existing feed items to user
-  let timeLastSent = 0;
-  let inProgressChunk = [];
-  for (const chunk of prepareArrayChunks(
-    existingApplicationFeedItems,
-    GET_ALL_CHUNK_SIZE,
-  )) {
-    inProgressChunk.push(...chunk);
-
-    if (inProgressChunk.length < GET_ALL_CHUNK_SIZE) {
-      continue;
-    }
-
-    const now = Date.now();
-    const timePassed = now - timeLastSent;
-
-    if (timePassed < GET_ALL_ITEMS_YIELD_BUFFER_MS) {
-      await new Promise((res) =>
-        setTimeout(res, GET_ALL_ITEMS_YIELD_BUFFER_MS - timePassed),
-      );
-    }
-
-    timeLastSent = Date.now();
-
-    yield {
-      type: "feed-items",
-      feedItems: inProgressChunk,
-    };
-
-    inProgressChunk = [];
-  }
-
-  // Send new feed items to user as they come in
-  for await (const feedResult of fetchAndInsertFeedData(context, feedsList)) {
-    yield {
-      type: "feed-status",
-      status: feedResult.status,
-      feedId: feedResult.id,
-    };
-
-    if (feedResult.status !== "success") {
-      continue;
-    }
-
-    for (const chunk of prepareArrayChunks(
-      feedResult.feedItems,
-      GET_ALL_CHUNK_SIZE,
-    )) {
-      inProgressChunk.push(...chunk);
-      if (inProgressChunk.length < GET_ALL_CHUNK_SIZE) {
-        continue;
-      }
-
-      const now = Date.now();
-      const timePassed = now - timeLastSent;
-
-      if (timePassed < GET_ALL_ITEMS_YIELD_BUFFER_MS) {
-        await new Promise((res) =>
-          setTimeout(res, GET_ALL_ITEMS_YIELD_BUFFER_MS - timePassed),
-        );
-      }
-
-      timeLastSent = Date.now();
-
-      yield {
-        type: "feed-items",
-        feedItems: chunk,
-      };
-
-      inProgressChunk = [];
-    }
-  }
-
-  return;
-});
 
 export const setWatchedValue = protectedProcedure
   .input(
@@ -219,12 +124,20 @@ export const setWatchedValue = protectedProcedure
 export const setBulkWatchedValue = protectedProcedure
   .input(
     z.object({
-      items: z.array(
-        z.object({
-          id: z.string(),
-          feedId: z.number(),
-        }),
-      ),
+      items: z
+        .array(
+          z.object({
+            id: z.string(),
+            feedId: z.number(),
+          }),
+        )
+        .max(MAX_BULK_MUTATION_ITEMS)
+        .transform((values) =>
+          deduplicateByLastValue(
+            values,
+            (value) => `${value.feedId}:${value.id}`,
+          ),
+        ),
       isWatched: z.boolean(),
     }),
   )
@@ -420,11 +333,19 @@ export const getById = protectedProcedure
   });
 
 export const getByFeedId = protectedProcedure
-  .input(z.object({ feedId: z.number() }))
+  .input(
+    z.object({
+      feedId: z.number(),
+      cursor: z
+        .object({ postedAt: z.coerce.date(), id: z.string() })
+        .optional(),
+      limit: z.number().int().min(1).max(50).optional(),
+    }),
+  )
   .handler(async function* ({
     context,
     input,
-  }): AsyncGenerator<GetAllItemsChunk> {
+  }): AsyncGenerator<FeedItemsChunk> {
     const feed = await context.db.query.feeds.findFirst({
       where: and(eq(feeds.id, input.feedId), eq(feeds.userId, context.user.id)),
     });
@@ -433,12 +354,26 @@ export const getByFeedId = protectedProcedure
       return;
     }
 
+    const limit = input.limit ?? 50;
+    const cursorFilter = input.cursor
+      ? or(
+          lt(feedItems.postedAt, input.cursor.postedAt),
+          and(
+            eq(feedItems.postedAt, input.cursor.postedAt),
+            lt(feedItems.id, input.cursor.id),
+          ),
+        )
+      : undefined;
     const itemsData = await context.db.query.feedItems.findMany({
-      where: and(eq(feedItems.feedId, input.feedId)),
-      orderBy: desc(feedItems.postedAt),
+      where: and(eq(feedItems.feedId, input.feedId), cursorFilter),
+      orderBy: [desc(feedItems.postedAt), desc(feedItems.id)],
+      limit: limit + 1,
     });
+    const hasMore = itemsData.length > limit;
+    const itemsToReturn = itemsData.slice(0, limit);
+    const lastItem = itemsToReturn.at(-1);
 
-    const existingApplicationFeedItems = itemsData.map((item) => ({
+    const existingApplicationFeedItems = itemsToReturn.map((item) => ({
       ...item,
       platform: feed.platform,
     })) as ApplicationFeedItem[];
@@ -447,7 +382,16 @@ export const getByFeedId = protectedProcedure
       yield {
         type: "feed-items",
         feedItems: chunk,
+        hasMore,
+        nextCursor:
+          hasMore && lastItem
+            ? { postedAt: lastItem.postedAt, id: lastItem.id }
+            : null,
       };
+    }
+
+    if (input.cursor) {
+      return;
     }
 
     for await (const feedResult of fetchAndInsertFeedData(context, [feed])) {

--- a/apps/app/src/server/api/routers/initialRouter.ts
+++ b/apps/app/src/server/api/routers/initialRouter.ts
@@ -3,11 +3,13 @@ import {
   asc,
   desc,
   eq,
+  exists,
   getTableColumns,
   gt,
   inArray,
   isNull,
   lt,
+  not,
   or,
   sql,
 } from "drizzle-orm";
@@ -54,6 +56,7 @@ import {
   buildViewCategoryFilter,
   buildVisibilityFilter,
   isFeedCompatibleWithContentType,
+  VIDEO_PLATFORMS,
 } from "~/lib/data/feed-items/filters";
 import { INBOX_VIEW_ID } from "~/lib/data/views/constants";
 import { sortViewsByPlacement } from "~/lib/data/views/utils";
@@ -81,6 +84,11 @@ import {
 import { protectedProcedure } from "~/server/orpc/base";
 import { fetchAndInsertFeedData } from "~/server/rss/fetchFeeds";
 import { refreshUserFeeds } from "~/server/rss/refreshUserFeeds";
+import {
+  boundedNumberIdsSchema,
+  boundedStringsSchema,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
 export type PaginationCursor = {
   placement?: number;
@@ -628,6 +636,177 @@ async function fetchUserPrerequisiteData(
   };
 }
 
+type ScopedViewPageData = {
+  view: ApplicationView;
+  applicationFeeds: ApplicationFeed[];
+  feedsById: Map<number, DatabaseFeed>;
+  feedIds: number[];
+};
+
+function buildScopedViewPageData(
+  view: ApplicationView,
+  feedsList: DatabaseFeed[],
+): ScopedViewPageData {
+  return {
+    view,
+    applicationFeeds: parseArrayOfSchema(feedsList, feedsSchema),
+    feedsById: new Map(feedsList.map((feed) => [feed.id, feed])),
+    feedIds: feedsList.map((feed) => feed.id),
+  };
+}
+
+async function fetchUncategorizedPageData(
+  context: ORPCContext,
+  userId: string,
+): Promise<ScopedViewPageData> {
+  const compatibleCustomView = or(
+    isNull(views.contentType),
+    inArray(views.contentType, ["all", "longform"]),
+    and(
+      inArray(views.contentType, ["horizontal-video", "vertical-video"]),
+      inArray(feeds.platform, [...VIDEO_PLATFORMS]),
+    ),
+  );
+  const directlyAssignedToCompatibleView = exists(
+    context.db
+      .select({ value: sql<number>`1` })
+      .from(viewFeeds)
+      .innerJoin(
+        views,
+        and(eq(views.id, viewFeeds.viewId), eq(views.userId, userId)),
+      )
+      .where(and(eq(viewFeeds.feedId, feeds.id), compatibleCustomView)),
+  );
+  const taggedIntoCompatibleView = exists(
+    context.db
+      .select({ value: sql<number>`1` })
+      .from(feedCategories)
+      .innerJoin(
+        viewCategories,
+        eq(viewCategories.categoryId, feedCategories.categoryId),
+      )
+      .innerJoin(
+        views,
+        and(eq(views.id, viewCategories.viewId), eq(views.userId, userId)),
+      )
+      .where(and(eq(feedCategories.feedId, feeds.id), compatibleCustomView)),
+  );
+  const includedByUnfilteredCompatibleView = exists(
+    context.db
+      .select({ value: sql<number>`1` })
+      .from(views)
+      .where(
+        and(
+          eq(views.userId, userId),
+          compatibleCustomView,
+          not(
+            exists(
+              context.db
+                .select({ value: sql<number>`1` })
+                .from(viewFeeds)
+                .where(eq(viewFeeds.viewId, views.id)),
+            ),
+          ),
+          not(
+            exists(
+              context.db
+                .select({ value: sql<number>`1` })
+                .from(viewCategories)
+                .where(eq(viewCategories.viewId, views.id)),
+            ),
+          ),
+        ),
+      ),
+  );
+  const feedsList = await context.db
+    .select()
+    .from(feeds)
+    .where(
+      and(
+        eq(feeds.userId, userId),
+        not(directlyAssignedToCompatibleView),
+        not(taggedIntoCompatibleView),
+        not(includedByUnfilteredCompatibleView),
+      ),
+    );
+
+  return buildScopedViewPageData(
+    buildUncategorizedView(userId, [], []),
+    feedsList,
+  );
+}
+
+async function fetchScopedViewPageData(
+  context: ORPCContext,
+  viewId: number,
+): Promise<ScopedViewPageData | null> {
+  const userId = context.user!.id;
+  if (viewId === INBOX_VIEW_ID) {
+    return fetchUncategorizedPageData(context, userId);
+  }
+
+  const [view] = await context.db
+    .select()
+    .from(views)
+    .where(and(eq(views.id, viewId), eq(views.userId, userId)))
+    .limit(1);
+  if (!view) return null;
+
+  const [categoryRows, directFeedRows, sectionRows] = await Promise.all([
+    context.db
+      .select()
+      .from(viewCategories)
+      .where(eq(viewCategories.viewId, viewId)),
+    context.db.select().from(viewFeeds).where(eq(viewFeeds.viewId, viewId)),
+    context.db
+      .select()
+      .from(viewSections)
+      .where(eq(viewSections.viewId, viewId))
+      .orderBy(asc(viewSections.placement)),
+  ]);
+  const categoryIds = categoryRows.flatMap((row) =>
+    row.categoryId === null ? [] : [row.categoryId],
+  );
+  const directFeedIds = directFeedRows.map((row) => row.feedId);
+  const taggedFeedFilter =
+    categoryIds.length > 0
+      ? exists(
+          context.db
+            .select({ value: sql<number>`1` })
+            .from(feedCategories)
+            .where(
+              and(
+                eq(feedCategories.feedId, feeds.id),
+                inArray(feedCategories.categoryId, categoryIds),
+              ),
+            ),
+        )
+      : undefined;
+  const directFeedFilter =
+    directFeedIds.length > 0 ? inArray(feeds.id, directFeedIds) : undefined;
+  const hasExplicitMembership =
+    categoryIds.length > 0 || directFeedIds.length > 0;
+  const membershipFilter = hasExplicitMembership
+    ? or(directFeedFilter, taggedFeedFilter)
+    : undefined;
+  const feedsList = await context.db
+    .select()
+    .from(feeds)
+    .where(and(eq(feeds.userId, userId), membershipFilter));
+  const applicationView: ApplicationView = {
+    ...view,
+    isDefault: false,
+    categoryIds,
+    feedIds: directFeedIds,
+    viewSections: sectionRows.map((section) => ({
+      ...section,
+      itemType: section.itemType as "tag" | "feed",
+    })),
+  };
+
+  return buildScopedViewPageData(applicationView, feedsList);
+}
+
 type ApplicationViewsData = {
   customViews: ApplicationView[];
   allViews: ApplicationView[];
@@ -770,6 +949,7 @@ type ViewPaginatedFeedItemScope = {
   type: "view";
   view: ApplicationView;
   feedIds: number[];
+  membershipResolved?: boolean;
   feedCategoriesList: DatabaseFeedCategory[];
   customViewCategoryIds: Set<number>;
   customViews: ApplicationView[];
@@ -806,15 +986,17 @@ function buildPaginatedFeedItemQuery({
     scope.type === "view"
       ? [
           inArray(feedItems.feedId, scope.feedIds),
-          buildViewCategoryFilter(
-            scope.view,
-            scope.feedCategoriesList,
-            scope.feedIds,
-            scope.customViewCategoryIds,
-            scope.customViews,
-            scope.applicationFeeds,
-            scope.customViewFeedIds,
-          ),
+          scope.membershipResolved
+            ? undefined
+            : buildViewCategoryFilter(
+                scope.view,
+                scope.feedCategoriesList,
+                scope.feedIds,
+                scope.customViewCategoryIds,
+                scope.customViews,
+                scope.applicationFeeds,
+                scope.customViewFeedIds,
+              ),
           buildContentTypeFilter(
             scope.view.contentType,
             scope.applicationFeeds,
@@ -881,6 +1063,7 @@ async function queryLightweightItemsForView(
     customViews: ApplicationView[];
     applicationFeeds: ApplicationFeed[];
     customViewFeedIds?: Set<number>;
+    membershipResolved?: boolean;
   },
 ): Promise<{
   items: LightweightFeedItem[];
@@ -898,6 +1081,7 @@ async function queryLightweightItemsForView(
     customViews,
     applicationFeeds,
     customViewFeedIds,
+    membershipResolved,
   } = params;
 
   let itemsData: Array<
@@ -915,6 +1099,7 @@ async function queryLightweightItemsForView(
       customViews,
       applicationFeeds,
       customViewFeedIds,
+      membershipResolved,
     },
     visibilityFilter,
     cursor,
@@ -1054,6 +1239,7 @@ async function queryFeedItemsForView(
     customViews: ApplicationView[];
     applicationFeeds: ApplicationFeed[];
     customViewFeedIds?: Set<number>;
+    membershipResolved?: boolean;
   },
 ): Promise<{
   items: ApplicationFeedItem[];
@@ -1071,6 +1257,7 @@ async function queryFeedItemsForView(
     customViews,
     applicationFeeds,
     customViewFeedIds,
+    membershipResolved,
   } = params;
 
   let itemsData: Array<typeof feedItems.$inferSelect & { placement?: number }>;
@@ -1084,6 +1271,7 @@ async function queryFeedItemsForView(
       customViews,
       applicationFeeds,
       customViewFeedIds,
+      membershipResolved,
     },
     visibilityFilter,
     cursor,
@@ -1539,7 +1727,7 @@ export const requestInitialData = protectedProcedure
  * Only fetches RSS for the specified newFeedIds (the newly imported feeds).
  */
 export const requestImportedData = protectedProcedure
-  .input(z.object({ newFeedIds: z.number().array() }))
+  .input(z.object({ newFeedIds: boundedNumberIdsSchema }))
   .handler(async ({ context, input }) => {
     const { newFeedIds } = input;
     const channel = getUserChannel(context.user.id);
@@ -1770,24 +1958,28 @@ export const streamingImport = protectedProcedure
       feeds: z
         .object({
           feedUrl: z.string(),
-          categories: z.string().array(),
+          categories: boundedStringsSchema,
           categoryPaths: z
             .array(
-              z.array(
-                z.union([
-                  z.string(),
-                  z.object({
-                    name: z.string(),
-                    type: z.enum(["view", "tag", "feed"]).optional(),
-                    feedUrl: z.string().optional(),
-                  }),
-                ]),
-              ),
+              z
+                .array(
+                  z.union([
+                    z.string(),
+                    z.object({
+                      name: z.string(),
+                      type: z.enum(["view", "tag", "feed"]).optional(),
+                      feedUrl: z.string().optional(),
+                    }),
+                  ]),
+                )
+                .max(MAX_BULK_MUTATION_ITEMS),
             )
+            .max(MAX_BULK_MUTATION_ITEMS)
             .optional(),
-          tagNames: z.string().array().optional(),
+          tagNames: boundedStringsSchema.optional(),
         })
-        .array(),
+        .array()
+        .max(MAX_BULK_MUTATION_ITEMS),
       importMode: z.enum(["tags", "views", "ignore"]).optional(),
     }),
   )
@@ -2455,10 +2647,9 @@ export const requestItemsByVisibility = protectedProcedure
     const limit = input.limit ?? ITEMS_PER_PAGE;
     const clientItems = input.clientItems;
 
-    // Fetch prerequisite data using helper
-    let prerequisiteData: PrerequisiteData;
+    let pageData: ScopedViewPageData | null;
     try {
-      prerequisiteData = await fetchUserPrerequisiteData(context);
+      pageData = await fetchScopedViewPageData(context, input.viewId);
     } catch (error) {
       captureException(error);
       await publisher.publish(channel, {
@@ -2475,18 +2666,19 @@ export const requestItemsByVisibility = protectedProcedure
       return { status: "error" };
     }
 
-    const { feedCategoriesList } = prerequisiteData;
+    if (!pageData) {
+      await publisher.publish(channel, {
+        source: "visibility",
+        chunk: {
+          type: "error",
+          message: `View with ID ${input.viewId} not found`,
+          phase: "find-view",
+        },
+      });
+      return { status: "error" };
+    }
 
-    // Build application data using helper
-    const {
-      customViews,
-      allViews,
-      customViewCategoryIds,
-      customViewFeedIds,
-      applicationFeeds,
-      feedsById,
-      feedIds,
-    } = prepareApplicationData(context.user.id, prerequisiteData);
+    const { view: targetView, applicationFeeds, feedsById, feedIds } = pageData;
 
     if (feedIds.length === 0) {
       await publisher.publish(channel, {
@@ -2503,21 +2695,6 @@ export const requestItemsByVisibility = protectedProcedure
       return { status: "completed" };
     }
 
-    // Find target view (INBOX_VIEW_ID maps to the Uncategorized view)
-    const targetView = allViews.find((v) => v.id === input.viewId);
-
-    if (!targetView) {
-      await publisher.publish(channel, {
-        source: "visibility",
-        chunk: {
-          type: "error",
-          message: `View with ID ${input.viewId} not found`,
-          phase: "find-view",
-        },
-      });
-      return { status: "error" };
-    }
-
     try {
       const { items, hasMore, nextCursor } = await queryFeedItemsForView(
         context,
@@ -2528,11 +2705,11 @@ export const requestItemsByVisibility = protectedProcedure
           cursor: input.cursor ?? null,
           limit,
           feedsById,
-          feedCategoriesList,
-          customViewCategoryIds,
-          customViews,
+          feedCategoriesList: [],
+          customViewCategoryIds: new Set(),
+          customViews: [],
           applicationFeeds,
-          customViewFeedIds,
+          membershipResolved: true,
         },
       );
 
@@ -2839,156 +3016,15 @@ export const requestItemsByCategoryId = protectedProcedure
     return { status: "completed" };
   });
 
-// ============================================================================
-// LEGACY STREAMING PROCEDURES (kept for backward compatibility during migration)
-// ============================================================================
-
-export const getAllByView = protectedProcedure
-  .input(z.object({ visibilityFilter: visibilityFilterSchema }).optional())
-  .handler(async function* ({
-    context,
-    input,
-  }): AsyncGenerator<GetByViewChunk> {
-    const visibilityFilter = input?.visibilityFilter;
-    const isVisibilityFilterFetch = !!visibilityFilter;
-
-    // Step 1: Fetch all prerequisite data using helper
-    let prerequisiteData: PrerequisiteData;
-    try {
-      prerequisiteData = await fetchUserPrerequisiteData(context);
-    } catch (error) {
-      captureException(error);
-      yield {
-        type: "error",
-        message:
-          error instanceof Error
-            ? error.message
-            : "Failed to fetch initial data",
-        phase: "initial-fetch",
-      };
-      return;
-    }
-
-    const { feedsList, contentCategoriesList, feedCategoriesList } =
-      prerequisiteData;
-
-    // Build application data using helper
-    const {
-      customViews,
-      allViews,
-      customViewCategoryIds,
-      customViewFeedIds,
-      applicationFeeds,
-      feedsById,
-      feedIds,
-    } = prepareApplicationData(context.user.id, prerequisiteData);
-
-    // Step 2: Yield prerequisite data chunks (skip when fetching for visibility filter)
-    if (!isVisibilityFilterFetch) {
-      yield {
-        type: "views",
-        views: allViews,
-      };
-
-      yield {
-        type: "feeds",
-        feeds: applicationFeeds,
-      };
-
-      yield {
-        type: "content-categories",
-        contentCategories: contentCategoriesList,
-      };
-
-      yield {
-        type: "feed-categories",
-        feedCategories: feedCategoriesList,
-      };
-
-      // Step 3: Yield view-feeds chunks for each view
-      const feedCategoriesMap = buildFeedCategoriesMap(feedCategoriesList);
-      for (const view of allViews) {
-        const feedIdsForView = computeFeedsForView(
-          view,
-          applicationFeeds,
-          feedCategoriesList,
-          customViews,
-          customViewCategoryIds,
-          feedCategoriesMap,
-          customViewFeedIds,
-        );
-
-        yield {
-          type: "view-feeds",
-          viewId: view.id,
-          feedIds: feedIdsForView,
-        };
-      }
-    }
-
-    const firstView = allViews[0];
-
-    if (feedIds.length === 0 || !firstView) {
-      if (!isVisibilityFilterFetch) {
-        yield { type: "initial-data-complete" };
-      }
-      return;
-    }
-
-    const fetchContentForViewParams: FetchContentForViewParams = {
-      feedIds,
-      visibilityFilter,
-      feedCategoriesList,
-      customViewCategoryIds,
-      customViews,
-      applicationFeeds,
-      feedsById,
-    };
-
-    // Step 4: Query and yield initial items (first 100) for EACH view
-    for await (const { chunk } of fetchContentForViews(
-      context,
-      allViews,
-      fetchContentForViewParams,
-    )) {
-      yield chunk;
-    }
-
-    // Skip initial-data-complete and RSS fetch when fetching for visibility filter
-    if (!isVisibilityFilterFetch) {
-      // Signal that initial data is complete - client can hide loading screen
-      yield { type: "initial-data-complete" };
-
-      // Step 5: Run fetch and insert for fresh RSS items in background
-      // Items are inserted to DB by fetchAndInsertFeedData - don't yield them here
-      // Fresh items will be available via pagination (getItemsByVisibility)
-      const activeFeedsForLegacy = feedsList.filter((feed) => feed.isActive);
-      for await (const feedResult of fetchAndInsertFeedData(
-        context,
-        activeFeedsForLegacy,
-      )) {
-        yield {
-          type: "feed-status",
-          status: feedResult.status,
-          feedId: feedResult.id,
-        };
-        // Items already inserted to DB - they'll be included in pagination queries
-      }
-    }
-
-    return;
-  });
-
 export const revalidateView = protectedProcedure
   .input(z.object({ viewId: z.number() }))
   .handler(async function* ({
     context,
     input,
   }): AsyncGenerator<RevalidateViewChunk> {
-    // Step 1: Fetch all prerequisite data using helper
-    let prerequisiteData: PrerequisiteData;
+    let targetPageData: ScopedViewPageData | null;
     try {
-      prerequisiteData = await fetchUserPrerequisiteData(context);
+      targetPageData = await fetchScopedViewPageData(context, input.viewId);
     } catch (error) {
       captureException(error);
       yield {
@@ -3002,66 +3038,24 @@ export const revalidateView = protectedProcedure
       return;
     }
 
-    const { feedCategoriesList } = prerequisiteData;
-
-    // Build application data using helper
-    const {
-      customViews,
-      allViews,
-      customViewCategoryIds,
-      customViewFeedIds,
-      applicationFeeds,
-      feedsById,
-      feedIds,
-    } = prepareApplicationData(context.user.id, prerequisiteData);
-
-    // Find uncategorized view (always present in allViews with id === INBOX_VIEW_ID)
-    const uncategorizedView = allViews.find((v) => v.id === INBOX_VIEW_ID)!;
-
-    // Step 2: Yield views
-    yield {
-      type: "views",
-      views: allViews,
-    };
-
-    // Step 3: Yield view-feeds chunks for each view
-    const feedCategoriesMap = buildFeedCategoriesMap(feedCategoriesList);
-    for (const view of allViews) {
-      const feedIdsForView = computeFeedsForView(
-        view,
-        applicationFeeds,
-        feedCategoriesList,
-        customViews,
-        customViewCategoryIds,
-        feedCategoriesMap,
-        customViewFeedIds,
-      );
-
+    if (!targetPageData) {
       yield {
-        type: "view-feeds",
-        viewId: view.id,
-        feedIds: feedIdsForView,
+        type: "error",
+        message: `View with ID ${input.viewId} not found`,
+        phase: "find-view",
       };
-    }
-
-    if (feedIds.length === 0) {
       return;
     }
 
-    // Step 3: Find target view
-    const targetView =
-      input.viewId === INBOX_VIEW_ID
-        ? uncategorizedView
-        : allViews.find((v) => v.id === input.viewId);
-
-    if (!targetView) {
-      return;
-    }
-
-    // Helper function to query and yield feed items for a view (limited for pagination)
-    async function* queryAndYieldFeedItemsForView(
-      view: ApplicationView,
+    async function* queryAndYieldScope(
+      pageData: ScopedViewPageData,
     ): AsyncGenerator<RevalidateViewChunk> {
+      const { view, applicationFeeds, feedsById, feedIds } = pageData;
+      if (feedIds.length === 0) {
+        yield { type: "feed-items", viewId: view.id, feedItems: [] };
+        return;
+      }
+
       try {
         const { items } = await queryFeedItemsForView(context, view, {
           visibilityFilter: "unread",
@@ -3069,10 +3063,11 @@ export const revalidateView = protectedProcedure
           cursor: null,
           limit: REVALIDATE_VIEW_CHUNK_SIZE,
           feedsById,
-          feedCategoriesList,
-          customViewCategoryIds,
-          customViews,
+          feedCategoriesList: [],
+          customViewCategoryIds: new Set(),
+          customViews: [],
           applicationFeeds,
+          membershipResolved: true,
         });
 
         yield {
@@ -3093,12 +3088,26 @@ export const revalidateView = protectedProcedure
       }
     }
 
-    // Step 4: Query feed items for target view
-    yield* queryAndYieldFeedItemsForView(targetView);
+    yield* queryAndYieldScope(targetPageData);
 
-    // Step 5: If target is not Uncategorized, also query feed items for Uncategorized
-    if (targetView.id !== INBOX_VIEW_ID) {
-      yield* queryAndYieldFeedItemsForView(uncategorizedView);
+    if (targetPageData.view.id !== INBOX_VIEW_ID) {
+      try {
+        const uncategorizedPageData = await fetchUncategorizedPageData(
+          context,
+          context.user.id,
+        );
+        yield* queryAndYieldScope(uncategorizedPageData);
+      } catch (error) {
+        captureException(error);
+        yield {
+          type: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to revalidate Uncategorized",
+          phase: "feed-items",
+        };
+      }
     }
 
     return;
@@ -3169,10 +3178,9 @@ export const getItemsByVisibility = protectedProcedure
   }): AsyncGenerator<GetItemsByVisibilityChunk> {
     const limit = input.limit ?? ITEMS_PER_PAGE;
 
-    // Fetch prerequisite data using helper
-    let prerequisiteData: PrerequisiteData;
+    let pageData: ScopedViewPageData | null;
     try {
-      prerequisiteData = await fetchUserPrerequisiteData(context);
+      pageData = await fetchScopedViewPageData(context, input.viewId);
     } catch (error) {
       captureException(error);
       yield {
@@ -3186,18 +3194,16 @@ export const getItemsByVisibility = protectedProcedure
       return;
     }
 
-    const { feedCategoriesList } = prerequisiteData;
+    if (!pageData) {
+      yield {
+        type: "error",
+        message: `View with ID ${input.viewId} not found`,
+        phase: "find-view",
+      };
+      return;
+    }
 
-    // Build application data using helper
-    const {
-      customViews,
-      allViews,
-      customViewCategoryIds,
-      customViewFeedIds,
-      applicationFeeds,
-      feedsById,
-      feedIds,
-    } = prepareApplicationData(context.user.id, prerequisiteData);
+    const { view: targetView, applicationFeeds, feedsById, feedIds } = pageData;
 
     if (feedIds.length === 0) {
       yield {
@@ -3212,66 +3218,23 @@ export const getItemsByVisibility = protectedProcedure
       return;
     }
 
-    // Find target view (INBOX_VIEW_ID maps to the Uncategorized view which is in allViews)
-    const targetView = allViews.find((v) => v.id === input.viewId);
-
-    if (!targetView) {
-      yield {
-        type: "error",
-        message: `View with ID ${input.viewId} not found`,
-        phase: "find-view",
-      };
-      return;
-    }
-
     try {
-      let itemsData: Array<
-        typeof feedItems.$inferSelect & { placement?: number }
-      >;
-      const queryParts = buildPaginatedFeedItemQuery({
-        scope: {
-          type: "view",
-          view: targetView,
-          feedIds,
-          feedCategoriesList,
-          customViewCategoryIds,
-          customViews,
-          applicationFeeds,
-          customViewFeedIds,
-        },
+      const {
+        items: applicationFeedItems,
+        hasMore,
+        nextCursor,
+      } = await queryFeedItemsForView(context, targetView, {
+        feedIds,
+        feedsById,
+        feedCategoriesList: [],
+        customViewCategoryIds: new Set(),
+        customViews: [],
+        applicationFeeds,
+        membershipResolved: true,
         visibilityFilter: input.visibilityFilter,
         cursor: input.cursor ?? null,
-      });
-
-      if (!queryParts.placementExpr) {
-        itemsData = await context.db.query.feedItems.findMany({
-          where: queryParts.filter,
-          orderBy: queryParts.orderBy,
-          limit: limit + 1,
-        });
-      } else {
-        itemsData = await context.db
-          .select({
-            ...getTableColumns(feedItems),
-            placement: queryParts.placementExpr,
-          })
-          .from(feedItems)
-          .where(queryParts.filter)
-          .orderBy(...queryParts.orderBy)
-          .limit(limit + 1);
-      }
-
-      // Process pagination results using helper
-      const { itemsToReturn, hasMore, nextCursor } = processPaginationResults(
-        itemsData,
         limit,
-      );
-
-      // Map to application feed items using helper
-      const applicationFeedItems = mapToApplicationFeedItems(
-        itemsToReturn,
-        feedsById,
-      );
+      });
 
       const chunks = prepareArrayChunks(
         applicationFeedItems,

--- a/apps/app/src/server/api/routers/viewFeedsRouter.ts
+++ b/apps/app/src/server/api/routers/viewFeedsRouter.ts
@@ -7,6 +7,7 @@ import {
 } from "./feed-router/utils";
 import { protectedProcedure } from "~/server/orpc/base";
 import { viewFeeds, views } from "~/server/db/schema";
+import { boundedNumberIdsSchema } from "~/lib/schemas/bulk";
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {
   const userViews = await context.db
@@ -93,7 +94,7 @@ export const removeFromView = protectedProcedure
   });
 
 export const bulkAssignToView = protectedProcedure
-  .input(z.object({ feedIds: z.number().array(), viewId: z.number() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema, viewId: z.number() }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 
@@ -133,7 +134,7 @@ export const bulkAssignToView = protectedProcedure
   });
 
 export const bulkRemoveFromView = protectedProcedure
-  .input(z.object({ feedIds: z.number().array(), viewId: z.number() }))
+  .input(z.object({ feedIds: boundedNumberIdsSchema, viewId: z.number() }))
   .handler(async ({ context, input }) => {
     if (input.feedIds.length === 0) return;
 

--- a/apps/app/src/server/api/routers/viewRouter.ts
+++ b/apps/app/src/server/api/routers/viewRouter.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, asc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -20,6 +20,10 @@ import {
   views,
   viewSections,
 } from "~/server/db/schema";
+import {
+  deduplicateByLastValue,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
 export const create = protectedProcedure
   .input(createViewSchema)
@@ -219,28 +223,40 @@ export const update = protectedProcedure
 export const updatePlacement = protectedProcedure
   .input(
     z.object({
-      views: z.array(
-        z.object({
-          id: z.number(),
-          placement: z.number(),
-        }),
-      ),
+      views: z
+        .array(
+          z.object({
+            id: z.number(),
+            placement: z.number(),
+          }),
+        )
+        .max(MAX_BULK_MUTATION_ITEMS)
+        .transform((values) =>
+          deduplicateByLastValue(values, (value) => value.id),
+        ),
     }),
   )
   .handler(async ({ context, input }) => {
+    if (input.views.length === 0) return;
+
     await context.db.transaction(async (tx) => {
-      return await Promise.all(
-        input.views.map(async (view) => {
-          return await tx
-            .update(views)
-            .set({
-              placement: view.placement,
-            })
-            .where(
-              and(eq(views.id, view.id), eq(views.userId, context.user.id)),
-            );
-        }),
+      const placementCases = input.views.map(
+        (view) => sql`when ${view.id} then ${view.placement}`,
       );
+      await tx
+        .update(views)
+        .set({
+          placement: sql`case ${views.id} ${sql.join(placementCases, sql.raw(" "))} else ${views.placement} end`,
+        })
+        .where(
+          and(
+            inArray(
+              views.id,
+              input.views.map((view) => view.id),
+            ),
+            eq(views.userId, context.user.id),
+          ),
+        );
     });
   });
 
@@ -286,22 +302,36 @@ export const getAll = protectedProcedure.handler(async ({ context }) => {
         ])
       : [[], [], []];
 
+  const categoryIdsByViewId = new Map<number, number[]>();
+  for (const association of viewCategoriesList) {
+    if (association.viewId === null || association.categoryId === null)
+      continue;
+    const categoryIds = categoryIdsByViewId.get(association.viewId) ?? [];
+    categoryIds.push(association.categoryId);
+    categoryIdsByViewId.set(association.viewId, categoryIds);
+  }
+  const feedIdsByViewId = new Map<number, number[]>();
+  for (const association of viewFeedsList) {
+    const feedIds = feedIdsByViewId.get(association.viewId) ?? [];
+    feedIds.push(association.feedId);
+    feedIdsByViewId.set(association.viewId, feedIds);
+  }
+  const sectionsByViewId = new Map<number, ApplicationView["viewSections"]>();
+  for (const section of viewSectionsList) {
+    const sections = sectionsByViewId.get(section.viewId) ?? [];
+    sections.push({
+      ...section,
+      itemType: section.itemType as "tag" | "feed",
+    });
+    sectionsByViewId.set(section.viewId, sections);
+  }
+
   const customViews: ApplicationView[] = viewsList.map((view) => ({
     ...view,
     isDefault: false,
-    categoryIds: viewCategoriesList
-      .filter((category) => category.viewId === view.id)
-      .map((category) => category.categoryId)
-      .filter((id) => id !== null),
-    feedIds: viewFeedsList
-      .filter((vf) => vf.viewId === view.id)
-      .map((vf) => vf.feedId),
-    viewSections: viewSectionsList
-      .filter((sv) => sv.viewId === view.id)
-      .map((sv) => ({
-        ...sv,
-        itemType: sv.itemType as "tag" | "feed",
-      })),
+    categoryIds: categoryIdsByViewId.get(view.id) ?? [],
+    feedIds: feedIdsByViewId.get(view.id) ?? [],
+    viewSections: sectionsByViewId.get(view.id) ?? [],
   }));
 
   const inboxView = buildUncategorizedView(

--- a/apps/app/src/server/db/schema.ts
+++ b/apps/app/src/server/db/schema.ts
@@ -29,6 +29,10 @@ import {
   viewLayoutSchema,
   viewReadStatusSchema,
 } from "./constants";
+import {
+  boundedNumberIdsSchema,
+  MAX_BULK_MUTATION_ITEMS,
+} from "~/lib/schemas/bulk";
 
 /**
  * This is an example of how to use the multi-project schema feature of Drizzle ORM. Use the same
@@ -707,20 +711,26 @@ export const createViewSchema = createInsertSchema(views)
       layout: viewLayoutSchema.optional(),
       daysWindow: z.number().lte(30).optional(),
       placement: z.number().gte(-1).optional(),
-      categoryIds: z.array(z.number()).optional(),
-      feedIds: z.array(z.number()).optional(),
-      viewSections: z.array(viewSectionInputSchema).optional(),
+      categoryIds: boundedNumberIdsSchema.optional(),
+      feedIds: boundedNumberIdsSchema.optional(),
+      viewSections: z
+        .array(viewSectionInputSchema)
+        .max(MAX_BULK_MUTATION_ITEMS)
+        .optional(),
     }),
   );
 
 export const updateViewSchema = createUpdateSchema(views).merge(
   z.object({
     id: z.number(),
-    categoryIds: z.array(z.number()),
-    feedIds: z.array(z.number()),
+    categoryIds: boundedNumberIdsSchema,
+    feedIds: boundedNumberIdsSchema,
     contentType: viewContentTypeSchema.optional(),
     layout: viewLayoutSchema.optional(),
-    viewSections: z.array(viewSectionInputSchema).optional(),
+    viewSections: z
+      .array(viewSectionInputSchema)
+      .max(MAX_BULK_MUTATION_ITEMS)
+      .optional(),
   }),
 );
 

--- a/apps/app/tests/unit/performance/legacy-organization-workloads.test.ts
+++ b/apps/app/tests/unit/performance/legacy-organization-workloads.test.ts
@@ -1,0 +1,600 @@
+import { createRouterClient } from "@orpc/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyMigrations,
+  createLocalBenchmarkTarget,
+  openBenchmarkDatabase,
+} from "../../../scripts/performance/database";
+import type { ORPCContext } from "~/server/orpc/base";
+import {
+  contentCategories,
+  feedCategories,
+  feedItems,
+  feeds,
+  user,
+  viewCategories,
+  viewFeeds,
+  views,
+  viewSections,
+} from "~/server/db/schema";
+import { orpcRouter } from "~/server/orpc/router";
+
+const testState = vi.hoisted((): { database: unknown } => ({
+  database: undefined,
+}));
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return testState.database;
+  },
+}));
+vi.mock("~/server/auth", () => ({ auth: {} }));
+vi.mock("~/env", () => ({
+  env: {
+    BACKGROUND_REFRESH_ENABLED: false,
+    DATABASE_URL: "file::memory:",
+    KV_STORE: "none",
+    PUBLIC_BASE_URL: "http://localhost:3000",
+    TRUSTED_ORIGINS: [],
+  },
+}));
+
+describe("legacy server workload contracts", () => {
+  it("does not expose full-library Feed-item or initial View procedures", () => {
+    expect("getAll" in orpcRouter.feedItem).toBe(false);
+    expect("getAllByView" in orpcRouter.initial).toBe(false);
+  });
+
+  it("materializes only one bounded Feed-item page before the first yield", async () => {
+    const target = createLocalBenchmarkTarget();
+    const session = openBenchmarkDatabase({ url: target.url });
+    try {
+      await applyMigrations(session.baseClient);
+      const now = new Date("2026-07-31T12:00:00.000Z");
+      await session.database.insert(user).values({
+        id: "user-one",
+        name: "User One",
+        email: "user-one@example.com",
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await session.database.insert(feeds).values({
+        id: 1,
+        userId: "user-one",
+        name: "Feed",
+        url: "https://example.com/feed.xml",
+        platform: "website",
+      });
+      await session.database.insert(feedItems).values(
+        Array.from({ length: 120 }, (_, index) => ({
+          id: `item-${index.toString().padStart(3, "0")}`,
+          feedId: 1,
+          contentId: `content-${index}`,
+          title: `Item ${index}`,
+          author: "Author",
+          url: `https://example.com/${index}`,
+          postedAt: new Date(now.getTime() - index * 1_000),
+          createdAt: now,
+          updatedAt: now,
+        })),
+      );
+
+      testState.database = session.database;
+      const api = createRouterClient(orpcRouter, {
+        context: {
+          headers: new Headers(),
+          session: { id: "session-one" },
+          user: { id: "user-one" },
+          db: session.database,
+        } as ORPCContext,
+      });
+
+      session.instrumentation.reset();
+      const stream = await api.feedItem.getByFeedId({ feedId: 1 });
+      const iterator = stream[Symbol.asyncIterator]();
+      const first = await iterator.next();
+      await iterator.return?.(undefined);
+
+      expect(first.value).toMatchObject({
+        type: "feed-items",
+        feedItems: { length: 50 },
+      });
+      expect(session.instrumentation.snapshot()).toMatchObject({
+        statementCount: 2,
+        materializedRows: 52,
+      });
+    } finally {
+      session.close();
+      target.cleanup();
+    }
+  });
+
+  it("keeps later View pages constant across 3, 10, and 25 Views", async () => {
+    async function measureLaterPage(viewCount: number) {
+      const target = createLocalBenchmarkTarget();
+      const session = openBenchmarkDatabase({ url: target.url });
+      try {
+        await applyMigrations(session.baseClient);
+        const now = new Date("2026-07-31T12:00:00.000Z");
+        await session.database.insert(user).values({
+          id: "user-one",
+          name: "User One",
+          email: "user-one@example.com",
+          emailVerified: true,
+          createdAt: now,
+          updatedAt: now,
+        });
+        await session.database.insert(feeds).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            id: index + 1,
+            userId: "user-one",
+            name: `Feed ${index + 1}`,
+            url: `https://example.com/${index + 1}.xml`,
+            platform: "website" as const,
+          })),
+        );
+        await session.database.insert(contentCategories).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            id: index + 1,
+            userId: "user-one",
+            name: `Tag ${index + 1}`,
+          })),
+        );
+        await session.database.insert(views).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            id: index + 1,
+            userId: "user-one",
+            name: `View ${index + 1}`,
+            contentType: "longform" as const,
+            layout: "list" as const,
+            placement: index,
+          })),
+        );
+        await session.database.insert(feedCategories).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            feedId: index + 1,
+            categoryId: index + 1,
+          })),
+        );
+        await session.database.insert(viewCategories).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            viewId: index + 1,
+            categoryId: index + 1,
+          })),
+        );
+        await session.database.insert(viewFeeds).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            viewId: index + 1,
+            feedId: index + 1,
+          })),
+        );
+        await session.database.insert(viewSections).values(
+          Array.from({ length: viewCount }, (_, index) => ({
+            viewId: index + 1,
+            placement: 0,
+            itemType: "feed" as const,
+            itemId: index + 1,
+          })),
+        );
+        await session.database.insert(feedItems).values(
+          Array.from({ length: 5 }, (_, index) => ({
+            id: `item-${index.toString().padStart(3, "0")}`,
+            feedId: 1,
+            contentId: `content-${index}`,
+            title: `Item ${index}`,
+            author: "Author",
+            url: `https://example.com/item/${index}`,
+            orientation: "horizontal",
+            postedAt: new Date(now.getTime() - index * 1_000),
+            createdAt: now,
+            updatedAt: now,
+          })),
+        );
+
+        testState.database = session.database;
+        const api = createRouterClient(orpcRouter, {
+          context: {
+            headers: new Headers(),
+            session: { id: "session-one" },
+            user: { id: "user-one" },
+            db: session.database,
+          } as ORPCContext,
+        });
+
+        session.instrumentation.reset();
+        const stream = await api.initial.getItemsByVisibility({
+          viewId: 1,
+          visibilityFilter: "unread",
+          cursor: {
+            postedAt: new Date(now.getTime() - 1_000),
+            id: "item-001",
+          },
+          limit: 2,
+        });
+        const iterator = stream[Symbol.asyncIterator]();
+        const first = await iterator.next();
+        await iterator.return?.(undefined);
+
+        if (first.value?.type === "error") {
+          throw new Error(first.value.message);
+        }
+        expect(first.value).toMatchObject({
+          type: "feed-items",
+          feedItems: [{ id: "item-002" }, { id: "item-003" }],
+          hasMore: true,
+        });
+        return session.instrumentation.snapshot();
+      } finally {
+        session.close();
+        target.cleanup();
+      }
+    }
+
+    const measurements = [];
+    for (const viewCount of [3, 10, 25]) {
+      // Each public procedure call uses the same injected database binding.
+      // oxlint-disable-next-line react-doctor/async-await-in-loop
+      measurements.push(await measureLaterPage(viewCount));
+    }
+
+    expect(
+      measurements.map(({ statementCount, materializedRows }) => ({
+        statementCount,
+        materializedRows,
+      })),
+    ).toEqual([
+      { statementCount: 6, materializedRows: 8 },
+      { statementCount: 6, materializedRows: 8 },
+      { statementCount: 6, materializedRows: 8 },
+    ]);
+  });
+
+  it("revalidates only the target View and Uncategorized scopes", async () => {
+    const target = createLocalBenchmarkTarget();
+    const session = openBenchmarkDatabase({ url: target.url });
+    try {
+      await applyMigrations(session.baseClient);
+      const now = new Date("2026-07-31T12:00:00.000Z");
+      await session.database.insert(user).values({
+        id: "user-one",
+        name: "User One",
+        email: "user-one@example.com",
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await session.database.insert(feeds).values(
+        Array.from({ length: 25 }, (_, index) => ({
+          id: index + 1,
+          userId: "user-one",
+          name: `Feed ${index + 1}`,
+          url: `https://example.com/${index + 1}.xml`,
+          platform: "website" as const,
+        })),
+      );
+      await session.database.insert(views).values(
+        Array.from({ length: 25 }, (_, index) => ({
+          id: index + 1,
+          userId: "user-one",
+          name: `View ${index + 1}`,
+          contentType: "longform" as const,
+          layout: "list" as const,
+          placement: index,
+        })),
+      );
+      await session.database.insert(viewFeeds).values(
+        Array.from({ length: 25 }, (_, index) => ({
+          viewId: index + 1,
+          feedId: index + 1,
+        })),
+      );
+      await session.database.insert(viewSections).values(
+        Array.from({ length: 25 }, (_, index) => ({
+          viewId: index + 1,
+          placement: 0,
+          itemType: "feed" as const,
+          itemId: index + 1,
+        })),
+      );
+      await session.database.insert(feedItems).values(
+        Array.from({ length: 5 }, (_, index) => ({
+          id: `revalidate-item-${index}`,
+          feedId: 1,
+          contentId: `revalidate-content-${index}`,
+          title: `Item ${index}`,
+          author: "Author",
+          url: `https://example.com/revalidate/${index}`,
+          orientation: "horizontal",
+          postedAt: new Date(now.getTime() - index * 1_000),
+          createdAt: now,
+          updatedAt: now,
+        })),
+      );
+
+      testState.database = session.database;
+      const api = createRouterClient(orpcRouter, {
+        context: {
+          headers: new Headers(),
+          session: { id: "session-one" },
+          user: { id: "user-one" },
+          db: session.database,
+        } as ORPCContext,
+      });
+
+      session.instrumentation.reset();
+      const stream = await api.initial.revalidateView({ viewId: 1 });
+      const chunks = [];
+      for await (const chunk of stream) chunks.push(chunk);
+
+      const targetChunk = chunks.find(
+        (chunk) => chunk.type === "feed-items" && chunk.viewId === 1,
+      );
+      expect(targetChunk?.type).toBe("feed-items");
+      if (targetChunk?.type === "feed-items") {
+        expect(targetChunk.feedItems).toHaveLength(5);
+      }
+      expect(session.instrumentation.snapshot()).toMatchObject({
+        statementCount: 7,
+        materializedRows: 9,
+      });
+    } finally {
+      session.close();
+      target.cleanup();
+    }
+  });
+
+  it("assembles public View results without rescanning association rows per View", async () => {
+    const now = new Date("2026-07-31T12:00:00.000Z");
+    const viewRows = Array.from({ length: 25 }, (_, index) => ({
+      id: index + 1,
+      userId: "user-one",
+      name: `View ${index + 1}`,
+      daysWindow: 0,
+      readStatus: 0,
+      orientation: "horizontal" as const,
+      contentType: "longform" as const,
+      layout: "list" as const,
+      placement: index,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    const categoryRows = Array.from({ length: 25 }, (_, index) => ({
+      id: index + 1,
+      userId: "user-one",
+      name: `Tag ${index + 1}`,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    let repeatedAssociationComparisons = 0;
+    function trackRepeatedFiltering<T>(rows: T[]) {
+      Object.defineProperty(rows, "filter", {
+        value: (predicate: (row: T, index: number, rows: T[]) => unknown) => {
+          repeatedAssociationComparisons += rows.length;
+          const filteredRows: T[] = [];
+          rows.forEach((row, index) => {
+            if (predicate(row, index, rows)) filteredRows.push(row);
+          });
+          return filteredRows;
+        },
+      });
+      return rows;
+    }
+    const rowsByTable = new Map<unknown, unknown[]>([
+      [views, viewRows],
+      [contentCategories, categoryRows],
+      [
+        viewCategories,
+        trackRepeatedFiltering(
+          viewRows.map((view) => ({
+            viewId: view.id,
+            categoryId: view.id,
+          })),
+        ),
+      ],
+      [
+        viewFeeds,
+        trackRepeatedFiltering(
+          viewRows.map((view) => ({ viewId: view.id, feedId: view.id })),
+        ),
+      ],
+      [
+        viewSections,
+        trackRepeatedFiltering(
+          viewRows.map((view) => ({
+            id: view.id,
+            viewId: view.id,
+            placement: 0,
+            itemType: "feed" as const,
+            itemId: view.id,
+            layout: null,
+            createdAt: now,
+            updatedAt: now,
+          })),
+        ),
+      ],
+    ]);
+    const fakeDatabase = {
+      select() {
+        let selectedRows: unknown[] = [];
+        const query = {
+          from(table: unknown) {
+            selectedRows = rowsByTable.get(table) ?? [];
+            return query;
+          },
+          where() {
+            return query;
+          },
+          orderBy() {
+            return Promise.resolve(selectedRows);
+          },
+          then<TFulfilled = unknown[], TRejected = never>(
+            onFulfilled?:
+              | ((value: unknown[]) => TFulfilled | PromiseLike<TFulfilled>)
+              | null,
+            onRejected?:
+              ((reason: unknown) => TRejected | PromiseLike<TRejected>) | null,
+          ) {
+            return Promise.resolve(selectedRows).then(onFulfilled, onRejected);
+          },
+        };
+        return query;
+      },
+    };
+
+    testState.database = fakeDatabase;
+    const api = createRouterClient(orpcRouter, {
+      context: {
+        headers: new Headers(),
+        session: { id: "session-one" },
+        user: { id: "user-one" },
+        db: fakeDatabase,
+      } as unknown as ORPCContext,
+    });
+    const result = await api.view.getAll();
+
+    expect(result).toHaveLength(26);
+    expect(repeatedAssociationComparisons).toBe(0);
+  });
+
+  it("rejects oversized Feed, Tag, and View mutation inputs", async () => {
+    testState.database = {
+      transaction() {
+        throw new Error("handler reached");
+      },
+    };
+    const api = createRouterClient(orpcRouter, {
+      context: {
+        headers: new Headers(),
+        session: { id: "session-one" },
+        user: { id: "user-one" },
+        db: testState.database,
+      } as ORPCContext,
+    });
+    const oversizedIds = Array.from({ length: 501 }, (_, index) => index + 1);
+    const operations = [
+      () => api.feed.bulkDelete({ feedIds: oversizedIds }),
+      () =>
+        api.feedCategories.bulkAssignToFeeds({
+          feedIds: oversizedIds,
+          categoryId: 1,
+        }),
+      () =>
+        api.viewFeeds.bulkAssignToView({ feedIds: oversizedIds, viewId: 1 }),
+      () =>
+        api.view.updatePlacement({
+          views: oversizedIds.map((id) => ({ id, placement: id })),
+        }),
+    ];
+
+    for (const operation of operations) {
+      let rejection: unknown;
+      try {
+        // oxlint-disable-next-line react-doctor/async-await-in-loop
+        await operation();
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).toBeDefined();
+      expect(String(rejection)).not.toContain("handler reached");
+    }
+  });
+
+  it("deduplicates maximum-size organization mutations into bounded set-based statements", async () => {
+    const target = createLocalBenchmarkTarget();
+    const session = openBenchmarkDatabase({ url: target.url });
+    try {
+      await applyMigrations(session.baseClient);
+      const now = new Date("2026-07-31T12:00:00.000Z");
+      await session.database.insert(user).values({
+        id: "user-one",
+        name: "User One",
+        email: "user-one@example.com",
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const maximumUniqueIds = Array.from(
+        { length: 500 },
+        (_, index) => index + 1,
+      );
+      await session.database.insert(feeds).values(
+        maximumUniqueIds.map((id) => ({
+          id,
+          userId: "user-one",
+          name: `Feed ${id}`,
+          url: `https://example.com/${id}.xml`,
+          platform: "website" as const,
+        })),
+      );
+      await session.database.insert(contentCategories).values([
+        { id: 1, userId: "user-one", name: "Bulk" },
+        { id: 2, userId: "user-one", name: "State" },
+      ]);
+      await session.database.insert(feedCategories).values([
+        { feedId: 2, categoryId: 2 },
+        { feedId: 3, categoryId: 2 },
+      ]);
+      await session.database.insert(views).values(
+        maximumUniqueIds.map((id) => ({
+          id,
+          userId: "user-one",
+          name: `View ${id}`,
+          contentType: "longform" as const,
+          layout: "list" as const,
+          placement: id,
+        })),
+      );
+
+      testState.database = session.database;
+      const api = createRouterClient(orpcRouter, {
+        context: {
+          headers: new Headers(),
+          session: { id: "session-one" },
+          user: { id: "user-one" },
+          db: session.database,
+        } as ORPCContext,
+      });
+      const repeatedFeedIds = Array.from(
+        { length: 500 },
+        (_, index) => (index % 3) + 1,
+      );
+
+      session.instrumentation.reset();
+      await api.feedCategories.bulkAssignToFeeds({
+        feedIds: maximumUniqueIds,
+        categoryId: 1,
+      });
+      expect(session.instrumentation.snapshot()).toMatchObject({
+        statementCount: 2,
+        materializedRows: 500,
+      });
+
+      session.instrumentation.reset();
+      await api.contentCategories.update({
+        id: 2,
+        name: "Updated state",
+        feedCategorizations: repeatedFeedIds.map((feedId, index) => ({
+          feedId,
+          selected: index % 2 === 0,
+        })),
+      });
+      expect(session.instrumentation.snapshot()).toMatchObject({
+        statementCount: 4,
+        materializedRows: 4,
+      });
+
+      session.instrumentation.reset();
+      await api.view.updatePlacement({
+        views: repeatedFeedIds.map((id, placement) => ({ id, placement })),
+      });
+      expect(session.instrumentation.snapshot()).toMatchObject({
+        statementCount: 1,
+        materializedRows: 0,
+      });
+    } finally {
+      session.close();
+      target.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Retires exposed full-library legacy procedures, cursor-bounds the remaining Feed-item read, scopes View pagination and revalidation metadata to the requested View, indexes View association assembly, and bounds/deduplicates bulk Feed, Tag, and View writes with set-based statements. Adds deterministic public-procedure coverage for statement counts, materialized rows, 3/10/25-View scaling, maximum inputs, and deduplication. Validation: 171 unit tests; 33 self-hosted e2e tests; lint; typecheck; formatting; query-inventory check; production build; React Doctor.