### PR TITLE
Bound Feed refresh and ingestion resource use

### DIFF
--- a/apps/app/benchmarks/app-query-inventory.json
+++ b/apps/app/benchmarks/app-query-inventory.json
@@ -7,17 +7,17 @@
     "scripts/**/*.ts(x)"
   ],
   "exclusions": ["node_modules", "src/server/db/migrations"],
-  "accessCount": 410,
+  "accessCount": 415,
   "areas": {
     "Bookmark and capture": 21,
     "administration": 33,
     "application support": 42,
     "authentication": 17,
-    "background and maintenance tasks": 18,
+    "background and maintenance tasks": 20,
     "database infrastructure": 3,
     "request procedures": 155,
     "synchronization and projection": 10,
-    "test-only infrastructure": 111
+    "test-only infrastructure": 114
   },
   "entries": [
     {
@@ -275,22 +275,6 @@
       "line": 31,
       "method": "delete",
       "expression": "db.delete"
-    },
-    {
-      "file": "server/tasks/feeds/background-refresh.ts",
-      "area": "background and maintenance tasks",
-      "symbol": "eligibleUsers",
-      "line": 47,
-      "method": "select",
-      "expression": "db\n        .select"
-    },
-    {
-      "file": "server/tasks/feeds/background-refresh.ts",
-      "area": "background and maintenance tasks",
-      "symbol": "feedsToRefresh",
-      "line": 85,
-      "method": "select",
-      "expression": "db\n      .select"
     },
     {
       "file": "src/app/api.extension.bookmarks.ts",
@@ -2221,10 +2205,42 @@
       "expression": "database\n            .select"
     },
     {
+      "file": "src/server/rss/backgroundRefresh.ts",
+      "area": "background and maintenance tasks",
+      "symbol": "getDueUserPage",
+      "line": 105,
+      "method": "select",
+      "expression": "db\n    .select"
+    },
+    {
+      "file": "src/server/rss/backgroundRefresh.ts",
+      "area": "background and maintenance tasks",
+      "symbol": "result",
+      "line": 115,
+      "method": "select",
+      "expression": "db\n    .select"
+    },
+    {
+      "file": "src/server/rss/backgroundRefresh.ts",
+      "area": "background and maintenance tasks",
+      "symbol": "getDueFeedPage",
+      "line": 133,
+      "method": "select",
+      "expression": "db\n    .select"
+    },
+    {
+      "file": "src/server/rss/backgroundRefresh.ts",
+      "area": "background and maintenance tasks",
+      "symbol": "getDueUserPage",
+      "line": 91,
+      "method": "select",
+      "expression": "db\n      .select"
+    },
+    {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
       "symbol": "existingItems",
-      "line": 175,
+      "line": 186,
       "method": "select",
       "expression": "context.db\n      .select"
     },
@@ -2232,71 +2248,71 @@
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
       "symbol": "feedItemsList",
-      "line": 207,
+      "line": 218,
       "method": "insert",
       "expression": "context.db\n        .insert"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 273,
+      "symbol": "processFeed",
+      "line": 283,
       "method": "update",
       "expression": "context.db\n              .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 292,
+      "symbol": "processFeed",
+      "line": 302,
       "method": "update",
       "expression": "context.db\n              .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 316,
+      "symbol": "processFeed",
+      "line": 326,
       "method": "update",
       "expression": "context.db\n            .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 364,
+      "symbol": "processFeed",
+      "line": 374,
       "method": "update",
       "expression": "context.db\n            .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 387,
+      "symbol": "processFeed",
+      "line": 397,
       "method": "update",
       "expression": "context.db\n            .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 414,
+      "symbol": "processFeed",
+      "line": 424,
       "method": "update",
       "expression": "context.db\n            .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 443,
+      "symbol": "processFeed",
+      "line": 453,
       "method": "update",
       "expression": "context.db\n          .update"
     },
     {
       "file": "src/server/rss/fetchFeeds.ts",
       "area": "background and maintenance tasks",
-      "symbol": "feedPromises",
-      "line": 472,
+      "symbol": "processFeed",
+      "line": 482,
       "method": "update",
       "expression": "context.db\n            .update"
     },
@@ -2336,17 +2352,9 @@
       "file": "src/server/subscriptions/helpers.ts",
       "area": "application support",
       "symbol": "result",
-      "line": 123,
+      "line": 139,
       "method": "update",
       "expression": "db\n    .update"
-    },
-    {
-      "file": "src/server/subscriptions/helpers.ts",
-      "area": "application support",
-      "symbol": "userRow",
-      "line": 139,
-      "method": "select",
-      "expression": "db\n    .select"
     },
     {
       "file": "src/server/subscriptions/helpers.ts",
@@ -2359,8 +2367,16 @@
     {
       "file": "src/server/subscriptions/helpers.ts",
       "area": "application support",
+      "symbol": "userRow",
+      "line": 155,
+      "method": "select",
+      "expression": "db\n    .select"
+    },
+    {
+      "file": "src/server/subscriptions/helpers.ts",
+      "area": "application support",
       "symbol": "activeFeeds",
-      "line": 156,
+      "line": 172,
       "method": "select",
       "expression": "db\n    .select"
     },
@@ -2368,7 +2384,7 @@
       "file": "src/server/subscriptions/helpers.ts",
       "area": "application support",
       "symbol": "deactivateExcessFeeds",
-      "line": 169,
+      "line": 185,
       "method": "update",
       "expression": "db\n    .update"
     },
@@ -3299,6 +3315,30 @@
       "line": 36,
       "method": "transaction",
       "expression": "session.database.transaction"
+    },
+    {
+      "file": "tests/unit/rss/background-refresh.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 38,
+      "method": "insert",
+      "expression": "testDatabase.database.insert"
+    },
+    {
+      "file": "tests/unit/rss/background-refresh.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 54,
+      "method": "insert",
+      "expression": "testDatabase.database\n        .insert"
+    },
+    {
+      "file": "tests/unit/rss/background-refresh.test.ts",
+      "area": "test-only infrastructure",
+      "symbol": "<module>",
+      "line": 97,
+      "method": "insert",
+      "expression": "testDatabase.database.insert"
     }
   ]
 }

--- a/apps/app/server/tasks/feeds/background-refresh.ts
+++ b/apps/app/server/tasks/feeds/background-refresh.ts
@@ -1,19 +1,13 @@
 import { defineTask } from "nitro/task";
-import { and, eq, inArray, isNull, lte, or } from "drizzle-orm";
-import { db } from "../../../src/server/db";
-import { feeds, user } from "../../../src/server/db/schema";
-import { refreshUserFeeds } from "../../../src/server/rss/refreshUserFeeds";
 import { hasSubscribers, publisher } from "../../../src/server/api/publisher";
-import {
-  checkUserRefreshEligibility,
-  getUserPlanId,
-} from "../../../src/server/subscriptions/helpers";
-import { IS_BILLING_ENABLED } from "../../../src/server/subscriptions/polar";
+import { db } from "../../../src/server/db";
 import {
   captureException,
   logError,
   logMessage,
 } from "../../../src/server/logger";
+import { runBackgroundFeedRefresh } from "../../../src/server/rss/backgroundRefresh";
+import { IS_BILLING_ENABLED } from "../../../src/server/subscriptions/polar";
 import { env } from "../../../src/env";
 
 export default defineTask({
@@ -22,9 +16,7 @@ export default defineTask({
     description: "Background refresh of active feeds for paid users",
   },
   async run() {
-    const backgroundRefreshEnabled = env.BACKGROUND_REFRESH_ENABLED;
-
-    if (!backgroundRefreshEnabled) {
+    if (!env.BACKGROUND_REFRESH_ENABLED) {
       logMessage(
         "[background-refresh] Disabled via BACKGROUND_REFRESH_ENABLED",
       );
@@ -32,144 +24,23 @@ export default defineTask({
     }
 
     const now = new Date();
-
     logMessage("[background-refresh] Running at ", now.toLocaleString());
 
-    // Determine eligible users first (cheap query on user table), then only
-    // fetch feeds for those users. This avoids loading thousands of feeds
-    // before knowing which users are actually eligible.
-    let eligibleUserIds: string[] | null = null;
-
-    if (IS_BILLING_ENABLED) {
-      // With billing: users whose plan-based nextRefreshAt has elapsed
-      // (or was never set). Admin users naturally qualify because they
-      // get UNLIMITED_CONFIG with the shortest refresh interval.
-      const eligibleUsers = await db
-        .select({ id: user.id })
-        .from(user)
-        .where(or(lte(user.nextRefreshAt, now), isNull(user.nextRefreshAt)))
-        .all();
-
-      // Exclude free users — they don't have background refresh.
-      const userPlans = await Promise.all(
-        eligibleUsers.map(async (u) => ({
-          id: u.id,
-          planId: await getUserPlanId(u.id),
-        })),
-      );
-      eligibleUserIds = userPlans
-        .filter((u) => u.planId !== "free")
-        .map((u) => u.id);
-    }
-    // Without billing: eligibleUserIds stays null → all active feeds
-
-    // Early exit if user filtering yielded no eligible users.
-    if (eligibleUserIds !== null && eligibleUserIds.length === 0) {
-      logMessage("[background-refresh] No eligible users to refresh");
-      return { result: "no-eligible-users" };
-    }
-
-    // Fetch feeds belonging to eligible users that are due for refresh.
-    // Include feeds with null nextFetchAt (never-scheduled feeds) so they
-    // get picked up on first pass.
-    const fetchAtCondition = or(
-      lte(feeds.nextFetchAt, now),
-      isNull(feeds.nextFetchAt),
-    );
-
-    const userCondition =
-      eligibleUserIds !== null
-        ? inArray(feeds.userId, eligibleUserIds)
-        : undefined;
-
-    const feedsToRefresh = await db
-      .select()
-      .from(feeds)
-      .where(and(eq(feeds.isActive, true), fetchAtCondition, userCondition))
-      .all();
-
-    // Group feeds by userId for per-user processing
-    const feedsByUser = new Map<string, typeof feedsToRefresh>();
-    for (const feed of feedsToRefresh) {
-      const existing = feedsByUser.get(feed.userId);
-      if (existing) {
-        existing.push(feed);
-      } else {
-        feedsByUser.set(feed.userId, [feed]);
-      }
-    }
-
-    // Build the full set of user IDs to process. Every eligible user gets
-    // refresh-start / refresh-complete regardless of whether they have
-    // feeds due, so the client always sees the loading state + cooldown.
-    const userIdsToProcess =
-      eligibleUserIds !== null ? eligibleUserIds : [...feedsByUser.keys()];
-
-    if (userIdsToProcess.length === 0) {
-      logMessage("[background-refresh] No users to process");
-      return { result: "no-users" };
-    }
-
-    let refreshedCount = 0;
-    let totalRowsWritten = 0;
-    let skippedCount = 0;
-    let emptyCount = 0;
-    let errorCount = 0;
-
-    for (const userId of userIdsToProcess) {
-      try {
-        const channel = `user:${userId}`;
-
-        // Skip users with no connected client — no one to receive the
-        // chunks, and we avoid unnecessary RSS fetches + Redis publishes.
-        if (!hasSubscribers(channel)) {
-          continue;
-        }
-
-        const userFeeds = feedsByUser.get(userId);
-
-        // Set the user's next refresh cooldown and publish refresh-start
-        // immediately so the client enters loading state.
-        // Users are refreshed sequentially to bound database and RSS load.
-        // oxlint-disable-next-line react-doctor/async-await-in-loop
-        const eligibility = await checkUserRefreshEligibility(db, userId);
-        logMessage(
-          `[background-refresh] refresh-start for user ${userId} on "${channel}" — feeds: ${userFeeds?.length ?? 0}, nextRefreshAt: ${eligibility.nextRefreshAt.toISOString()}`,
-        );
-
+    const metrics = await runBackgroundFeedRefresh({
+      db,
+      now,
+      billingEnabled: IS_BILLING_ENABLED,
+      hasSubscribers,
+      publish: async (channel, chunk) => {
         await publisher.publish(channel, {
           source: "initial",
-          chunk: {
-            type: "refresh-start",
-            totalFeeds: userFeeds?.length ?? 0,
-            nextRefreshAt: eligibility.nextRefreshAt,
-          },
+          chunk,
         });
-
-        // Run the actual RSS fetch (if this user has feeds due).
-        if (userFeeds && userFeeds.length > 0) {
-          const stats = await refreshUserFeeds({
-            db,
-            feedsList: userFeeds,
-            channel,
-          });
-
-          refreshedCount += stats.refreshedCount;
-          skippedCount += stats.skippedCount;
-          emptyCount += stats.emptyCount;
-          errorCount += stats.errorCount;
-          totalRowsWritten += stats.totalRowsWritten;
-        }
-
-        // Always signal completion so the client exits loading state.
-        await publisher.publish(channel, {
-          source: "initial",
-          chunk: { type: "refresh-complete" },
-        });
-      } catch (e) {
+      },
+      onUserError: (error, userId) => {
         captureException(
-          e instanceof Error
-            ? e
+          error instanceof Error
+            ? error
             : new Error(
                 `[background-refresh] Failed to refresh feeds for user ${userId}`,
               ),
@@ -177,17 +48,17 @@ export default defineTask({
         );
         logError(
           `[background-refresh] Failed to refresh feeds for user ${userId}:`,
-          e,
+          error,
         );
-      }
-    }
+      },
+    });
 
     logMessage(
-      `[background-refresh] Finished at ${new Date().toLocaleString()} — refreshed ${refreshedCount}, skipped ${skippedCount} (304/cached), empty ${emptyCount}, errors ${errorCount}, wrote ${totalRowsWritten} rows total`,
+      `[background-refresh] Finished at ${new Date().toLocaleString()} — refreshed ${metrics.refreshedCount}, skipped ${metrics.skippedCount} (304/cached), empty ${metrics.emptyCount}, errors ${metrics.errorCount}, wrote ${metrics.totalRowsWritten} rows; claimed ${metrics.usersClaimed} users in ${metrics.userPages} pages and ${metrics.totalDueFeeds} Feeds in ${metrics.feedPages} pages (max user page ${metrics.maximumUserPageSize}, max Feed page ${metrics.maximumFeedPageSize}, plan workers ${metrics.planConcurrency})`,
     );
 
     return {
-      result: `refreshed ${refreshedCount}, skipped ${skippedCount}, empty ${emptyCount}, errors ${errorCount}, wrote ${totalRowsWritten} rows`,
+      result: `refreshed ${metrics.refreshedCount}, skipped ${metrics.skippedCount}, empty ${metrics.emptyCount}, errors ${metrics.errorCount}, wrote ${metrics.totalRowsWritten} rows; users ${metrics.usersClaimed}/${metrics.userPages} pages, feeds ${metrics.totalDueFeeds}/${metrics.feedPages} pages`,
     };
   },
 });

--- a/apps/app/src/lib/semaphore.ts
+++ b/apps/app/src/lib/semaphore.ts
@@ -46,8 +46,8 @@ export class Semaphore {
  * Check if the database URL points to Turso's hosted service.
  * Turso hosted URLs contain ".turso.io"
  */
-function isTursoHosted(): boolean {
-  return env.DATABASE_URL.includes(".turso.io");
+export function getDatabaseConcurrencyLimit(databaseUrl: string): number {
+  return databaseUrl.includes(".turso.io") ? 10 : 5;
 }
 
 /**
@@ -55,7 +55,9 @@ function isTursoHosted(): boolean {
  *
  * - Local libsql-server: Limited to 5 concurrent connections to prevent
  *   "DbCreateTimeout" errors (the server has a small internal connection pool)
- * - Turso hosted: No practical limit - their infrastructure handles high concurrency
- *   and billing is based on rows read/written, not connections
+ * - Turso hosted: Limited to 10 concurrent operations so Feed and bulk work
+ *   cannot burst with input size.
  */
-export const dbSemaphore = new Semaphore(isTursoHosted() ? Infinity : 5);
+export const dbSemaphore = new Semaphore(
+  getDatabaseConcurrencyLimit(env.DATABASE_URL ?? ""),
+);

--- a/apps/app/src/server/rss/backgroundRefresh.ts
+++ b/apps/app/src/server/rss/backgroundRefresh.ts
@@ -1,0 +1,275 @@
+import { and, asc, count, eq, gt, isNull, lte, or } from "drizzle-orm";
+import { refreshUserFeeds } from "./refreshUserFeeds";
+import type { PlanId } from "~/server/subscriptions/plans";
+import type { DatabaseFeed } from "~/server/db/schema";
+import type { db as Database } from "~/server/db";
+import type { RefreshStats } from "./refreshUserFeeds";
+import {
+  checkUserRefreshEligibilityForPlan,
+  getUserPlanId,
+} from "~/server/subscriptions/helpers";
+import { feeds, user } from "~/server/db/schema";
+import { workerPool } from "~/lib/workerPool";
+
+export const BACKGROUND_USER_PAGE_SIZE = 25;
+export const BACKGROUND_FEED_PAGE_SIZE = 50;
+export const BACKGROUND_PLAN_CONCURRENCY = 4;
+
+type UserCandidate = {
+  id: string;
+  role: string | null;
+};
+
+type RefreshLifecycleChunk =
+  | { type: "refresh-start"; totalFeeds: number; nextRefreshAt: Date }
+  | { type: "refresh-complete" };
+
+type RefreshEligibility =
+  | { eligible: true; nextRefreshAt: Date }
+  | { eligible: false; nextRefreshAt: Date };
+
+type BackgroundRefreshDependencies = {
+  db: typeof Database;
+  now: Date;
+  billingEnabled: boolean;
+  hasSubscribers: (channel: string) => boolean;
+  claimUser?: (input: {
+    db: typeof Database;
+    userId: string;
+    planId: PlanId;
+    isAdmin: boolean;
+  }) => Promise<RefreshEligibility>;
+  getPlanId?: (userId: string) => Promise<PlanId>;
+  publish: (channel: string, chunk: RefreshLifecycleChunk) => Promise<void>;
+  refreshFeedPage?: (input: {
+    db: typeof Database;
+    feedsList: DatabaseFeed[];
+    channel: string;
+  }) => Promise<RefreshStats>;
+  onUserError?: (error: unknown, userId: string) => void;
+};
+
+export type BackgroundRefreshMetrics = RefreshStats & {
+  userPages: number;
+  feedPages: number;
+  usersClaimed: number;
+  totalDueFeeds: number;
+  maximumUserPageSize: number;
+  maximumFeedPageSize: number;
+  planConcurrency: number;
+};
+
+const EMPTY_STATS: RefreshStats = {
+  refreshedCount: 0,
+  skippedCount: 0,
+  emptyCount: 0,
+  errorCount: 0,
+  totalRowsWritten: 0,
+};
+
+function addRefreshStats(target: RefreshStats, source: RefreshStats) {
+  target.refreshedCount += source.refreshedCount;
+  target.skippedCount += source.skippedCount;
+  target.emptyCount += source.emptyCount;
+  target.errorCount += source.errorCount;
+  target.totalRowsWritten += source.totalRowsWritten;
+}
+
+async function getDueUserPage(
+  db: typeof Database,
+  input: {
+    afterUserId?: string;
+    billingEnabled: boolean;
+    now: Date;
+  },
+): Promise<UserCandidate[]> {
+  const afterCondition = input.afterUserId
+    ? gt(user.id, input.afterUserId)
+    : undefined;
+
+  if (input.billingEnabled) {
+    return db
+      .select({ id: user.id, role: user.role })
+      .from(user)
+      .where(
+        and(
+          or(lte(user.nextRefreshAt, input.now), isNull(user.nextRefreshAt)),
+          afterCondition,
+        ),
+      )
+      .orderBy(asc(user.id))
+      .limit(BACKGROUND_USER_PAGE_SIZE)
+      .all();
+  }
+
+  return db
+    .select({ id: user.id, role: user.role })
+    .from(user)
+    .where(afterCondition)
+    .orderBy(asc(user.id))
+    .limit(BACKGROUND_USER_PAGE_SIZE)
+    .all();
+}
+
+async function countDueFeeds(db: typeof Database, userId: string, now: Date) {
+  const result = await db
+    .select({ value: count() })
+    .from(feeds)
+    .where(
+      and(
+        eq(feeds.userId, userId),
+        eq(feeds.isActive, true),
+        or(lte(feeds.nextFetchAt, now), isNull(feeds.nextFetchAt)),
+      ),
+    )
+    .get();
+  return result?.value ?? 0;
+}
+
+async function getDueFeedPage(
+  db: typeof Database,
+  input: { userId: string; afterFeedId?: number; now: Date },
+) {
+  return db
+    .select()
+    .from(feeds)
+    .where(
+      and(
+        eq(feeds.userId, input.userId),
+        eq(feeds.isActive, true),
+        or(lte(feeds.nextFetchAt, input.now), isNull(feeds.nextFetchAt)),
+        input.afterFeedId ? gt(feeds.id, input.afterFeedId) : undefined,
+      ),
+    )
+    .orderBy(asc(feeds.id))
+    .limit(BACKGROUND_FEED_PAGE_SIZE)
+    .all();
+}
+
+export async function runBackgroundFeedRefresh(
+  dependencies: BackgroundRefreshDependencies,
+): Promise<BackgroundRefreshMetrics> {
+  const metrics: BackgroundRefreshMetrics = {
+    ...EMPTY_STATS,
+    userPages: 0,
+    feedPages: 0,
+    usersClaimed: 0,
+    totalDueFeeds: 0,
+    maximumUserPageSize: 0,
+    maximumFeedPageSize: 0,
+    planConcurrency: BACKGROUND_PLAN_CONCURRENCY,
+  };
+  const getPlanId = dependencies.getPlanId ?? getUserPlanId;
+  const claimUser =
+    dependencies.claimUser ??
+    ((input) =>
+      checkUserRefreshEligibilityForPlan(input.db, input.userId, input.planId, {
+        isAdmin: input.isAdmin,
+      }));
+  const refreshFeedPage = dependencies.refreshFeedPage ?? refreshUserFeeds;
+  let afterUserId: string | undefined;
+
+  while (true) {
+    const userPage = await getDueUserPage(dependencies.db, {
+      afterUserId,
+      billingEnabled: dependencies.billingEnabled,
+      now: dependencies.now,
+    });
+    if (userPage.length === 0) break;
+
+    metrics.userPages++;
+    metrics.maximumUserPageSize = Math.max(
+      metrics.maximumUserPageSize,
+      userPage.length,
+    );
+    afterUserId = userPage.at(-1)?.id;
+
+    const subscribedUsers = userPage.filter((candidate) =>
+      dependencies.hasSubscribers(`user:${candidate.id}`),
+    );
+    const planCandidates = dependencies.billingEnabled
+      ? workerPool(
+          subscribedUsers,
+          BACKGROUND_PLAN_CONCURRENCY,
+          async (candidate) => ({
+            candidate,
+            planId: await getPlanId(candidate.id),
+          }),
+        )
+      : workerPool(subscribedUsers, BACKGROUND_PLAN_CONCURRENCY, (candidate) =>
+          Promise.resolve({
+            candidate,
+            planId: "pro" as const,
+          }),
+        );
+
+    for await (const { candidate, planId } of planCandidates) {
+      if (dependencies.billingEnabled && planId === "free") continue;
+
+      const channel = `user:${candidate.id}`;
+      let refreshStarted = false;
+      try {
+        const dueFeedCount = await countDueFeeds(
+          dependencies.db,
+          candidate.id,
+          dependencies.now,
+        );
+        if (!dependencies.billingEnabled && dueFeedCount === 0) continue;
+
+        const eligibility = await claimUser({
+          db: dependencies.db,
+          userId: candidate.id,
+          planId,
+          isAdmin: candidate.role === "admin",
+        });
+        if (!eligibility.eligible) continue;
+        metrics.usersClaimed++;
+
+        metrics.totalDueFeeds += dueFeedCount;
+        await dependencies.publish(channel, {
+          type: "refresh-start",
+          totalFeeds: dueFeedCount,
+          nextRefreshAt: eligibility.nextRefreshAt,
+        });
+        refreshStarted = true;
+
+        let afterFeedId: number | undefined;
+        while (true) {
+          const feedPage = await getDueFeedPage(dependencies.db, {
+            userId: candidate.id,
+            afterFeedId,
+            now: dependencies.now,
+          });
+          if (feedPage.length === 0) break;
+
+          metrics.feedPages++;
+          metrics.maximumFeedPageSize = Math.max(
+            metrics.maximumFeedPageSize,
+            feedPage.length,
+          );
+          afterFeedId = feedPage.at(-1)?.id;
+          const pageStats = await refreshFeedPage({
+            db: dependencies.db,
+            feedsList: feedPage,
+            channel,
+          });
+          addRefreshStats(metrics, pageStats);
+        }
+      } catch (error) {
+        metrics.errorCount++;
+        dependencies.onUserError?.(error, candidate.id);
+      } finally {
+        if (refreshStarted) {
+          try {
+            await dependencies.publish(channel, { type: "refresh-complete" });
+          } catch (error) {
+            metrics.errorCount++;
+            dependencies.onUserError?.(error, candidate.id);
+          }
+        }
+      }
+    }
+  }
+
+  return metrics;
+}

--- a/apps/app/src/server/rss/calculateNextFetch.ts
+++ b/apps/app/src/server/rss/calculateNextFetch.ts
@@ -78,7 +78,9 @@ export function calculateNextFetch(
 /**
  * Parse HTTP headers from a fetch Response and extract metadata relevant for caching.
  */
-export function parseHttpHeaders(response: Response): FeedFetchMetadata {
+export function parseHttpHeaders(
+  response: Pick<Response, "headers">,
+): FeedFetchMetadata {
   const metadata: FeedFetchMetadata = {};
 
   // ETag header

--- a/apps/app/src/server/rss/feedBounds.ts
+++ b/apps/app/src/server/rss/feedBounds.ts
@@ -1,0 +1,22 @@
+import type { RSSContent } from "./types";
+
+export const MAX_PARSED_FEED_ITEMS = 200;
+export const MAX_ITEM_CONTENT_BYTES = 256 * 1024;
+export const MAX_ITEM_SNIPPET_BYTES = 32 * 1024;
+
+function truncateUtf8(value: string | undefined, maxBytes: number) {
+  if (!value) return value;
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= maxBytes) return value;
+
+  const truncated = new TextDecoder().decode(encoded.subarray(0, maxBytes));
+  return truncated.endsWith("\uFFFD") ? truncated.slice(0, -1) : truncated;
+}
+
+export function boundFeedItems(items: RSSContent[]): RSSContent[] {
+  return items.slice(0, MAX_PARSED_FEED_ITEMS).map((item) => ({
+    ...item,
+    content: truncateUtf8(item.content, MAX_ITEM_CONTENT_BYTES),
+    contentSnippet: truncateUtf8(item.contentSnippet, MAX_ITEM_SNIPPET_BYTES),
+  }));
+}

--- a/apps/app/src/server/rss/feedHttp.ts
+++ b/apps/app/src/server/rss/feedHttp.ts
@@ -1,0 +1,163 @@
+export type FeedHttpReadOptions = {
+  headers?: HeadersInit;
+  maxBodyBytes?: number;
+  maxHeaderBytes?: number;
+  maxRedirects?: number;
+  totalDurationMs?: number;
+};
+
+export type FeedHttpResponse = {
+  headers: Headers;
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text: string;
+  url: string;
+};
+
+const DEFAULT_MAX_BODY_BYTES = 2 * 1024 * 1024;
+const DEFAULT_MAX_HEADER_BYTES = 32 * 1024;
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_TOTAL_DURATION_MS = 15_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function assertHeadersWithinBudget(headers: Headers, maxHeaderBytes: number) {
+  let headerBytes = 0;
+  for (const [name, value] of headers) {
+    headerBytes += Buffer.byteLength(name) + Buffer.byteLength(value);
+    if (headerBytes > maxHeaderBytes) {
+      throw new Error(`Feed response headers exceed ${maxHeaderBytes} bytes`);
+    }
+  }
+}
+
+async function fetchWithRedirectBudget(
+  initialUrl: string,
+  options: FeedHttpReadOptions,
+  signal: AbortSignal,
+): Promise<Response> {
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const maxHeaderBytes = options.maxHeaderBytes ?? DEFAULT_MAX_HEADER_BYTES;
+  let requestUrl = initialUrl;
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const response = await fetch(requestUrl, {
+      headers: options.headers,
+      redirect: "manual",
+      signal,
+    });
+    try {
+      assertHeadersWithinBudget(response.headers, maxHeaderBytes);
+    } catch (error) {
+      await response.body?.cancel();
+      throw error;
+    }
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return response;
+    }
+
+    if (redirectCount >= maxRedirects) {
+      await response.body?.cancel();
+      const redirectLabel = maxRedirects === 1 ? "redirect" : "redirects";
+      throw new Error(`Feed request exceeded ${maxRedirects} ${redirectLabel}`);
+    }
+
+    const location = response.headers.get("location");
+    await response.body?.cancel();
+    if (!location) {
+      throw new Error("Feed redirect response is missing Location");
+    }
+
+    const redirectUrl = new URL(location, requestUrl);
+    if (redirectUrl.protocol !== "http:" && redirectUrl.protocol !== "https:") {
+      throw new Error("Feed redirect uses an unsupported protocol");
+    }
+    requestUrl = redirectUrl.toString();
+  }
+}
+
+export async function readFeedHttp(
+  url: string,
+  options: FeedHttpReadOptions = {},
+): Promise<FeedHttpResponse> {
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const totalDurationMs = options.totalDurationMs ?? DEFAULT_TOTAL_DURATION_MS;
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), totalDurationMs);
+
+  try {
+    const response = await fetchWithRedirectBudget(
+      url,
+      options,
+      abortController.signal,
+    );
+    const declaredBodyBytes = Number(response.headers.get("content-length"));
+    const responseMayHaveBody =
+      response.status !== 204 &&
+      response.status !== 205 &&
+      response.status !== 304;
+    if (
+      responseMayHaveBody &&
+      Number.isFinite(declaredBodyBytes) &&
+      declaredBodyBytes > maxBodyBytes
+    ) {
+      await response.body?.cancel();
+      throw new Error(
+        `Feed response Content-Length exceeds ${maxBodyBytes} bytes`,
+      );
+    }
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+      return {
+        headers: response.headers,
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        text: "",
+        url: response.url,
+      };
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBodyBytes) {
+        await reader.cancel();
+        throw new Error(`Feed response body exceeds ${maxBodyBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    return {
+      headers: response.headers,
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      text: new TextDecoder().decode(body),
+      url: response.url,
+    };
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw new Error(
+        `Feed request exceeded ${totalDurationMs}ms total duration`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/app/src/server/rss/fetchFeeds.ts
+++ b/apps/app/src/server/rss/fetchFeeds.ts
@@ -14,6 +14,8 @@ import {
   fetchYouTubeFeedDetails,
 } from "./parsers/youtube";
 import { computeItemHash } from "./hash";
+import { boundFeedItems } from "./feedBounds";
+import { readFeedHttp } from "./feedHttp";
 import type { ApplicationFeedItem, DatabaseFeed } from "../db/schema";
 import type { db as Database } from "../db";
 import type {
@@ -25,9 +27,13 @@ import type {
 } from "./types";
 import { env } from "~/env";
 import { dbSemaphore } from "~/lib/semaphore";
+import { workerPool } from "~/lib/workerPool";
 
 /** How long to back off a feed after a fetch error, to avoid cascading retries. */
 const ERROR_BACKOFF_MS = 60 * 60 * 1000; // 1 hour
+export const FEED_INGESTION_CONCURRENCY = 4;
+const MAX_DISCOVERED_FEED_URLS = 8;
+const MAX_CHANNEL_DISCOVERY_BYTES = 5 * 1024 * 1024;
 
 export type FetchFeedsStatus = "success" | "empty" | "error" | "skipped";
 
@@ -77,13 +83,15 @@ export async function fetchNewFeedDetails(
     isYouTubeHost &&
     (url.includes("youtube.com/@") || url.includes("youtube.com/channel/"))
   ) {
-    const feed = await fetch(url);
+    const feed = await readFeedHttp(url, {
+      maxBodyBytes: MAX_CHANNEL_DISCOVERY_BYTES,
+    });
     if (!feed.ok) {
       throw new Error(
         `Failed to fetch YouTube channel page: ${feed.status} ${feed.statusText}`,
       );
     }
-    const text = await feed.text();
+    const text = feed.text;
 
     const rssFeedUrlMatches = text.matchAll(
       /<link rel="alternate" type="application\/rss\+xml" title="RSS" href="(https:\/\/www\.youtube\.com\/feeds\/videos\.xml\?channel_id=[^&]{24})">/gm,
@@ -94,30 +102,33 @@ export async function fetchNewFeedDetails(
     );
   }
 
-  const feedDetailList = (
-    await Promise.all(
-      urls.map(async (feedUrl) => {
-        assertValidFeedUrl(feedUrl);
-        const feedHostname = new URL(feedUrl).hostname.toLowerCase();
-        const isYouTube =
-          feedHostname === "youtube.com" ||
-          feedHostname === "www.youtube.com" ||
-          feedHostname.endsWith(".youtube.com");
-        if (isYouTube) {
-          return fetchYouTubeFeedDetails(feedUrl);
-        }
-        if (
-          feedHostname === "nebula.tv" ||
-          feedHostname === "nebula.app" ||
-          feedHostname.endsWith(".nebula.tv") ||
-          feedHostname.endsWith(".nebula.app")
-        ) {
-          return fetchNebulaFeedDetails(feedUrl);
-        }
-        return fetchUnknownRssFeed(feedUrl);
-      }),
-    )
-  ).filter(Boolean);
+  const feedDetailList: NewFeedDetails[] = [];
+  for await (const feedDetails of workerPool(
+    urls.slice(0, MAX_DISCOVERED_FEED_URLS),
+    FEED_INGESTION_CONCURRENCY,
+    async (feedUrl) => {
+      assertValidFeedUrl(feedUrl);
+      const feedHostname = new URL(feedUrl).hostname.toLowerCase();
+      const isYouTube =
+        feedHostname === "youtube.com" ||
+        feedHostname === "www.youtube.com" ||
+        feedHostname.endsWith(".youtube.com");
+      if (isYouTube) {
+        return fetchYouTubeFeedDetails(feedUrl);
+      }
+      if (
+        feedHostname === "nebula.tv" ||
+        feedHostname === "nebula.app" ||
+        feedHostname.endsWith(".nebula.tv") ||
+        feedHostname.endsWith(".nebula.app")
+      ) {
+        return fetchNebulaFeedDetails(feedUrl);
+      }
+      return fetchUnknownRssFeed(feedUrl);
+    },
+  )) {
+    if (feedDetails) feedDetailList.push(feedDetails);
+  }
 
   // get feeds
   return feedDetailList;
@@ -243,10 +254,9 @@ export async function* fetchAndInsertFeedData(
   context: { db: typeof Database },
   databaseFeeds: DatabaseFeed[],
 ) {
-  const feedIds = databaseFeeds.map((feed) => feed.id);
   const now = new Date();
 
-  const feedPromises = databaseFeeds.map(async (feed): Promise<FeedResult> => {
+  const processFeed = async (feed: DatabaseFeed): Promise<FeedResult> => {
     try {
       // Check if we should skip this feed based on nextFetchAt
       if (feed.nextFetchAt && feed.nextFetchAt > now) {
@@ -328,7 +338,7 @@ export async function* fetchAndInsertFeedData(
         const applicationFeedItems = await insertFeedItems(
           context,
           feed.id,
-          cachedResult.data.items,
+          boundFeedItems(cachedResult.data.items),
           databaseFeeds,
         );
 
@@ -487,7 +497,7 @@ export async function* fetchAndInsertFeedData(
         error: e,
       };
     }
-  });
+  };
 
   let skippedCount = 0;
   let crossUserCacheCount = 0;
@@ -498,13 +508,11 @@ export async function* fetchAndInsertFeedData(
     databaseFeeds.map((feed) => [feed.id, feed.name]),
   );
 
-  while (feedPromises.length > 0) {
-    const result = await Promise.any(Array.from(feedPromises));
-
-    const resultIndex = feedIds.findIndex((id) => id === result.id);
-    void feedPromises.splice(resultIndex, 1);
-    feedIds.splice(resultIndex, 1);
-
+  for await (const result of workerPool(
+    databaseFeeds,
+    FEED_INGESTION_CONCURRENCY,
+    processFeed,
+  )) {
     if (result.status === "skipped") {
       skippedCount++;
     } else if (result.fromCache) {
@@ -526,7 +534,7 @@ export async function* fetchAndInsertFeedData(
       1,
     );
     logMessage(
-      `[Feed Fetch] ${skippedCount} skipped, ${crossUserCacheCount} cross-user cached (${cacheHitPercent}%), ${fetchedCount} fetched out of ${totalFeeds} feeds`,
+      `[Feed Fetch] ${skippedCount} skipped, ${crossUserCacheCount} cross-user cached (${cacheHitPercent}%), ${fetchedCount} fetched out of ${totalFeeds} feeds; workers=${Math.min(FEED_INGESTION_CONCURRENCY, totalFeeds)}, queued=${Math.max(0, totalFeeds - FEED_INGESTION_CONCURRENCY)}`,
     );
   }
 

--- a/apps/app/src/server/rss/parsers/nebula.ts
+++ b/apps/app/src/server/rss/parsers/nebula.ts
@@ -9,6 +9,8 @@ import {
   baseFeedSchema,
   extractRssMetadata,
 } from "../types";
+import { readFeedHttp } from "../feedHttp";
+import { boundFeedItems } from "../feedBounds";
 import type { DatabaseFeed } from "~/server/db/schema";
 import type {
   ConditionalHeaders,
@@ -74,14 +76,13 @@ export async function fetchNebulaFeedDetails(
 ): Promise<NewFeedDetails | null> {
   try {
     const rssUrl = convertNebulaUrlToRssUrl(url);
-    const response = await fetch(rssUrl);
+    const response = await readFeedHttp(rssUrl);
     if (!response.ok) {
       throw new Error(
         `Failed to fetch Nebula feed: ${response.status} ${response.statusText}`,
       );
     }
-    const text = await response.text();
-    const rssData = await parser.parseString(text);
+    const rssData = await parser.parseString(response.text);
 
     const { data: nebulaData, success } = nebulaSchema.safeParse(rssData);
 
@@ -105,7 +106,7 @@ export async function fetchNebulaFeedData(
   cached?: ConditionalHeaders,
 ): Promise<FeedFetchResult | null> {
   try {
-    const feedResponse = await fetch(feed.url, {
+    const feedResponse = await readFeedHttp(feed.url, {
       headers: cached ? buildConditionalHeaders(cached) : undefined,
     });
 
@@ -116,8 +117,12 @@ export async function fetchNebulaFeedData(
       };
     }
 
-    const text = await feedResponse.text();
-    const rssData = await parser.parseString(text);
+    if (!feedResponse.ok) {
+      throw new Error(
+        `Failed to fetch Nebula feed: ${feedResponse.status} ${feedResponse.statusText}`,
+      );
+    }
+    const rssData = await parser.parseString(feedResponse.text);
 
     const data = nebulaSchema.parse(rssData);
 
@@ -131,21 +136,23 @@ export async function fetchNebulaFeedData(
       id: feed.id,
       title: data.title,
       url: data.link,
-      items: data.items.map((item) => {
-        const idParts = item.guid.split("/");
-        const id = idParts[idParts.length - 1] || item.guid;
+      items: boundFeedItems(
+        data.items.map((item) => {
+          const idParts = item.guid.split("/");
+          const id = idParts[idParts.length - 1] || item.guid;
 
-        return {
-          id,
-          title: item.title,
-          publishedDate: item.isoDate,
-          url: item.link,
-          author: item["dc:creator"] ?? item.creator ?? data.title,
-          thumbnail: extractThumbnailFromContent(item.content),
-          content: item.contentSnippet,
-          contentSnippet: item.contentSnippet,
-        } satisfies RSSContent;
-      }),
+          return {
+            id,
+            title: item.title,
+            publishedDate: item.isoDate,
+            url: item.link,
+            author: item["dc:creator"] ?? item.creator ?? data.title,
+            thumbnail: extractThumbnailFromContent(item.content),
+            content: item.contentSnippet,
+            contentSnippet: item.contentSnippet,
+          } satisfies RSSContent;
+        }),
+      ),
       fetchMetadata,
     };
   } catch (e) {

--- a/apps/app/src/server/rss/parsers/peertube.ts
+++ b/apps/app/src/server/rss/parsers/peertube.ts
@@ -9,6 +9,8 @@ import {
   baseFeedSchema,
   extractRssMetadata,
 } from "../types";
+import { readFeedHttp } from "../feedHttp";
+import { boundFeedItems } from "../feedBounds";
 import type { DatabaseFeed } from "~/server/db/schema";
 import type {
   ConditionalHeaders,
@@ -89,7 +91,7 @@ export async function fetchPeerTubeFeedData(
   cached?: ConditionalHeaders,
 ): Promise<FeedFetchResult | null> {
   try {
-    const feedResponse = await fetch(feed.url, {
+    const feedResponse = await readFeedHttp(feed.url, {
       headers: cached ? buildConditionalHeaders(cached) : undefined,
     });
 
@@ -100,8 +102,12 @@ export async function fetchPeerTubeFeedData(
       };
     }
 
-    const text = await feedResponse.text();
-    const rssData = await parser.parseString(text);
+    if (!feedResponse.ok) {
+      throw new Error(
+        `Failed to fetch PeerTube feed: ${feedResponse.status} ${feedResponse.statusText}`,
+      );
+    }
+    const rssData = await parser.parseString(feedResponse.text);
 
     const data = peerTubeSchema.parse(rssData);
 
@@ -115,25 +121,27 @@ export async function fetchPeerTubeFeedData(
       id: feed.id,
       title: data.title,
       url: data.link,
-      items: data.items.flatMap((item) => {
-        const idParts = item.guid.split("/");
-        const id = idParts[idParts.length - 1];
+      items: boundFeedItems(
+        data.items.flatMap((item) => {
+          const idParts = item.guid.split("/");
+          const id = idParts[idParts.length - 1];
 
-        if (!id) return [];
+          if (!id) return [];
 
-        return [
-          {
-            id,
-            title: item.title,
-            publishedDate: item.isoDate,
-            url: item.link,
-            author: item.creator,
-            thumbnail: item["media:thumbnail"].$.url,
-            content: item["media:description"],
-            contentSnippet: item["media:description"],
-          } satisfies RSSContent,
-        ];
-      }),
+          return [
+            {
+              id,
+              title: item.title,
+              publishedDate: item.isoDate,
+              url: item.link,
+              author: item.creator,
+              thumbnail: item["media:thumbnail"].$.url,
+              content: item["media:description"],
+              contentSnippet: item["media:description"],
+            } satisfies RSSContent,
+          ];
+        }),
+      ),
       fetchMetadata,
     };
   } catch (e) {

--- a/apps/app/src/server/rss/parsers/unknown.ts
+++ b/apps/app/src/server/rss/parsers/unknown.ts
@@ -1,3 +1,4 @@
+import { readFeedHttp } from "../feedHttp";
 import { getPeerTubeFeedIfMatches } from "./peertube";
 import { getWebsiteFeedIfMatches } from "./website";
 import type { NewFeedDetails } from "../types";
@@ -7,13 +8,13 @@ export async function fetchUnknownRssFeed(
   url: string,
 ): Promise<NewFeedDetails | null> {
   try {
-    const feed = await fetch(url);
+    const feed = await readFeedHttp(url);
     if (!feed.ok) {
       throw new Error(
         `Failed to fetch RSS feed: ${feed.status} ${feed.statusText}`,
       );
     }
-    const text = await feed.text();
+    const text = feed.text;
 
     const peerTubeFeed = await getPeerTubeFeedIfMatches(text);
     if (peerTubeFeed) return peerTubeFeed;

--- a/apps/app/src/server/rss/parsers/website.ts
+++ b/apps/app/src/server/rss/parsers/website.ts
@@ -9,6 +9,8 @@ import {
   baseFeedSchema,
   extractRssMetadata,
 } from "../types";
+import { readFeedHttp } from "../feedHttp";
+import { boundFeedItems } from "../feedBounds";
 import type { DatabaseFeed } from "~/server/db/schema";
 import type {
   ConditionalHeaders,
@@ -18,6 +20,10 @@ import type {
   RSSContent,
 } from "../types";
 import { captureException, logError } from "~/server/logger";
+import { workerPool } from "~/lib/workerPool";
+
+const MAX_OG_IMAGE_FETCHES_PER_FEED = 8;
+const OG_IMAGE_FETCH_CONCURRENCY = 2;
 
 function getLongestString(...strings: Array<string | undefined>) {
   return strings.reduce((acc: string, cur) => {
@@ -111,11 +117,14 @@ function extractThumbnail(
 
 async function fetchOgImage(url: string): Promise<string | undefined> {
   try {
-    const response = await fetch(url);
+    const response = await readFeedHttp(url, {
+      maxBodyBytes: 256 * 1024,
+      totalDurationMs: 3_000,
+    });
 
     if (!response.ok) return undefined;
 
-    const html = await response.text();
+    const html = response.text;
 
     // Try og:image meta tag
     const ogImageMatch = html.match(
@@ -186,7 +195,7 @@ export async function fetchWebsiteFeedData(
   cached?: ConditionalHeaders,
 ): Promise<FeedFetchResult | null> {
   try {
-    const feedResponse = await fetch(feed.url, {
+    const feedResponse = await readFeedHttp(feed.url, {
       headers: cached ? buildConditionalHeaders(cached) : undefined,
     });
 
@@ -197,8 +206,12 @@ export async function fetchWebsiteFeedData(
       };
     }
 
-    const text = await feedResponse.text();
-    const rssData = await parser.parseString(text);
+    if (!feedResponse.ok) {
+      throw new Error(
+        `Failed to fetch website feed: ${feedResponse.status} ${feedResponse.statusText}`,
+      );
+    }
+    const rssData = await parser.parseString(feedResponse.text);
 
     const data = websiteSchema.parse(rssData);
 
@@ -208,39 +221,55 @@ export async function fetchWebsiteFeedData(
       ...extractRssMetadata(data),
     };
 
-    const itemPromises = data.items.map(async (item) => {
-      const id = item.guid || item.id;
+    const items = boundFeedItems(
+      data.items.flatMap((item) => {
+        const id = item.guid || item.id;
 
-      if (!id) return null;
+        if (!id) return [];
 
-      let thumbnail = extractThumbnail(item);
+        return [
+          {
+            id,
+            title: item.title,
+            publishedDate: item.pubDate || item.isoDate || item.updated || "",
+            url: item.link,
+            author: item.creator ?? "",
+            thumbnail: extractThumbnail(item),
+            content: getLongestString(
+              item["content:encoded"],
+              item.content,
+              item.description,
+            ),
+            contentSnippet: item.contentSnippet,
+          } satisfies RSSContent,
+        ];
+      }),
+    );
 
-      // Fetch og:image as last resort if no thumbnail found
-      if (!thumbnail) {
-        thumbnail = await fetchOgImage(item.link);
+    const metadataCandidates = items
+      .flatMap((item, position) =>
+        item.thumbnail ? [] : [{ itemIndex: position, item }],
+      )
+      .slice(0, MAX_OG_IMAGE_FETCHES_PER_FEED);
+
+    for await (const { itemIndex, thumbnail } of workerPool(
+      metadataCandidates,
+      OG_IMAGE_FETCH_CONCURRENCY,
+      async (candidate) => ({
+        itemIndex: candidate.itemIndex,
+        thumbnail: await fetchOgImage(candidate.item.url),
+      }),
+    )) {
+      if (thumbnail && items[itemIndex]) {
+        items[itemIndex].thumbnail = thumbnail;
       }
-
-      return {
-        id,
-        title: item.title,
-        publishedDate: item.pubDate || item.isoDate || item.updated || "",
-        url: item.link,
-        author: item.creator ?? "",
-        thumbnail,
-        content: getLongestString(
-          item["content:encoded"],
-          item.content,
-          item.description,
-        ),
-        contentSnippet: item.contentSnippet,
-      } satisfies RSSContent;
-    });
+    }
 
     return {
       id: feed.id,
       title: data.title,
       url: data.link ?? new URL(feed.url).origin,
-      items: (await Promise.all(itemPromises)).filter(Boolean),
+      items,
       fetchMetadata,
     };
   } catch (e) {

--- a/apps/app/src/server/rss/parsers/youtube.ts
+++ b/apps/app/src/server/rss/parsers/youtube.ts
@@ -9,6 +9,8 @@ import {
   baseFeedSchema,
   extractRssMetadata,
 } from "../types";
+import { readFeedHttp } from "../feedHttp";
+import { boundFeedItems } from "../feedBounds";
 import type { feeds } from "~/server/db/schema";
 import type {
   ConditionalHeaders,
@@ -55,7 +57,13 @@ const youtubeSchema = baseFeedSchema.extend({
 export async function fetchYouTubeFeedDetails(
   url: string,
 ): Promise<NewFeedDetails | null> {
-  const rssData = await parser.parseURL(url);
+  const response = await readFeedHttp(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch YouTube feed: ${response.status} ${response.statusText}`,
+    );
+  }
+  const rssData = await parser.parseString(response.text);
   const data = youtubeSchema.parse(rssData);
 
   return {
@@ -70,7 +78,7 @@ export async function fetchYouTubeFeedData(
   cached?: ConditionalHeaders,
 ): Promise<FeedFetchResult | null> {
   try {
-    const feedResponse = await fetch(feed.url, {
+    const feedResponse = await readFeedHttp(feed.url, {
       headers: cached ? buildConditionalHeaders(cached) : undefined,
     });
 
@@ -81,8 +89,12 @@ export async function fetchYouTubeFeedData(
       };
     }
 
-    const text = await feedResponse.text();
-    const rssData = await parser.parseString(text);
+    if (!feedResponse.ok) {
+      throw new Error(
+        `Failed to fetch YouTube feed: ${feedResponse.status} ${feedResponse.statusText}`,
+      );
+    }
+    const rssData = await parser.parseString(feedResponse.text);
     const data = youtubeSchema.parse(rssData);
 
     // Build fetch metadata from HTTP headers and RSS elements
@@ -95,21 +107,23 @@ export async function fetchYouTubeFeedData(
       id: feed.id,
       title: data.title,
       url: data.link,
-      items: data.items.map((item) => {
-        const thumbnail = item["media:group"]["media:thumbnail"][0]?.$.url;
-        const description = item["media:group"]["media:description"][0];
+      items: boundFeedItems(
+        data.items.map((item) => {
+          const thumbnail = item["media:group"]["media:thumbnail"][0]?.$.url;
+          const description = item["media:group"]["media:description"][0];
 
-        return {
-          id: item.id.replace("yt:video:", ""),
-          title: item.title,
-          publishedDate: item.isoDate,
-          url: item.link,
-          author: item.author,
-          thumbnail: thumbnail,
-          content: description,
-          contentSnippet: description,
-        } satisfies RSSContent;
-      }),
+          return {
+            id: item.id.replace("yt:video:", ""),
+            title: item.title,
+            publishedDate: item.isoDate,
+            url: item.link,
+            author: item.author,
+            thumbnail: thumbnail,
+            content: description,
+            contentSnippet: description,
+          } satisfies RSSContent;
+        }),
+      ),
       fetchMetadata,
     };
   } catch (e) {

--- a/apps/app/src/server/subscriptions/helpers.ts
+++ b/apps/app/src/server/subscriptions/helpers.ts
@@ -112,9 +112,25 @@ export async function checkUserRefreshEligibility(
     getUserPlanId(userId),
     isAdminUser(db, userId),
   ]);
-  const config = getEffectivePlanConfig(planId, { isAdmin });
+  return checkUserRefreshEligibilityForPlan(db, userId, planId, {
+    isAdmin,
+  });
+}
 
-  const now = new Date();
+export async function checkUserRefreshEligibilityForPlan(
+  db: DB,
+  userId: string,
+  planId: PlanId,
+  options: { isAdmin?: boolean; now?: Date } = {},
+): Promise<
+  | { eligible: true; nextRefreshAt: Date }
+  | { eligible: false; nextRefreshAt: Date }
+> {
+  const config = getEffectivePlanConfig(planId, {
+    isAdmin: options.isAdmin,
+  });
+
+  const now = options.now ?? new Date();
   const nowEpoch = Math.floor(now.getTime() / 1000);
   const nextRefreshAt = new Date(now.getTime() + config.refreshIntervalMs);
 

--- a/apps/app/tests/unit/rss/background-refresh.test.ts
+++ b/apps/app/tests/unit/rss/background-refresh.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBookmarkTestDatabase } from "../bookmarks/database";
+import type { RefreshStats } from "~/server/rss/refreshUserFeeds";
+import { runBackgroundFeedRefresh } from "~/server/rss/backgroundRefresh";
+import { feeds, user } from "~/server/db/schema";
+
+type TestDatabase = Awaited<ReturnType<typeof createBookmarkTestDatabase>>;
+
+let testDatabase: TestDatabase;
+
+beforeEach(async () => {
+  testDatabase = await createBookmarkTestDatabase();
+});
+
+afterEach(() => {
+  testDatabase.cleanup();
+});
+
+const EMPTY_REFRESH_STATS: RefreshStats = {
+  refreshedCount: 0,
+  skippedCount: 0,
+  emptyCount: 0,
+  errorCount: 0,
+  totalRowsWritten: 0,
+};
+
+describe("runBackgroundFeedRefresh", () => {
+  it("claims due users and Feeds in bounded cursor pages", async () => {
+    const now = new Date("2026-07-31T12:00:00.000Z");
+    const users = Array.from({ length: 27 }, (_, index) => ({
+      id: `user-${index.toString().padStart(2, "0")}`,
+      name: `User ${index}`,
+      email: `user-${index}@example.com`,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    await testDatabase.database.insert(user).values(users);
+
+    const dueFeeds = users.flatMap((candidate) =>
+      Array.from({ length: 51 }, (_, index) => ({
+        userId: candidate.id,
+        name: `Feed ${index}`,
+        url: `https://example.com/${candidate.id}/${index}.xml`,
+        imageUrl: "",
+        platform: "website",
+        openLocation: "serial",
+        createdAt: now,
+        updatedAt: now,
+        isActive: true,
+      })),
+    );
+    for (let index = 0; index < dueFeeds.length; index += 200) {
+      await testDatabase.database
+        .insert(feeds)
+        .values(dueFeeds.slice(index, index + 200));
+    }
+
+    const feedPageSizes: number[] = [];
+    const publishedChunkTypes: string[] = [];
+    const publish = vi.fn((_channel: string, chunk: { type: string }) => {
+      publishedChunkTypes.push(chunk.type);
+      return Promise.resolve();
+    });
+    const metrics = await runBackgroundFeedRefresh({
+      db: testDatabase.database,
+      now,
+      billingEnabled: false,
+      hasSubscribers: () => true,
+      claimUser: () =>
+        Promise.resolve({
+          eligible: true as const,
+          nextRefreshAt: new Date(now.getTime() + 60_000),
+        }),
+      publish,
+      refreshFeedPage: ({ feedsList }) => {
+        feedPageSizes.push(feedsList.length);
+        return Promise.resolve(EMPTY_REFRESH_STATS);
+      },
+    });
+
+    expect(metrics.userPages).toBe(2);
+    expect(metrics.feedPages).toBe(54);
+    expect(metrics.maximumUserPageSize).toBe(25);
+    expect(metrics.maximumFeedPageSize).toBe(50);
+    expect(feedPageSizes.every((size) => size <= 50)).toBe(true);
+    expect(
+      publishedChunkTypes.filter((type) => type === "refresh-start"),
+    ).toHaveLength(27);
+    expect(
+      publishedChunkTypes.filter((type) => type === "refresh-complete"),
+    ).toHaveLength(27);
+  });
+
+  it("bounds plan cache and provider resolution to four users", async () => {
+    const now = new Date("2026-07-31T12:00:00.000Z");
+    await testDatabase.database.insert(user).values(
+      Array.from({ length: 10 }, (_, index) => ({
+        id: `paid-${index.toString().padStart(2, "0")}`,
+        name: `Paid ${index}`,
+        email: `paid-${index}@example.com`,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })),
+    );
+
+    let activePlanRequests = 0;
+    let maximumActivePlanRequests = 0;
+    const metrics = await runBackgroundFeedRefresh({
+      db: testDatabase.database,
+      now,
+      billingEnabled: true,
+      hasSubscribers: () => true,
+      getPlanId: async () => {
+        activePlanRequests++;
+        maximumActivePlanRequests = Math.max(
+          maximumActivePlanRequests,
+          activePlanRequests,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        activePlanRequests--;
+        return "pro";
+      },
+      claimUser: () =>
+        Promise.resolve({
+          eligible: true as const,
+          nextRefreshAt: new Date(now.getTime() + 60_000),
+        }),
+      publish: () => Promise.resolve(),
+      refreshFeedPage: () => Promise.resolve(EMPTY_REFRESH_STATS),
+    });
+
+    expect(metrics.usersClaimed).toBe(10);
+    expect(maximumActivePlanRequests).toBeLessThanOrEqual(4);
+  });
+});

--- a/apps/app/tests/unit/rss/feed-http.test.ts
+++ b/apps/app/tests/unit/rss/feed-http.test.ts
@@ -1,0 +1,122 @@
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import { readFeedHttp } from "~/server/rss/feedHttp";
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    if (request.url === "/redirect-a") {
+      response.writeHead(302, { Location: "/redirect-b" });
+      response.end();
+      return;
+    }
+
+    if (request.url === "/redirect-b") {
+      response.writeHead(302, { Location: "/feed" });
+      response.end();
+      return;
+    }
+
+    if (request.url === "/feed") {
+      response.writeHead(200, { "Content-Type": "application/rss+xml" });
+      response.end("<rss />");
+      return;
+    }
+
+    if (request.url === "/slow") {
+      response.writeHead(200, { "Content-Type": "application/rss+xml" });
+      response.write("<rss>");
+      setTimeout(() => response.end("</rss>"), 100);
+      return;
+    }
+
+    if (request.url === "/large-headers") {
+      response.writeHead(200, {
+        "Content-Type": "application/rss+xml",
+        "X-Large": "x".repeat(80),
+      });
+      response.end("<rss />");
+      return;
+    }
+    if (request.url === "/not-modified") {
+      response.writeHead(304, { "Content-Length": "1024" });
+      response.end();
+      return;
+    }
+
+    if (request.url === "/declared-oversized") {
+      response.writeHead(200, {
+        "Content-Length": "65",
+        "Content-Type": "application/rss+xml",
+      });
+      response.end("x".repeat(65));
+      return;
+    }
+
+    if (request.url === "/oversized") {
+      response.writeHead(200, { "Content-Type": "application/rss+xml" });
+      response.end("x".repeat(65));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("readFeedHttp", () => {
+  it("rejects a chunked response once its body exceeds the byte budget", async () => {
+    await expect(
+      readFeedHttp(`${baseUrl}/oversized`, { maxBodyBytes: 64 }),
+    ).rejects.toThrow("Feed response body exceeds 64 bytes");
+  });
+
+  it("rejects an oversized declared response before reading its body", async () => {
+    await expect(
+      readFeedHttp(`${baseUrl}/declared-oversized`, { maxBodyBytes: 64 }),
+    ).rejects.toThrow("Feed response Content-Length exceeds 64 bytes");
+  });
+
+  it("rejects redirect chains beyond the configured budget", async () => {
+    await expect(
+      readFeedHttp(`${baseUrl}/redirect-a`, { maxRedirects: 1 }),
+    ).rejects.toThrow("Feed request exceeded 1 redirect");
+  });
+
+  it("aborts the whole redirect-and-body attempt at its duration budget", async () => {
+    await expect(
+      readFeedHttp(`${baseUrl}/slow`, { totalDurationMs: 20 }),
+    ).rejects.toThrow("Feed request exceeded 20ms total duration");
+  });
+
+  it("rejects response headers beyond the configured budget", async () => {
+    await expect(
+      readFeedHttp(`${baseUrl}/large-headers`, { maxHeaderBytes: 64 }),
+    ).rejects.toThrow("Feed response headers exceed 64 bytes");
+  });
+
+  it("preserves a bodyless 304 with a representation Content-Length", async () => {
+    const response = await readFeedHttp(`${baseUrl}/not-modified`, {
+      maxBodyBytes: 64,
+    });
+    expect(response.status).toBe(304);
+    expect(response.text).toBe("");
+  });
+});

--- a/apps/app/tests/unit/rss/fetch-and-insert.test.ts
+++ b/apps/app/tests/unit/rss/fetch-and-insert.test.ts
@@ -38,6 +38,8 @@ const LAST_MODIFIED_V2 = "Sun, 06 Apr 2026 18:00:00 GMT";
 let currentContent = FIRESHIP_OLD_XML;
 let currentEtag = ETAG_V1;
 let currentLastModified = LAST_MODIFIED_V1;
+let activeFeedRequests = 0;
+let maximumActiveFeedRequests = 0;
 
 let server: Server;
 let baseUrl: string;
@@ -56,6 +58,20 @@ function setServerContent(version: "v1" | "v2") {
 
 beforeAll(async () => {
   server = createServer((req, res) => {
+    if (req.url?.startsWith("/slow/")) {
+      activeFeedRequests++;
+      maximumActiveFeedRequests = Math.max(
+        maximumActiveFeedRequests,
+        activeFeedRequests,
+      );
+      setTimeout(() => {
+        res.writeHead(200, { "Content-Type": "application/atom+xml" });
+        res.end(currentContent);
+        activeFeedRequests--;
+      }, 20);
+      return;
+    }
+
     const ifNoneMatch = req.headers["if-none-match"];
     const ifModifiedSince = req.headers["if-modified-since"];
 
@@ -486,5 +502,30 @@ describe("fetchAndInsertFeedData content diffing", () => {
     // it's being upserted with the fresh content hash (not the stale one).
     expect(upserted[0]!.url).toBe(staleItemUrl);
     expect(upserted[0]!.contentHash).toBe(freshHash);
+  });
+});
+
+describe("fetchAndInsertFeedData resource bounds", () => {
+  it("keeps remote fetch, parse, and write work within four workers", async () => {
+    activeFeedRequests = 0;
+    maximumActiveFeedRequests = 0;
+    const { db } = createMockDb();
+    const feeds = Array.from({ length: 10 }, (_, index) =>
+      makeFeed({
+        id: index + 1,
+        url: `${baseUrl}/slow/${index + 1}`,
+      }),
+    );
+
+    const results = [];
+    for await (const result of fetchAndInsertFeedData(
+      { db: db as any },
+      feeds,
+    )) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(10);
+    expect(maximumActiveFeedRequests).toBeLessThanOrEqual(4);
   });
 });

--- a/apps/app/tests/unit/rss/website-bounds.test.ts
+++ b/apps/app/tests/unit/rss/website-bounds.test.ts
@@ -1,0 +1,131 @@
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import type { DatabaseFeed } from "~/server/db/schema";
+import { fetchWebsiteFeedData } from "~/server/rss/parsers/website";
+
+let server: Server;
+let baseUrl: string;
+
+let metadataRequestCount = 0;
+let activeMetadataRequests = 0;
+let maximumActiveMetadataRequests = 0;
+
+function buildFeed(
+  itemCount: number,
+  firstItemContent: string,
+  includeImages = true,
+) {
+  const items = Array.from({ length: itemCount }, (_, index) => {
+    const content = index === 0 ? firstItemContent : `content-${index}`;
+    const enclosure = includeImages
+      ? `<enclosure url="${baseUrl}/image/${index}.jpg" type="image/jpeg" />`
+      : "";
+    return `<item>
+      <guid>item-${index}</guid>
+      <title>Item ${index}</title>
+      <link>${baseUrl}/item/${index}</link>
+      <pubDate>Fri, 31 Jul 2026 12:00:00 GMT</pubDate>
+      <content:encoded><![CDATA[${content}]]></content:encoded>
+      ${enclosure}
+    </item>`;
+  }).join("");
+
+  return `<?xml version="1.0"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title>Bounded feed</title><link>${baseUrl}</link>${items}</channel></rss>`;
+}
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    if (request.url === "/feed") {
+      response.writeHead(200, { "Content-Type": "application/rss+xml" });
+      response.end(buildFeed(205, "x".repeat(300_000)));
+      return;
+    }
+    if (request.url === "/feed-no-images") {
+      response.writeHead(200, { "Content-Type": "application/rss+xml" });
+      response.end(buildFeed(20, "content", false));
+      return;
+    }
+    if (request.url?.startsWith("/item/")) {
+      metadataRequestCount++;
+      activeMetadataRequests++;
+      maximumActiveMetadataRequests = Math.max(
+        maximumActiveMetadataRequests,
+        activeMetadataRequests,
+      );
+      setTimeout(() => {
+        response.writeHead(200, { "Content-Type": "text/html" });
+        response.end(
+          `<meta property="og:image" content="${baseUrl}/fallback.jpg">`,
+        );
+        activeMetadataRequests--;
+      }, 10);
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function makeFeed(overrides: Partial<DatabaseFeed> = {}): DatabaseFeed {
+  return {
+    id: 1,
+    userId: "user-1",
+    name: "Bounded feed",
+    url: `${baseUrl}/feed`,
+    imageUrl: "",
+    platform: "website",
+    openLocation: "serial",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastFetchedAt: null,
+    nextFetchAt: null,
+    isActive: true,
+    etag: null,
+    lastModifiedHeader: null,
+    ...overrides,
+  };
+}
+
+describe("fetchWebsiteFeedData resource bounds", () => {
+  it("retains at most 200 items and 256 KiB of item content", async () => {
+    const result = await fetchWebsiteFeedData(makeFeed());
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("notModified");
+    if (!result || "notModified" in result) return;
+
+    expect(result.items).toHaveLength(200);
+    expect(result.items[0]?.content).toHaveLength(256 * 1024);
+  });
+
+  it("fetches fallback metadata for at most 8 items with concurrency 2", async () => {
+    metadataRequestCount = 0;
+    activeMetadataRequests = 0;
+    maximumActiveMetadataRequests = 0;
+
+    const result = await fetchWebsiteFeedData(
+      makeFeed({ url: `${baseUrl}/feed-no-images` }),
+    );
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("notModified");
+    if (!result || "notModified" in result) return;
+
+    expect(metadataRequestCount).toBe(8);
+    expect(maximumActiveMetadataRequests).toBeLessThanOrEqual(2);
+    expect(result.items.filter((item) => item.thumbnail)).toHaveLength(8);
+  });
+});

--- a/apps/app/tests/unit/semaphore.test.ts
+++ b/apps/app/tests/unit/semaphore.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getDatabaseConcurrencyLimit } from "~/lib/semaphore";
+
+describe("database concurrency policy", () => {
+  it("uses a finite ten-operation limit for hosted Turso", () => {
+    expect(
+      getDatabaseConcurrencyLimit("libsql://serial-example.turso.io"),
+    ).toBe(10);
+  });
+
+  it("keeps the tighter five-operation limit for local databases", () => {
+    expect(getDatabaseConcurrencyLimit("http://127.0.0.1:8082")).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- page background refresh work by user and feed, resolve plans through a bounded worker pool, and emit lifecycle/throughput metrics
- centralize Feed HTTP reads with body, header, redirect, and total-duration limits
- cap parsed item counts and text sizes, bound metadata/discovery/fetch concurrency, and cap hosted database concurrency
- add regression coverage for oversized and slow responses, bounded task pages, item limits, and worker pools

## Validation

- 32 unit test files / 177 tests
- TypeScript check
- ESLint (0 errors; existing warnings only)
- Prettier check
- query inventory check
- production Vite client + server build
- service worker generation (133 files)
- React Doctor changed scope: 100/100