### PR TITLE
Make Bookmark event projection change-aware

### DIFF
--- a/apps/app/benchmarks/CLIENT-AUDIT.md
+++ b/apps/app/benchmarks/CLIENT-AUDIT.md
@@ -3,11 +3,11 @@
 ## Result
 
 The pre-UI Bookmark foundation is not safe to extend yet. The audit found five
-release-blocking client/synchronization problems. The most serious is the same
-unbounded mixed projection observed by the server benchmark crossing the client
-boundary: representative browser synchronization exceeded libSQL's response
-limit, and list-neutral Bookmark events schedule authoritative work for every
-loaded mixed scope.
+release-blocking client/synchronization problems. CL-01's unbounded Bookmark
+event projection has since been remediated: entity-only events now patch one
+Bookmark without mixed projection work, while projection-relevant events target
+only changed scopes. The other four findings remain release blockers, including
+representative browser synchronization exceeding libSQL's response limit.
 
 The checked [coverage ledger](client-audit-coverage.json) records a finding or an
 explicit clean result for every applicable route, component, hook, state,
@@ -50,16 +50,17 @@ Retained evidence:
 
 ## Fixture results
 
-| Measurement                          |                   Small |          Representative |                   Stress |
-| ------------------------------------ | ----------------------: | ----------------------: | -----------------------: |
-| Feed items / Bookmarks / Views       |         1,000 / 100 / 3 |     10,000 / 1,000 / 10 |      50,000 / 5,000 / 25 |
-| Loaded mixed scopes                  |                      12 |                      33 |                       78 |
-| Persisted client payload             |                 0.58 MB |                 5.60 MB |                 28.31 MB |
-| One Bookmark progress event          |    0.59 ms / 12 refills |    1.06 ms / 33 refills |     3.83 ms / 78 refills |
-| 100 Bookmark events, one frame       |    41.7 ms / 12 refills |    99.8 ms / 33 refills |    312.1 ms / 78 refills |
-| 100 Bookmark events, separate frames | 33.8 ms / 1,200 refills | 86.8 ms / 3,300 refills | 302.5 ms / 7,800 refills |
-| Cold synchronization JS              |                 3.18 ms |                 45.2 ms |                 439.2 ms |
-| Whole-cache structured clone         |                 5.18 ms |                 28.9 ms |                 149.4 ms |
+| Measurement                          |               Small |      Representative |              Stress |
+| ------------------------------------ | ------------------: | ------------------: | ------------------: |
+| Feed items / Bookmarks / Views       |     1,000 / 100 / 3 | 10,000 / 1,000 / 10 | 50,000 / 5,000 / 25 |
+| Loaded mixed scopes                  |                  12 |                  33 |                  78 |
+| Persisted client payload             |             0.58 MB |             5.60 MB |            28.31 MB |
+| One Bookmark progress event          | 0.04 ms / 0 refills | 0.08 ms / 0 refills | 0.11 ms / 0 refills |
+| One Bookmark capture event           | 0.02 ms / 0 refills | 0.07 ms / 0 refills | 0.08 ms / 0 refills |
+| 100 Bookmark events, one frame       | 0.14 ms / 0 refills | 0.15 ms / 0 refills | 0.16 ms / 0 refills |
+| 100 Bookmark events, separate frames | 0.13 ms / 0 refills | 0.19 ms / 0 refills | 0.22 ms / 0 refills |
+| Cold synchronization JS              |             4.74 ms |             42.8 ms |            418.6 ms |
+| Whole-cache structured clone         |             9.85 ms |             30.9 ms |            149.1 ms |
 
 Heap deltas are diagnostic only because garbage collection may occur inside a
 sample; payload size, notification count, refill count, and synchronous duration
@@ -85,21 +86,17 @@ native Page-capture rendering as part of that later checkpoint's acceptance.
 
 ## Prioritized findings
 
-### CL-01 — Critical: list-neutral Bookmark events reproject and refill every scope
+### CL-01 — Resolved: Bookmark event projection is change-aware
 
-`processPublishedChunks` sends every Bookmark upsert—including progress-only and
-capture-only changes—through `reprojectUpsert`. That routine scans, filters, and
-sorts every loaded scope, and `useDataSubscription` then requests an authoritative
-first page for every affected scope. One stress event creates 78 server refills;
-100 events delivered across animation frames create 7,800. Even a same-frame
-burst still performs 100 complete local reprojections and produced a 311 ms main-
-thread stall.
-
-Remediation direction: classify Bookmark changes by projection-relevant fields;
-patch entity-only state without reprojection; index canonical membership and
-scope membership; return only genuinely changed scopes; coalesce and deduplicate
-authoritative validation with bounded concurrency; make list-neutral-event zero
-refill behavior a hard regression test.
+Bookmark upserts are classified against the cached entity before mixed-list work.
+Progress and Page-capture changes update the Bookmark cache with zero mixed-store
+notifications and zero authoritative refills. Visibility, ordering, View/Tag
+organization, canonical suppression, and deletion use inverse scope/canonical
+indexes and return only references that actually changed. At stress size, one
+progress or capture event completes below 0.2 ms in the retained diagnostic run;
+both 100-event burst shapes produce zero projection notifications and refills.
+Deterministic unit coverage locks canonical restoration, organization and
+visibility moves, optimistic rollback, and animation-frame batching semantics.
 
 ### CL-02 — Critical: synchronization and persisted state scale with the library
 

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedAt": "2026-07-31",
   "scope": "All client/shared routes, components, hooks, state, subscription, persistence, rendering, styles, and browser entry code under apps/app/src.",
-  "files": 310,
+  "files": 311,
   "findings": { "CL-01": 6, "CL-02": 4, "CL-03": 8, "CL-04": 6, "CL-05": 5 },
   "coverage": [
     {
@@ -1928,7 +1928,7 @@
     {
       "file": "src/lib/data/mixed-content/bookmarkProjection.ts",
       "classification": "state-sync-persistence",
-      "lines": 427,
+      "lines": 428,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."
@@ -1968,7 +1968,7 @@
     {
       "file": "src/lib/data/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 2029,
+      "lines": 1951,
       "status": "finding",
       "findings": ["CL-02", "CL-03", "CL-04"],
       "result": "Reviewed; contributes to CL-02, CL-03, CL-04."
@@ -2334,6 +2334,14 @@
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
     },
     {
+      "file": "src/lib/schemas/bulk.ts",
+      "classification": "client-shared",
+      "lines": 23,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
       "file": "src/lib/schemas/utils.ts",
       "classification": "client-shared",
       "lines": 15,
@@ -2352,7 +2360,7 @@
     {
       "file": "src/lib/semaphore.ts",
       "classification": "client-shared",
-      "lines": 62,
+      "lines": 64,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -1928,7 +1928,7 @@
     {
       "file": "src/lib/data/mixed-content/bookmarkProjection.ts",
       "classification": "state-sync-persistence",
-      "lines": 428,
+      "lines": 429,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "generatedAt": "2026-07-31",
   "scope": "All client/shared routes, components, hooks, state, subscription, persistence, rendering, styles, and browser entry code under apps/app/src.",
-  "files": 309,
-  "findings": { "CL-01": 5, "CL-02": 4, "CL-03": 8, "CL-04": 6, "CL-05": 5 },
+  "files": 310,
+  "findings": { "CL-01": 6, "CL-02": 4, "CL-03": 8, "CL-04": 6, "CL-05": 5 },
   "coverage": [
     {
       "file": "src/app/__root.tsx",
@@ -1704,7 +1704,7 @@
     {
       "file": "src/lib/data/bookmarks/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 64,
+      "lines": 98,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
@@ -1926,9 +1926,17 @@
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
     },
     {
+      "file": "src/lib/data/mixed-content/bookmarkProjection.ts",
+      "classification": "state-sync-persistence",
+      "lines": 427,
+      "status": "finding",
+      "findings": ["CL-01"],
+      "result": "Reviewed; contributes to CL-01."
+    },
+    {
       "file": "src/lib/data/mixed-content/mutations.ts",
       "classification": "state-sync-persistence",
-      "lines": 81,
+      "lines": 86,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -1936,7 +1944,7 @@
     {
       "file": "src/lib/data/mixed-content/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 292,
+      "lines": 323,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
@@ -1976,7 +1984,7 @@
     {
       "file": "src/lib/data/subscriptionCoordinator.ts",
       "classification": "state-sync-persistence",
-      "lines": 65,
+      "lines": 73,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."

--- a/apps/app/benchmarks/results/client-representative.json
+++ b/apps/app/benchmarks/results/client-representative.json
@@ -10,77 +10,85 @@
   "persistedPayloadBytes": {
     "application": 4974404,
     "bookmarks": 525422,
-    "mixedContent": 101376,
-    "total": 5601202
+    "mixedContent": 101328,
+    "total": 5601154
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 1.5205839999999853,
-      "heapDeltaBytes": 1033184,
+      "durationMs": 0.7068749999999682,
+      "heapDeltaBytes": 190040,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 33
+      "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 1.0634169999999585,
-      "heapDeltaBytes": 959192,
+      "durationMs": 0.08458300000006602,
+      "heapDeltaBytes": 4392,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 1,
-      "authoritativeRefills": 33
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "bookmarkCaptureEvent": {
+      "durationMs": 0.06704199999990124,
+      "heapDeltaBytes": 8696,
+      "bookmarkStoreNotifications": 1,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 1.1337500000000205,
-      "heapDeltaBytes": 910592,
+      "durationMs": 0.27625000000000455,
+      "heapDeltaBytes": 138648,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 33
+      "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 2.168624999999963,
-      "heapDeltaBytes": 1915952,
+      "durationMs": 0.20612500000004275,
+      "heapDeltaBytes": 60600,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 33
+      "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 2.1870839999999703,
-      "heapDeltaBytes": 1158688,
+      "durationMs": 2.42941600000006,
+      "heapDeltaBytes": 1180184,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 99.77208299999995,
-      "heapDeltaBytes": -9496416,
+      "durationMs": 0.15141700000003766,
+      "heapDeltaBytes": 164624,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 33
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 86.81987500000002,
-      "heapDeltaBytes": 14908408,
+      "durationMs": 0.18658400000003894,
+      "heapDeltaBytes": 237296,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 3300
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 45.199833999999896,
-      "heapDeltaBytes": -26493728,
+      "durationMs": 42.82662499999992,
+      "heapDeltaBytes": 25227040,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 990,
+      "feedItemStoreNotifications": 890,
       "mixedStoreNotifications": 33,
       "authoritativeRefills": 0
     },
     "persistenceStructuredClone": {
-      "durationMs": 28.924750000000017,
-      "heapDeltaBytes": 11461016,
+      "durationMs": 30.898542000000134,
+      "heapDeltaBytes": 11510360,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/benchmarks/results/client-small.json
+++ b/apps/app/benchmarks/results/client-small.json
@@ -10,77 +10,85 @@
   "persistedPayloadBytes": {
     "application": 487535,
     "bookmarks": 51697,
-    "mixedContent": 36819,
-    "total": 576051
+    "mixedContent": 36781,
+    "total": 576013
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 8.213124999999991,
-      "heapDeltaBytes": 742928,
+      "durationMs": 0.6110830000000078,
+      "heapDeltaBytes": 127312,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 12
+      "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 0.5942079999999805,
-      "heapDeltaBytes": 803760,
+      "durationMs": 0.04437500000005912,
+      "heapDeltaBytes": 4392,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 1,
-      "authoritativeRefills": 12
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "bookmarkCaptureEvent": {
+      "durationMs": 0.024540999999999258,
+      "heapDeltaBytes": 3608,
+      "bookmarkStoreNotifications": 1,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 0.3978749999999991,
-      "heapDeltaBytes": 357760,
+      "durationMs": 0.20124999999995907,
+      "heapDeltaBytes": 138368,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 12
+      "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 0.2352499999999509,
-      "heapDeltaBytes": 282720,
+      "durationMs": 0.1377909999999929,
+      "heapDeltaBytes": 60968,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 12
+      "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 0.0831670000000031,
-      "heapDeltaBytes": 18920,
+      "durationMs": 0.08454199999994216,
+      "heapDeltaBytes": 13208,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 41.667790999999966,
-      "heapDeltaBytes": -56356320,
+      "durationMs": 0.1429160000000138,
+      "heapDeltaBytes": 497672,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 12
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 33.803290999999945,
-      "heapDeltaBytes": 7861288,
+      "durationMs": 0.12995899999998528,
+      "heapDeltaBytes": 222320,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 1200
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 3.181082999999944,
-      "heapDeltaBytes": -11202536,
+      "durationMs": 4.740042000000017,
+      "heapDeltaBytes": -11594368,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 360,
+      "feedItemStoreNotifications": 261,
       "mixedStoreNotifications": 12,
       "authoritativeRefills": 0
     },
     "persistenceStructuredClone": {
-      "durationMs": 5.184750000000008,
-      "heapDeltaBytes": 1165848,
+      "durationMs": 9.853166999999985,
+      "heapDeltaBytes": -79355536,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/benchmarks/results/client-stress.json
+++ b/apps/app/benchmarks/results/client-stress.json
@@ -10,77 +10,85 @@
   "persistedPayloadBytes": {
     "application": 25403859,
     "bookmarks": 2664299,
-    "mixedContent": 241091,
-    "total": 28309249
+    "mixedContent": 240894,
+    "total": 28309052
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 4.546667000000014,
-      "heapDeltaBytes": 2935696,
+      "durationMs": 0.7257919999999558,
+      "heapDeltaBytes": 138720,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 78
+      "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 3.8261250000000473,
-      "heapDeltaBytes": 2709520,
+      "durationMs": 0.10504100000002836,
+      "heapDeltaBytes": 4416,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 1,
-      "authoritativeRefills": 78
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "bookmarkCaptureEvent": {
+      "durationMs": 0.07883299999991777,
+      "heapDeltaBytes": 3688,
+      "bookmarkStoreNotifications": 1,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 3.809374999999932,
-      "heapDeltaBytes": 2705712,
+      "durationMs": 0.30749999999989086,
+      "heapDeltaBytes": 141224,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 78
+      "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 1.7328330000000278,
-      "heapDeltaBytes": 1425520,
+      "durationMs": 0.2617089999998825,
+      "heapDeltaBytes": 61136,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
-      "authoritativeRefills": 78
+      "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 13.422250000000076,
-      "heapDeltaBytes": 6253408,
+      "durationMs": 15.532167000000072,
+      "heapDeltaBytes": 6187736,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 312.14591700000005,
-      "heapDeltaBytes": 7327408,
+      "durationMs": 0.1591249999999036,
+      "heapDeltaBytes": 172704,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 78
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 302.5160840000001,
-      "heapDeltaBytes": 17731968,
+      "durationMs": 0.21783400000003894,
+      "heapDeltaBytes": 230272,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
-      "mixedStoreNotifications": 100,
-      "authoritativeRefills": 7800
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 439.2450839999999,
-      "heapDeltaBytes": 14182592,
+      "durationMs": 418.62691700000005,
+      "heapDeltaBytes": -7424664,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 2340,
+      "feedItemStoreNotifications": 2225,
       "mixedStoreNotifications": 78,
       "authoritativeRefills": 0
     },
     "persistenceStructuredClone": {
-      "durationMs": 149.3705419999999,
-      "heapDeltaBytes": 51175848,
+      "durationMs": 149.11070900000004,
+      "heapDeltaBytes": 48244488,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -46,6 +46,7 @@ export type ClientAuditResult = {
   operations: {
     bookmarkSave: ClientAuditOperation;
     bookmarkProgressEvent: ClientAuditOperation;
+    bookmarkCaptureEvent: ClientAuditOperation;
     bookmarkOrganizationChange: ClientAuditOperation;
     bookmarkDelete: ClientAuditOperation;
     feedProgressEvent: ClientAuditOperation;
@@ -126,8 +127,8 @@ function makeView(index: number): ApplicationView {
     createdAt: FIXTURE_TIME,
     updatedAt: FIXTURE_TIME,
     isDefault: false,
-    categoryIds: [],
-    feedIds: [],
+    categoryIds: index === -1 ? [] : [index],
+    feedIds: index === -1 ? [] : [index + 1],
     viewSections: [],
   };
 }
@@ -142,31 +143,34 @@ function feedReference(index: number): MixedContentReference {
 }
 
 function resetStores() {
-  bookmarksStore.setState({ bookmarksDict: {} });
-  mixedContentStore.setState({ scopes: {}, suppressedReferences: {} });
+  bookmarksStore.getState().reset();
+  mixedContentStore.getState().reset();
   feedItemsStore.getState().reset();
 }
 
 function seedClientFixture(profileName: BenchmarkProfileName) {
   resetStores();
   const profile = BENCHMARK_PROFILES[profileName];
-  const views = Array.from({ length: profile.views + 1 }, (_, index) =>
-    makeView(index),
-  );
+  const views = [
+    makeView(-1),
+    ...Array.from({ length: profile.views }, (_, index) => makeView(index)),
+  ];
   viewsStore.setState({
     views,
     viewsDict: Object.fromEntries(views.map((view) => [view.id, view])),
     fetchStatus: "success",
   });
 
-  const bookmarks = Array.from({ length: profile.bookmarks }, (_, index) =>
-    makeBookmark(index),
-  );
-  bookmarksStore.setState({
-    bookmarksDict: Object.fromEntries(
-      bookmarks.map((bookmark) => [bookmark.id, bookmark]),
-    ),
-  });
+  const bookmarks = Array.from({ length: profile.bookmarks }, (_, index) => ({
+    ...makeBookmark(index),
+    viewIds: [index % profile.views],
+    tagIds: [index % profile.views],
+  }));
+  bookmarksStore
+    .getState()
+    .replace(
+      Object.fromEntries(bookmarks.map((bookmark) => [bookmark.id, bookmark])),
+    );
 
   const feedItems = Array.from({ length: profile.feedItems }, (_, index) =>
     makeFeedItem(index),
@@ -188,17 +192,43 @@ function seedClientFixture(profileName: BenchmarkProfileName) {
       const references = Array.from({ length: PAGE_SIZE }, (_, index) =>
         feedReference((offset + index) % profile.feedItems),
       );
+      const scopedBookmark =
+        view.id === -1
+          ? undefined
+          : bookmarks.find(
+              (bookmark) =>
+                bookmark.viewIds.includes(view.id) &&
+                (bookmark.isSaved
+                  ? visibility === "later"
+                  : bookmark.isRead
+                    ? visibility === "read"
+                    : visibility === "unread"),
+            );
+      if (scopedBookmark) {
+        references[references.length - 1] = {
+          entityKind: "bookmark",
+          entityId: scopedBookmark.id,
+          sectionPlacement: null,
+          normalizedAt:
+            visibility === "later"
+              ? scopedBookmark.savedUpdatedAt
+              : visibility === "read"
+                ? scopedBookmark.readUpdatedAt
+                : scopedBookmark.createdAt,
+        };
+      }
       mixedContentStore.getState().applyPage({
         scope: { type: "view", viewId: view.id },
         visibility,
         page: {
           references,
-          bookmarks: [],
+          bookmarks: scopedBookmark ? [scopedBookmark] : [],
           feedItems: [],
           cursor: null,
           hasMore: true,
         },
         replacesScope: true,
+        feedItems: feedItemsDict,
       });
     }
   }
@@ -258,7 +288,7 @@ function measurePersistenceClone() {
         feedItemsOrder: feedItemsStore.getState().feedItemsOrder,
       },
       bookmarks: {
-        bookmarksDict: bookmarksStore.getState().bookmarksDict,
+        bookmarksDict: bookmarksStore.getState().snapshot(),
       },
       mixedContent: {
         scopes: mixedContentStore.getState().scopes,
@@ -275,7 +305,7 @@ function persistedPayloadBytes() {
     feedItemsOrder: feedItemsStore.getState().feedItemsOrder,
   }).byteLength;
   const bookmarks = serialize({
-    bookmarksDict: bookmarksStore.getState().bookmarksDict,
+    bookmarksDict: bookmarksStore.getState().snapshot(),
   }).byteLength;
   const mixedContent = serialize({
     scopes: mixedContentStore.getState().scopes,
@@ -300,6 +330,10 @@ export function runClientAuditProfile(
         bookmarkUpsertPayload({
           ...makeBookmark(profile.bookmarks + 1),
           id: "audit-bookmark-new",
+          isSaved: true,
+          isRead: false,
+          viewIds: [profile.views - 1],
+          tagIds: [profile.views - 1],
         }),
       ]).length,
   );
@@ -314,12 +348,27 @@ export function runClientAuditProfile(
   );
 
   fixture = seedClientFixture(profileName);
+  const captureBookmark = fixture.bookmarks[0]!;
+  const bookmarkCaptureEvent = measure(
+    () =>
+      processPublishedChunks([
+        bookmarkUpsertPayload({
+          ...captureBookmark,
+          title: "Updated capture title",
+          captureHash: "updated-capture-hash",
+          capturedAt: new Date(FIXTURE_TIME.getTime() + 1),
+          updatedAt: new Date(FIXTURE_TIME.getTime() + 1),
+        }),
+      ]).length,
+  );
+
+  fixture = seedClientFixture(profileName);
   const bookmarkOrganizationChange = measure(
     () =>
       processPublishedChunks([
         bookmarkUpsertPayload({
           ...fixture.bookmarks[0]!,
-          viewIds: [profile.views],
+          viewIds: [profile.views - 1],
           tagIds: [profile.views - 1],
           updatedAt: new Date(FIXTURE_TIME.getTime() + 1),
         }),
@@ -436,6 +485,7 @@ export function runClientAuditProfile(
     operations: {
       bookmarkSave,
       bookmarkProgressEvent,
+      bookmarkCaptureEvent,
       bookmarkOrganizationChange,
       bookmarkDelete,
       feedProgressEvent,

--- a/apps/app/scripts/performance/inventory-client-audit.ts
+++ b/apps/app/scripts/performance/inventory-client-audit.ts
@@ -18,6 +18,7 @@ const findingPaths: Record<string, string[]> = {
     "src/lib/data/subscriptionCoordinator.ts",
     "src/lib/data/bookmarks/manifest.ts",
     "src/lib/data/bookmarks/store.ts",
+    "src/lib/data/mixed-content/bookmarkProjection.ts",
     "src/lib/data/mixed-content/store.ts",
   ],
   "CL-02": [

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -9,45 +9,73 @@ import type {
   BookmarkManifestEntry,
 } from "~/server/mixed-content/sync";
 
-type BookmarkStore = {
+type PersistedBookmarkStore = {
   bookmarksDict: Record<string, ApplicationBookmark>;
+};
+
+type BookmarkStore = {
+  revision: number;
   reset: () => void;
+  replace: (bookmarks: Record<string, ApplicationBookmark>) => void;
+  getBookmark: (id: string) => ApplicationBookmark | undefined;
+  snapshot: () => Record<string, ApplicationBookmark>;
   upsert: (bookmark: ApplicationBookmark) => void;
   remove: (id: string) => void;
   applyDiff: (diff: BookmarkDiffEntry[]) => void;
   manifest: () => BookmarkManifestEntry[];
 };
 
+const bookmarkEntities: Record<string, ApplicationBookmark> = {};
+
+function isPersistedBookmarkStore(
+  value: unknown,
+): value is PersistedBookmarkStore {
+  return (
+    typeof value === "object" && value !== null && "bookmarksDict" in value
+  );
+}
+
+function replaceBookmarkEntities(
+  bookmarks: Record<string, ApplicationBookmark>,
+) {
+  for (const id of Object.keys(bookmarkEntities)) delete bookmarkEntities[id];
+  Object.assign(bookmarkEntities, bookmarks);
+}
+
 const vanillaBookmarkStore = createStore<BookmarkStore>()(
   persist(
     (set, get) => ({
-      bookmarksDict: {},
-      reset: () => set({ bookmarksDict: {} }),
-      upsert: (bookmark) =>
-        set({
-          bookmarksDict: {
-            ...get().bookmarksDict,
-            [bookmark.id]: bookmark,
-          },
-        }),
+      revision: 0,
+      reset: () => {
+        replaceBookmarkEntities({});
+        set({ revision: get().revision + 1 });
+      },
+      replace: (bookmarks) => {
+        replaceBookmarkEntities(bookmarks);
+        set({ revision: get().revision + 1 });
+      },
+      getBookmark: (id) => bookmarkEntities[id],
+      snapshot: () => bookmarkEntities,
+      upsert: (bookmark) => {
+        bookmarkEntities[bookmark.id] = bookmark;
+        set({ revision: get().revision + 1 });
+      },
       remove: (id) => {
-        const { [id]: _removed, ...bookmarksDict } = get().bookmarksDict;
-        void _removed;
-        set({ bookmarksDict });
+        delete bookmarkEntities[id];
+        set({ revision: get().revision + 1 });
       },
       applyDiff: (diff) => {
-        const bookmarksDict = { ...get().bookmarksDict };
         for (const entry of diff) {
           if (entry.status === "new" || entry.status === "updated") {
-            bookmarksDict[entry.bookmark.id] = entry.bookmark;
+            bookmarkEntities[entry.bookmark.id] = entry.bookmark;
           } else if (entry.status === "deleted") {
-            delete bookmarksDict[entry.id];
+            delete bookmarkEntities[entry.id];
           }
         }
-        set({ bookmarksDict });
+        set({ revision: get().revision + 1 });
       },
       manifest: () =>
-        Object.values(get().bookmarksDict).map((bookmark) => ({
+        Object.values(bookmarkEntities).map((bookmark) => ({
           id: bookmark.id,
           version: bookmarkManifestValue(bookmark),
         })),
@@ -55,7 +83,13 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
     {
       name: "serial-bookmarks-store",
       storage: createIDBStorage(),
-      partialize: (state) => ({ bookmarksDict: state.bookmarksDict }),
+      partialize: () => ({ bookmarksDict: bookmarkEntities }),
+      merge: (persistedState, currentState) => {
+        if (isPersistedBookmarkStore(persistedState)) {
+          replaceBookmarkEntities(persistedState.bookmarksDict);
+        }
+        return currentState;
+      },
     },
   ),
 );

--- a/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
+++ b/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
@@ -1,0 +1,427 @@
+import { INBOX_VIEW_ID } from "../views/constants";
+import type { VisibilityFilter } from "../atoms";
+import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
+import type {
+  ApplicationBookmark,
+  MixedContentCursor,
+  MixedContentReference,
+  MixedContentScope,
+} from "~/server/mixed-content/projection";
+
+export type LoadedMixedScope = {
+  scope: MixedContentScope;
+  visibility: VisibilityFilter;
+  references: MixedContentReference[];
+  cursor: MixedContentCursor;
+  hasMore: boolean;
+};
+
+export type ProjectionIndexes = {
+  bookmarkScopeKeys: Record<string, string[]>;
+  feedItemScopeKeys: Record<string, string[]>;
+  canonicalByFeedItemId: Record<string, string>;
+  feedItemIdsByCanonical: Record<string, string[]>;
+};
+
+export function getMixedScopeKey(
+  scope: MixedContentScope,
+  visibility: VisibilityFilter,
+) {
+  return scope.type === "view"
+    ? `view:${scope.viewId}:${visibility}`
+    : `tag:${scope.tagId}:${visibility}`;
+}
+
+function compareReferences(
+  left: MixedContentReference,
+  right: MixedContentReference,
+) {
+  const leftPlacement = left.sectionPlacement ?? 0;
+  const rightPlacement = right.sectionPlacement ?? 0;
+  if (leftPlacement !== rightPlacement) return leftPlacement - rightPlacement;
+  const timeDifference =
+    right.normalizedAt.getTime() - left.normalizedAt.getTime();
+  if (timeDifference !== 0) return timeDifference;
+  const kindDifference = left.entityKind.localeCompare(right.entityKind);
+  if (kindDifference !== 0) return kindDifference;
+  return right.entityId.localeCompare(left.entityId);
+}
+
+export function uniqueReferences(references: MixedContentReference[]) {
+  const byKey = new Map(
+    references.map((reference) => [
+      `${reference.entityKind}:${reference.entityId}`,
+      reference,
+    ]),
+  );
+  return [...byKey.values()].sort(compareReferences);
+}
+
+export function referencesEqual(
+  left: MixedContentReference[],
+  right: MixedContentReference[],
+) {
+  return (
+    left.length === right.length &&
+    left.every((reference, index) => {
+      const candidate = right[index];
+      return (
+        candidate !== undefined &&
+        reference.entityKind === candidate.entityKind &&
+        reference.entityId === candidate.entityId &&
+        reference.sectionPlacement === candidate.sectionPlacement &&
+        reference.normalizedAt.getTime() === candidate.normalizedAt.getTime()
+      );
+    })
+  );
+}
+
+export function referenceRecordsEqual(
+  left: Record<string, MixedContentReference[]>,
+  right: Record<string, MixedContentReference[]>,
+) {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        right[key] !== undefined && referencesEqual(left[key]!, right[key]),
+    )
+  );
+}
+
+export function emptyProjectionIndexes(): ProjectionIndexes {
+  return {
+    bookmarkScopeKeys: {},
+    feedItemScopeKeys: {},
+    canonicalByFeedItemId: {},
+    feedItemIdsByCanonical: {},
+  };
+}
+
+function addUniqueValue(
+  record: Record<string, string[]>,
+  key: string,
+  value: string,
+) {
+  const values = record[key] ?? [];
+  if (!values.includes(value)) record[key] = [...values, value];
+}
+
+function removeValue(
+  record: Record<string, string[]>,
+  key: string,
+  value: string,
+) {
+  const values = record[key];
+  if (!values) return;
+  const nextValues = values.filter((candidate) => candidate !== value);
+  if (nextValues.length === 0) delete record[key];
+  else record[key] = nextValues;
+}
+
+export function canonicalize(url: string) {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    if (parsed.protocol === "http:" && parsed.port === "80") parsed.port = "";
+    if (parsed.protocol === "https:" && parsed.port === "443") parsed.port = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function removeScopeFromIndexes(
+  indexes: ProjectionIndexes,
+  scopeKey: string,
+  references: MixedContentReference[],
+) {
+  for (const reference of references) {
+    if (reference.entityKind === "bookmark") {
+      removeValue(indexes.bookmarkScopeKeys, reference.entityId, scopeKey);
+      continue;
+    }
+
+    removeValue(indexes.feedItemScopeKeys, reference.entityId, scopeKey);
+    if (indexes.feedItemScopeKeys[reference.entityId] !== undefined) continue;
+    const canonicalUrl = indexes.canonicalByFeedItemId[reference.entityId];
+    delete indexes.canonicalByFeedItemId[reference.entityId];
+    if (canonicalUrl) {
+      removeValue(
+        indexes.feedItemIdsByCanonical,
+        canonicalUrl,
+        reference.entityId,
+      );
+    }
+  }
+}
+
+function addScopeToIndexes(
+  indexes: ProjectionIndexes,
+  scopeKey: string,
+  references: MixedContentReference[],
+  feedItems: Record<string, ApplicationFeedItem>,
+) {
+  for (const reference of references) {
+    if (reference.entityKind === "bookmark") {
+      addUniqueValue(indexes.bookmarkScopeKeys, reference.entityId, scopeKey);
+      continue;
+    }
+
+    addUniqueValue(indexes.feedItemScopeKeys, reference.entityId, scopeKey);
+    const item = feedItems[reference.entityId];
+    if (!item?.url) continue;
+    const canonicalUrl = canonicalize(item.url);
+    const previousCanonical = indexes.canonicalByFeedItemId[reference.entityId];
+    if (previousCanonical && previousCanonical !== canonicalUrl) {
+      removeValue(
+        indexes.feedItemIdsByCanonical,
+        previousCanonical,
+        reference.entityId,
+      );
+    }
+    indexes.canonicalByFeedItemId[reference.entityId] = canonicalUrl;
+    addUniqueValue(
+      indexes.feedItemIdsByCanonical,
+      canonicalUrl,
+      reference.entityId,
+    );
+  }
+}
+
+export function replaceScopeInIndexes(input: {
+  indexes: ProjectionIndexes;
+  scopeKey: string;
+  previousReferences: MixedContentReference[];
+  nextReferences: MixedContentReference[];
+  feedItems: Record<string, ApplicationFeedItem>;
+}) {
+  const { indexes, scopeKey, previousReferences, nextReferences, feedItems } =
+    input;
+  removeScopeFromIndexes(indexes, scopeKey, previousReferences);
+  addScopeToIndexes(indexes, scopeKey, nextReferences, feedItems);
+}
+
+export function buildProjectionIndexes(
+  scopes: Record<string, LoadedMixedScope>,
+  feedItems: Record<string, ApplicationFeedItem>,
+) {
+  const indexes = emptyProjectionIndexes();
+  for (const [scopeKey, scope] of Object.entries(scopes)) {
+    addScopeToIndexes(indexes, scopeKey, scope.references, feedItems);
+  }
+  return indexes;
+}
+
+export function bookmarkVisibility(
+  bookmark: ApplicationBookmark,
+): VisibilityFilter {
+  if (bookmark.isSaved) return "later";
+  return bookmark.isRead ? "read" : "unread";
+}
+
+function sameIds(left: number[], right: number[]) {
+  if (left.length !== right.length) return false;
+  const rightIds = new Set(right);
+  return left.every((id) => rightIds.has(id));
+}
+
+export function isBookmarkProjectionChange(
+  previousBookmark: ApplicationBookmark | undefined,
+  bookmark: ApplicationBookmark,
+) {
+  if (!previousBookmark) return true;
+  if (
+    previousBookmark.canonicalUrl !== bookmark.canonicalUrl ||
+    previousBookmark.isSaved !== bookmark.isSaved ||
+    previousBookmark.isRead !== bookmark.isRead ||
+    previousBookmark.createdAt.getTime() !== bookmark.createdAt.getTime() ||
+    !sameIds(previousBookmark.viewIds, bookmark.viewIds) ||
+    !sameIds(previousBookmark.tagIds, bookmark.tagIds)
+  ) {
+    return true;
+  }
+
+  const visibility = bookmarkVisibility(bookmark);
+  if (visibility === "later") {
+    return (
+      previousBookmark.savedUpdatedAt.getTime() !==
+      bookmark.savedUpdatedAt.getTime()
+    );
+  }
+  if (visibility === "read") {
+    return (
+      previousBookmark.readUpdatedAt.getTime() !==
+      bookmark.readUpdatedAt.getTime()
+    );
+  }
+  return false;
+}
+
+function isBookmarkCompatibleWithView(view: ApplicationView) {
+  return view.contentType === "all" || view.contentType === "longform";
+}
+
+type ViewMembershipIndex = {
+  compatibleViewsById: Map<number, ApplicationView>;
+  viewIdsByTagId: Map<number, number[]>;
+  catchAllViewIds: number[];
+};
+
+let indexedViews: ApplicationView[] | undefined;
+let cachedViewMembershipIndex: ViewMembershipIndex | undefined;
+
+function getViewMembershipIndex(views: ApplicationView[]) {
+  if (views === indexedViews && cachedViewMembershipIndex) {
+    return cachedViewMembershipIndex;
+  }
+  const compatibleViews = views.filter(
+    (view) => view.id !== INBOX_VIEW_ID && isBookmarkCompatibleWithView(view),
+  );
+  const viewIdsByTagId = new Map<number, number[]>();
+  for (const view of compatibleViews) {
+    for (const tagId of view.categoryIds) {
+      viewIdsByTagId.set(tagId, [
+        ...(viewIdsByTagId.get(tagId) ?? []),
+        view.id,
+      ]);
+    }
+  }
+  indexedViews = views;
+  cachedViewMembershipIndex = {
+    compatibleViewsById: new Map(
+      compatibleViews.map((view) => [view.id, view]),
+    ),
+    viewIdsByTagId,
+    catchAllViewIds: compatibleViews
+      .filter(
+        (view) => view.feedIds.length === 0 && view.categoryIds.length === 0,
+      )
+      .map((view) => view.id),
+  };
+  return cachedViewMembershipIndex;
+}
+
+function matchingCustomViewIds(
+  bookmark: ApplicationBookmark,
+  views: ApplicationView[],
+) {
+  const index = getViewMembershipIndex(views);
+  const matchingIds = new Set(index.catchAllViewIds);
+  for (const viewId of bookmark.viewIds) {
+    if (index.compatibleViewsById.has(viewId)) matchingIds.add(viewId);
+  }
+  for (const tagId of bookmark.tagIds) {
+    for (const viewId of index.viewIdsByTagId.get(tagId) ?? []) {
+      matchingIds.add(viewId);
+    }
+  }
+  return { index, matchingIds };
+}
+
+function isInsideTimeWindow(date: Date, daysWindow: number) {
+  if (daysWindow <= 0) return true;
+  return date.getTime() >= Date.now() - daysWindow * 24 * 60 * 60 * 1_000;
+}
+
+export function matchingLoadedScopeKeys(
+  bookmark: ApplicationBookmark,
+  scopes: Record<string, LoadedMixedScope>,
+  views: ApplicationView[],
+) {
+  const visibility = bookmarkVisibility(bookmark);
+  const keys = new Set<string>();
+  for (const tagId of bookmark.tagIds) {
+    const key = getMixedScopeKey({ type: "tag", tagId }, visibility);
+    if (scopes[key]) keys.add(key);
+  }
+
+  const { index, matchingIds } = matchingCustomViewIds(bookmark, views);
+  for (const viewId of matchingIds) {
+    const view = index.compatibleViewsById.get(viewId);
+    if (!view) continue;
+    if (!isInsideTimeWindow(bookmark.createdAt, view.daysWindow)) continue;
+    const key = getMixedScopeKey({ type: "view", viewId: view.id }, visibility);
+    if (scopes[key]) keys.add(key);
+  }
+
+  if (matchingIds.size === 0) {
+    const inboxKey = getMixedScopeKey(
+      { type: "view", viewId: INBOX_VIEW_ID },
+      visibility,
+    );
+    if (scopes[inboxKey]) keys.add(inboxKey);
+  }
+  return keys;
+}
+
+export function matchesScope(
+  bookmark: ApplicationBookmark,
+  scope: MixedContentScope,
+  views: ApplicationView[],
+) {
+  if (scope.type === "tag") return bookmark.tagIds.includes(scope.tagId);
+  const { index, matchingIds } = matchingCustomViewIds(bookmark, views);
+  if (scope.viewId === INBOX_VIEW_ID) {
+    return matchingIds.size === 0;
+  }
+  const view = index.compatibleViewsById.get(scope.viewId);
+  return Boolean(
+    view &&
+    matchingIds.has(view.id) &&
+    isInsideTimeWindow(bookmark.createdAt, view.daysWindow),
+  );
+}
+
+export function bookmarkReference(
+  bookmark: ApplicationBookmark,
+  scopeState: LoadedMixedScope,
+  views: ApplicationView[],
+): MixedContentReference {
+  const scope = scopeState.scope;
+  const bookmarkTagIds = new Set(bookmark.tagIds);
+  const view =
+    scope.type === "view"
+      ? views.find((candidate) => candidate.id === scope.viewId)
+      : undefined;
+  const hasSections =
+    scopeState.visibility !== "read" && (view?.viewSections.length ?? 0) > 0;
+  const matchingPlacements =
+    view?.viewSections
+      .filter(
+        (section) =>
+          section.itemType === "tag" && bookmarkTagIds.has(section.itemId),
+      )
+      .map((section) => section.placement) ?? [];
+  const normalizedAt =
+    scopeState.visibility === "later"
+      ? bookmark.savedUpdatedAt
+      : scopeState.visibility === "read"
+        ? bookmark.readUpdatedAt
+        : bookmark.createdAt;
+  return {
+    entityKind: "bookmark",
+    entityId: bookmark.id,
+    sectionPlacement: hasSections
+      ? matchingPlacements.length > 0
+        ? Math.min(...matchingPlacements)
+        : 999_999
+      : null,
+    normalizedAt,
+  };
+}
+
+export function collisionScopeKeys(
+  canonicalUrl: string,
+  indexes: ProjectionIndexes,
+) {
+  const keys = new Set<string>();
+  for (const feedItemId of
+    indexes.feedItemIdsByCanonical[canonicalize(canonicalUrl)] ?? []) {
+    for (const key of indexes.feedItemScopeKeys[feedItemId] ?? [])
+      keys.add(key);
+  }
+  return keys;
+}

--- a/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
+++ b/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
@@ -418,8 +418,9 @@ export function collisionScopeKeys(
   indexes: ProjectionIndexes,
 ) {
   const keys = new Set<string>();
-  for (const feedItemId of
-    indexes.feedItemIdsByCanonical[canonicalize(canonicalUrl)] ?? []) {
+  for (const feedItemId of indexes.feedItemIdsByCanonical[
+    canonicalize(canonicalUrl)
+  ] ?? []) {
     for (const key of indexes.feedItemScopeKeys[feedItemId] ?? [])
       keys.add(key);
   }

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -30,7 +30,7 @@ export async function setMixedReadValue(input: {
 }) {
   const targets = partitionMixedReadTargets(input.references);
   const previousBookmarks = targets.bookmarkIds
-    .map((id) => bookmarksStore.getState().bookmarksDict[id])
+    .map((id) => bookmarksStore.getState().getBookmark(id))
     .filter((bookmark) => bookmark !== undefined);
   const now = new Date();
 
@@ -44,6 +44,7 @@ export async function setMixedReadValue(input: {
     bookmarksStore.getState().upsert(optimisticBookmark);
     mixedContentStore.getState().reprojectUpsert({
       bookmark: optimisticBookmark,
+      previousBookmark: bookmark,
       feedItems: feedItemsStore.getState().feedItemsDict,
       views: viewsStore.getState().views,
     });
@@ -66,9 +67,13 @@ export async function setMixedReadValue(input: {
     ]);
   } catch (error) {
     for (const bookmark of previousBookmarks) {
+      const optimisticBookmark = bookmarksStore
+        .getState()
+        .getBookmark(bookmark.id);
       bookmarksStore.getState().upsert(bookmark);
       mixedContentStore.getState().reprojectUpsert({
         bookmark,
+        previousBookmark: optimisticBookmark,
         feedItems: feedItemsStore.getState().feedItemsDict,
         views: viewsStore.getState().views,
       });

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -2,23 +2,34 @@ import { createStore } from "zustand";
 import { persist } from "zustand/middleware";
 import { createIDBStorage } from "../idb-storage";
 import { createSelectorHooks } from "../createSelectorHooks";
+import {
+  bookmarkReference,
+  bookmarkVisibility,
+  buildProjectionIndexes,
+  canonicalize,
+  collisionScopeKeys,
+  emptyProjectionIndexes,
+  getMixedScopeKey,
+  isBookmarkProjectionChange,
+  matchesScope,
+  matchingLoadedScopeKeys,
+  referenceRecordsEqual,
+  referencesEqual,
+  replaceScopeInIndexes,
+  uniqueReferences,
+} from "./bookmarkProjection";
+import type { LoadedMixedScope, ProjectionIndexes } from "./bookmarkProjection";
 import type { VisibilityFilter } from "../atoms";
 import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
 import type {
   ApplicationBookmark,
-  MixedContentCursor,
   MixedContentPage,
   MixedContentReference,
   MixedContentScope,
 } from "~/server/mixed-content/projection";
 
-export type LoadedMixedScope = {
-  scope: MixedContentScope;
-  visibility: VisibilityFilter;
-  references: MixedContentReference[];
-  cursor: MixedContentCursor;
-  hasMore: boolean;
-};
+export { getMixedScopeKey } from "./bookmarkProjection";
+export type { LoadedMixedScope } from "./bookmarkProjection";
 
 type SuppressedReferences = Record<
   string,
@@ -28,170 +39,136 @@ type SuppressedReferences = Record<
 type MixedContentStore = {
   scopes: Record<string, LoadedMixedScope>;
   suppressedReferences: SuppressedReferences;
+  projectionIndexes: ProjectionIndexes;
+  projectionIndexesComplete: boolean;
   reset: () => void;
   applyPage: (input: {
     scope: MixedContentScope;
     visibility: VisibilityFilter;
     page: MixedContentPage;
     replacesScope: boolean;
+    feedItems: Record<string, ApplicationFeedItem>;
   }) => void;
   reprojectUpsert: (input: {
     bookmark: ApplicationBookmark;
+    previousBookmark: ApplicationBookmark | undefined;
     feedItems: Record<string, ApplicationFeedItem>;
     views: ApplicationView[];
   }) => LoadedMixedScope[];
-  reprojectDeletion: (bookmarkId: string) => LoadedMixedScope[];
+  reprojectDeletion: (input: {
+    bookmarkId: string;
+    feedItems: Record<string, ApplicationFeedItem>;
+  }) => LoadedMixedScope[];
 };
-
-export function getMixedScopeKey(
-  scope: MixedContentScope,
-  visibility: VisibilityFilter,
-) {
-  return scope.type === "view"
-    ? `view:${scope.viewId}:${visibility}`
-    : `tag:${scope.tagId}:${visibility}`;
-}
-
-function compareReferences(
-  left: MixedContentReference,
-  right: MixedContentReference,
-) {
-  const leftPlacement = left.sectionPlacement ?? 0;
-  const rightPlacement = right.sectionPlacement ?? 0;
-  if (leftPlacement !== rightPlacement) return leftPlacement - rightPlacement;
-  const timeDifference =
-    right.normalizedAt.getTime() - left.normalizedAt.getTime();
-  if (timeDifference !== 0) return timeDifference;
-  const kindDifference = left.entityKind.localeCompare(right.entityKind);
-  if (kindDifference !== 0) return kindDifference;
-  return right.entityId.localeCompare(left.entityId);
-}
-
-function matchesVisibility(
-  bookmark: ApplicationBookmark,
-  visibility: VisibilityFilter,
-) {
-  if (visibility === "later") return bookmark.isSaved;
-  if (bookmark.isSaved) return false;
-  return visibility === "read" ? bookmark.isRead : !bookmark.isRead;
-}
-
-function matchesScope(
-  bookmark: ApplicationBookmark,
-  scope: MixedContentScope,
-  views: ApplicationView[],
-) {
-  const bookmarkTagIds = new Set(bookmark.tagIds);
-  const bookmarkViewIds = new Set(bookmark.viewIds);
-  if (scope.type === "tag") return bookmarkTagIds.has(scope.tagId);
-  const customViews = views.filter((view) => view.id >= 0);
-  if (scope.viewId < 0) {
-    return !customViews.some(
-      (view) =>
-        (view.contentType === "all" || view.contentType === "longform") &&
-        (bookmarkViewIds.has(view.id) ||
-          view.categoryIds.some((tagId) => bookmarkTagIds.has(tagId)) ||
-          (view.feedIds.length === 0 && view.categoryIds.length === 0)),
-    );
-  }
-  const view = customViews.find((candidate) => candidate.id === scope.viewId);
-  if (
-    !view ||
-    (view.contentType !== "all" && view.contentType !== "longform")
-  ) {
-    return false;
-  }
-  return (
-    bookmarkViewIds.has(view.id) ||
-    view.categoryIds.some((tagId) => bookmarkTagIds.has(tagId)) ||
-    (view.feedIds.length === 0 && view.categoryIds.length === 0)
-  );
-}
-
-function bookmarkReference(
-  bookmark: ApplicationBookmark,
-  scopeState: LoadedMixedScope,
-  views: ApplicationView[],
-): MixedContentReference {
-  const scope = scopeState.scope;
-  const bookmarkTagIds = new Set(bookmark.tagIds);
-  const view =
-    scope.type === "view"
-      ? views.find((candidate) => candidate.id === scope.viewId)
-      : undefined;
-  const hasSections =
-    scopeState.visibility !== "read" && (view?.viewSections.length ?? 0) > 0;
-  const matchingPlacements =
-    view?.viewSections
-      .filter(
-        (section) =>
-          section.itemType === "tag" && bookmarkTagIds.has(section.itemId),
-      )
-      .map((section) => section.placement) ?? [];
-  const normalizedAt =
-    scopeState.visibility === "later"
-      ? bookmark.savedUpdatedAt
-      : scopeState.visibility === "read"
-        ? bookmark.readUpdatedAt
-        : bookmark.createdAt;
-  return {
-    entityKind: "bookmark",
-    entityId: bookmark.id,
-    sectionPlacement: hasSections
-      ? matchingPlacements.length > 0
-        ? Math.min(...matchingPlacements)
-        : 999_999
-      : null,
-    normalizedAt,
-  };
-}
-
-function uniqueReferences(references: MixedContentReference[]) {
-  const byKey = new Map(
-    references.map((reference) => [
-      `${reference.entityKind}:${reference.entityId}`,
-      reference,
-    ]),
-  );
-  return [...byKey.values()].sort(compareReferences);
-}
 
 const vanillaMixedContentStore = createStore<MixedContentStore>()(
   persist(
     (set, get) => ({
       scopes: {},
       suppressedReferences: {},
-      reset: () => set({ scopes: {}, suppressedReferences: {} }),
-      applyPage: ({ scope, visibility, page, replacesScope }) => {
-        const key = getMixedScopeKey(scope, visibility);
-        const existing = get().scopes[key];
+      projectionIndexes: emptyProjectionIndexes(),
+      projectionIndexesComplete: true,
+      reset: () =>
         set({
-          scopes: {
-            ...get().scopes,
-            [key]: {
-              scope,
-              visibility,
-              references: uniqueReferences(
-                replacesScope
-                  ? page.references
-                  : [...(existing?.references ?? []), ...page.references],
-              ),
-              cursor: page.cursor,
-              hasMore: page.hasMore,
-            },
-          },
-        });
-      },
-      reprojectUpsert: ({ bookmark, feedItems, views }) => {
-        const scopes = { ...get().scopes };
-        const suppressedReferences = { ...get().suppressedReferences };
-        const bookmarkSuppressed = {
-          ...(suppressedReferences[bookmark.id] ?? {}),
+          scopes: {},
+          suppressedReferences: {},
+          projectionIndexes: emptyProjectionIndexes(),
+          projectionIndexesComplete: true,
+        }),
+      applyPage: ({ scope, visibility, page, replacesScope, feedItems }) => {
+        const key = getMixedScopeKey(scope, visibility);
+        const current = get();
+        const existing = current.scopes[key];
+        const nextScope = {
+          scope,
+          visibility,
+          references: uniqueReferences(
+            replacesScope
+              ? page.references
+              : [...(existing?.references ?? []), ...page.references],
+          ),
+          cursor: page.cursor,
+          hasMore: page.hasMore,
         };
-        const affected: LoadedMixedScope[] = [];
+        const scopes = { ...current.scopes, [key]: nextScope };
+        const projectionIndexes = current.projectionIndexesComplete
+          ? current.projectionIndexes
+          : buildProjectionIndexes(scopes, feedItems);
+        if (current.projectionIndexesComplete) {
+          replaceScopeInIndexes({
+            indexes: projectionIndexes,
+            scopeKey: key,
+            previousReferences: existing?.references ?? [],
+            nextReferences: nextScope.references,
+            feedItems,
+          });
+        }
+        set({ scopes, projectionIndexes, projectionIndexesComplete: true });
+      },
+      reprojectUpsert: ({ bookmark, previousBookmark, feedItems, views }) => {
+        if (!isBookmarkProjectionChange(previousBookmark, bookmark)) return [];
 
-        for (const [key, scopeState] of Object.entries(scopes)) {
-          const newlySuppressed = scopeState.references.filter((reference) => {
+        const current = get();
+        const projectionIndexes = current.projectionIndexesComplete
+          ? current.projectionIndexes
+          : buildProjectionIndexes(current.scopes, feedItems);
+        const candidateKeys = new Set(
+          projectionIndexes.bookmarkScopeKeys[bookmark.id] ?? [],
+        );
+        if (previousBookmark) {
+          for (const key of matchingLoadedScopeKeys(
+            previousBookmark,
+            current.scopes,
+            views,
+          )) {
+            candidateKeys.add(key);
+          }
+        }
+        for (const key of matchingLoadedScopeKeys(
+          bookmark,
+          current.scopes,
+          views,
+        )) {
+          candidateKeys.add(key);
+        }
+
+        const canonicalChanged =
+          previousBookmark?.canonicalUrl !== bookmark.canonicalUrl;
+        const previousSuppressed =
+          current.suppressedReferences[bookmark.id] ?? {};
+        const nextSuppressedForBookmark = canonicalChanged
+          ? {}
+          : { ...previousSuppressed };
+        if (canonicalChanged) {
+          for (const key of Object.keys(previousSuppressed)) {
+            candidateKeys.add(key);
+          }
+          for (const key of collisionScopeKeys(
+            bookmark.canonicalUrl,
+            projectionIndexes,
+          )) {
+            candidateKeys.add(key);
+          }
+        }
+
+        let scopes = current.scopes;
+        const affected: LoadedMixedScope[] = [];
+        for (const key of candidateKeys) {
+          const scopeState = current.scopes[key];
+          if (!scopeState) continue;
+          let references = scopeState.references.filter(
+            (reference) =>
+              reference.entityKind !== "bookmark" ||
+              reference.entityId !== bookmark.id,
+          );
+          if (canonicalChanged) {
+            references = uniqueReferences([
+              ...references,
+              ...(previousSuppressed[key] ?? []),
+            ]);
+          }
+
+          const newlySuppressed = references.filter((reference) => {
             if (reference.entityKind !== "feed-item") return false;
             const item = feedItems[reference.entityId];
             return item?.url
@@ -199,25 +176,21 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
               : false;
           });
           if (newlySuppressed.length > 0) {
-            bookmarkSuppressed[key] = uniqueReferences([
-              ...(bookmarkSuppressed[key] ?? []),
+            nextSuppressedForBookmark[key] = uniqueReferences([
+              ...(nextSuppressedForBookmark[key] ?? []),
               ...newlySuppressed,
             ]);
           }
-          const newlySuppressedKeys = new Set(
-            newlySuppressed.map(
-              (reference) => `${reference.entityKind}:${reference.entityId}`,
-            ),
+          const newlySuppressedIds = new Set(
+            newlySuppressed.map((reference) => reference.entityId),
           );
-          let references = scopeState.references.filter(
+          references = references.filter(
             (reference) =>
-              reference.entityId !== bookmark.id &&
-              !newlySuppressedKeys.has(
-                `${reference.entityKind}:${reference.entityId}`,
-              ),
+              reference.entityKind !== "feed-item" ||
+              !newlySuppressedIds.has(reference.entityId),
           );
           if (
-            matchesVisibility(bookmark, scopeState.visibility) &&
+            bookmarkVisibility(bookmark) === scopeState.visibility &&
             matchesScope(bookmark, scopeState.scope, views)
           ) {
             references = [
@@ -225,43 +198,101 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
               bookmarkReference(bookmark, scopeState, views),
             ];
           }
-          const nextScope = {
-            ...scopeState,
-            references: uniqueReferences(references),
-          };
+          references = uniqueReferences(references);
+          if (referencesEqual(scopeState.references, references)) continue;
+
+          const nextScope = { ...scopeState, references };
+          if (scopes === current.scopes) scopes = { ...current.scopes };
           scopes[key] = nextScope;
+          replaceScopeInIndexes({
+            indexes: projectionIndexes,
+            scopeKey: key,
+            previousReferences: scopeState.references,
+            nextReferences: references,
+            feedItems,
+          });
           affected.push(nextScope);
         }
-        suppressedReferences[bookmark.id] = bookmarkSuppressed;
-        set({ scopes, suppressedReferences });
+
+        const suppressedReferences = { ...current.suppressedReferences };
+        if (Object.keys(nextSuppressedForBookmark).length > 0) {
+          suppressedReferences[bookmark.id] = nextSuppressedForBookmark;
+        } else {
+          delete suppressedReferences[bookmark.id];
+        }
+        const suppressionChanged = !referenceRecordsEqual(
+          previousSuppressed,
+          nextSuppressedForBookmark,
+        );
+        if (
+          affected.length > 0 ||
+          suppressionChanged ||
+          !current.projectionIndexesComplete
+        ) {
+          set({
+            scopes,
+            suppressedReferences,
+            projectionIndexes,
+            projectionIndexesComplete: true,
+          });
+        }
         return affected;
       },
-      reprojectDeletion: (bookmarkId) => {
-        const scopes = { ...get().scopes };
+      reprojectDeletion: ({ bookmarkId, feedItems }) => {
+        const current = get();
+        const projectionIndexes = current.projectionIndexesComplete
+          ? current.projectionIndexes
+          : buildProjectionIndexes(current.scopes, feedItems);
+        const hadSuppressedReferences =
+          current.suppressedReferences[bookmarkId] !== undefined;
         const suppressedForBookmark =
-          get().suppressedReferences[bookmarkId] ?? {};
+          current.suppressedReferences[bookmarkId] ?? {};
+        const candidateKeys = new Set([
+          ...(projectionIndexes.bookmarkScopeKeys[bookmarkId] ?? []),
+          ...Object.keys(suppressedForBookmark),
+        ]);
+        let scopes = current.scopes;
         const affected: LoadedMixedScope[] = [];
-        for (const [key, scopeState] of Object.entries(scopes)) {
-          const nextScope = {
-            ...scopeState,
-            references: uniqueReferences([
-              ...scopeState.references.filter(
-                (reference) =>
-                  !(
-                    reference.entityKind === "bookmark" &&
-                    reference.entityId === bookmarkId
-                  ),
-              ),
-              ...(suppressedForBookmark[key] ?? []),
-            ]),
-          };
+        for (const key of candidateKeys) {
+          const scopeState = current.scopes[key];
+          if (!scopeState) continue;
+          const references = uniqueReferences([
+            ...scopeState.references.filter(
+              (reference) =>
+                reference.entityKind !== "bookmark" ||
+                reference.entityId !== bookmarkId,
+            ),
+            ...(suppressedForBookmark[key] ?? []),
+          ]);
+          if (referencesEqual(scopeState.references, references)) continue;
+
+          const nextScope = { ...scopeState, references };
+          if (scopes === current.scopes) scopes = { ...current.scopes };
           scopes[key] = nextScope;
+          replaceScopeInIndexes({
+            indexes: projectionIndexes,
+            scopeKey: key,
+            previousReferences: scopeState.references,
+            nextReferences: references,
+            feedItems,
+          });
           affected.push(nextScope);
         }
         const { [bookmarkId]: _removed, ...suppressedReferences } =
-          get().suppressedReferences;
+          current.suppressedReferences;
         void _removed;
-        set({ scopes, suppressedReferences });
+        if (
+          affected.length > 0 ||
+          hadSuppressedReferences ||
+          !current.projectionIndexesComplete
+        ) {
+          set({
+            scopes,
+            suppressedReferences,
+            projectionIndexes,
+            projectionIndexesComplete: true,
+          });
+        }
         return affected;
       },
     }),
@@ -272,20 +303,20 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
         scopes: state.scopes,
         suppressedReferences: state.suppressedReferences,
       }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as
+          Partial<MixedContentStore> | undefined;
+        const scopes = persisted?.scopes ?? {};
+        return {
+          ...currentState,
+          ...(persisted ?? {}),
+          scopes,
+          projectionIndexes: emptyProjectionIndexes(),
+          projectionIndexesComplete: Object.keys(scopes).length === 0,
+        };
+      },
     },
   ),
 );
-
-function canonicalize(url: string) {
-  try {
-    const parsed = new URL(url);
-    parsed.hash = "";
-    if (parsed.protocol === "http:" && parsed.port === "80") parsed.port = "";
-    if (parsed.protocol === "https:" && parsed.port === "443") parsed.port = "";
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
 
 export const mixedContentStore = createSelectorHooks(vanillaMixedContentStore);

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -27,6 +27,7 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
         visibility: chunk.visibility,
         page: chunk.page,
         replacesScope: chunk.replacesScope,
+        feedItems: feedItemsStore.getState().feedItemsDict,
       });
       continue;
     }
@@ -37,9 +38,13 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
       continue;
     }
     if (chunk.type === "bookmark-upsert") {
+      const previousBookmark = bookmarksStore
+        .getState()
+        .getBookmark(chunk.bookmark.id);
       bookmarksStore.getState().upsert(chunk.bookmark);
       const affected = mixedContentStore.getState().reprojectUpsert({
         bookmark: chunk.bookmark,
+        previousBookmark,
         feedItems: feedItemsStore.getState().feedItemsDict,
         views: viewsStore.getState().views,
       });
@@ -52,7 +57,10 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
       continue;
     }
     bookmarksStore.getState().remove(chunk.id);
-    const affected = mixedContentStore.getState().reprojectDeletion(chunk.id);
+    const affected = mixedContentStore.getState().reprojectDeletion({
+      bookmarkId: chunk.id,
+      feedItems: feedItemsStore.getState().feedItemsDict,
+    });
     for (const scope of affected) {
       affectedScopes.set(
         JSON.stringify([scope.scope, scope.visibility]),

--- a/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
+++ b/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ApplicationView } from "~/server/db/schema";
+import type {
+  ApplicationBookmark,
+  MixedContentPage,
+  MixedContentReference,
+  MixedContentScope,
+} from "~/server/mixed-content/projection";
+import type { PublishedChunk } from "~/server/api/publisher";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+import { feedItemsStore } from "~/lib/data/store";
+import {
+  getMixedScopeKey,
+  mixedContentStore,
+} from "~/lib/data/mixed-content/store";
+import { viewsStore } from "~/lib/data/views/store";
+import { processPublishedChunks } from "~/lib/data/subscriptionCoordinator";
+
+const NOW = new Date("2026-07-31T12:00:00.000Z");
+
+function bookmark(
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  return {
+    id: "bookmark-one",
+    userId: "user-one",
+    sourceUrl: "https://example.com/article",
+    canonicalUrl: "https://example.com/article",
+    isSaved: true,
+    isRead: false,
+    progress: 4,
+    duration: 10,
+    savedUpdatedAt: NOW,
+    readUpdatedAt: NOW,
+    progressUpdatedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    title: "Article",
+    author: "Writer",
+    publishedAt: null,
+    effectiveUrl: "https://example.com/article",
+    iconUrl: null,
+    representativeImageUrl: null,
+    captureHash: "capture-hash",
+    capturedAt: NOW,
+    viewIds: [10],
+    tagIds: [],
+    ...overrides,
+  };
+}
+
+function view(id: number, overrides: Partial<ApplicationView> = {}) {
+  return {
+    id,
+    userId: "user-one",
+    name: `View ${id}`,
+    daysWindow: 0,
+    readStatus: 0,
+    orientation: "horizontal",
+    contentType: "longform",
+    layout: "list",
+    placement: id,
+    createdAt: NOW,
+    updatedAt: NOW,
+    categoryIds: [],
+    feedIds: [id],
+    isDefault: false,
+    viewSections: [],
+    ...overrides,
+  } satisfies ApplicationView;
+}
+
+function reference(
+  entityId: string,
+  normalizedAt = NOW,
+  sectionPlacement: number | null = null,
+): MixedContentReference {
+  return {
+    entityKind: "bookmark",
+    entityId,
+    sectionPlacement,
+    normalizedAt,
+  };
+}
+
+function page(references: MixedContentReference[]): MixedContentPage {
+  return {
+    references,
+    bookmarks: [],
+    feedItems: [],
+    cursor: null,
+    hasMore: false,
+  };
+}
+
+function loadScope(
+  scope: MixedContentScope,
+  visibility: "unread" | "read" | "later",
+  references: MixedContentReference[] = [],
+) {
+  mixedContentStore.getState().applyPage({
+    scope,
+    visibility,
+    page: page(references),
+    replacesScope: true,
+    feedItems: feedItemsStore.getState().feedItemsDict,
+  });
+}
+
+function upsertPayload(nextBookmark: ApplicationBookmark): PublishedChunk {
+  return {
+    source: "bookmark",
+    chunk: { type: "bookmark-upsert", bookmark: nextBookmark },
+  };
+}
+
+beforeEach(() => {
+  bookmarksStore.getState().reset();
+  feedItemsStore.getState().reset();
+  mixedContentStore.getState().reset();
+  viewsStore.getState().set([view(10), view(11), view(12)]);
+});
+
+describe("change-aware Bookmark projection", () => {
+  it("patches progress and capture metadata without mixed projection work", () => {
+    const saved = bookmark();
+    bookmarksStore.getState().upsert(saved);
+    for (const targetView of [10, 11, 12]) {
+      for (const visibility of ["unread", "read", "later"] as const) {
+        loadScope(
+          { type: "view", viewId: targetView },
+          visibility,
+          targetView === 10 && visibility === "later"
+            ? [reference(saved.id)]
+            : [],
+        );
+      }
+    }
+
+    let mixedNotifications = 0;
+    const unsubscribe = mixedContentStore.subscribe(() => mixedNotifications++);
+    const progressAt = new Date(NOW.getTime() + 1);
+    const progressResult = processPublishedChunks([
+      upsertPayload({
+        ...saved,
+        progress: 8,
+        progressUpdatedAt: progressAt,
+        updatedAt: progressAt,
+      }),
+    ]);
+    const captureAt = new Date(NOW.getTime() + 2);
+    const captureResult = processPublishedChunks([
+      upsertPayload({
+        ...bookmarksStore.getState().getBookmark(saved.id)!,
+        title: "Fresh capture",
+        captureHash: "fresh-hash",
+        capturedAt: captureAt,
+        updatedAt: captureAt,
+      }),
+    ]);
+    unsubscribe();
+
+    expect(progressResult).toEqual([]);
+    expect(captureResult).toEqual([]);
+    expect(mixedNotifications).toBe(0);
+    expect(bookmarksStore.getState().getBookmark(saved.id)).toMatchObject({
+      progress: 8,
+      title: "Fresh capture",
+      captureHash: "fresh-hash",
+    });
+  });
+
+  it("updates only old and new membership, visibility, and ordering scopes", () => {
+    const saved = bookmark();
+    bookmarksStore.getState().upsert(saved);
+    for (const targetView of [10, 11, 12]) {
+      for (const visibility of ["unread", "read", "later"] as const) {
+        loadScope(
+          { type: "view", viewId: targetView },
+          visibility,
+          targetView === 10 && visibility === "later"
+            ? [reference(saved.id)]
+            : [],
+        );
+      }
+    }
+    for (const visibility of ["unread", "read", "later"] as const) {
+      loadScope({ type: "tag", tagId: 5 }, visibility);
+    }
+
+    const moved = bookmark({
+      viewIds: [11],
+      tagIds: [5],
+      updatedAt: new Date(NOW.getTime() + 1),
+    });
+    const organizationScopes = processPublishedChunks([upsertPayload(moved)]);
+    expect(
+      organizationScopes
+        .map((scope) => getMixedScopeKey(scope.scope, scope.visibility))
+        .sort(),
+    ).toEqual(["tag:5:later", "view:10:later", "view:11:later"]);
+
+    const unread = bookmark({
+      viewIds: [11],
+      tagIds: [5],
+      isSaved: false,
+      updatedAt: new Date(NOW.getTime() + 2),
+    });
+    const visibilityScopes = processPublishedChunks([upsertPayload(unread)]);
+    expect(
+      visibilityScopes
+        .map((scope) => getMixedScopeKey(scope.scope, scope.visibility))
+        .sort(),
+    ).toEqual([
+      "tag:5:later",
+      "tag:5:unread",
+      "view:11:later",
+      "view:11:unread",
+    ]);
+
+    const reorderedAt = new Date(NOW.getTime() + 3);
+    const orderingScopes = processPublishedChunks([
+      upsertPayload({
+        ...unread,
+        createdAt: reorderedAt,
+        updatedAt: reorderedAt,
+      }),
+    ]);
+    expect(
+      orderingScopes
+        .map((scope) => getMixedScopeKey(scope.scope, scope.visibility))
+        .sort(),
+    ).toEqual(["tag:5:unread", "view:11:unread"]);
+    expect(
+      mixedContentStore.getState().scopes["view:12:unread"]?.references,
+    ).toEqual([]);
+  });
+
+  it("coalesces a same-frame entity-only burst without projection notifications", () => {
+    const saved = bookmark();
+    bookmarksStore.getState().upsert(saved);
+    loadScope({ type: "view", viewId: 10 }, "later", [reference(saved.id)]);
+    const burst = Array.from({ length: 100 }, (_, index) => {
+      const changedAt = new Date(NOW.getTime() + index + 1);
+      return upsertPayload({
+        ...saved,
+        progress: index,
+        progressUpdatedAt: changedAt,
+        updatedAt: changedAt,
+      });
+    });
+    let mixedNotifications = 0;
+    const unsubscribe = mixedContentStore.subscribe(() => mixedNotifications++);
+
+    const affectedScopes = processPublishedChunks(burst);
+    unsubscribe();
+
+    expect(affectedScopes).toEqual([]);
+    expect(mixedNotifications).toBe(0);
+    expect(bookmarksStore.getState().getBookmark(saved.id)?.progress).toBe(99);
+  });
+});

--- a/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
@@ -161,7 +161,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       },
     ]);
 
-    expect(bookmarksStore.getState().bookmarksDict[savedBookmark.id]).toEqual(
+    expect(bookmarksStore.getState().getBookmark(savedBookmark.id)).toEqual(
       savedBookmark,
     );
     expect(feedItemsStore.getState().feedItemsDict[item.id]).toEqual(item);
@@ -195,12 +195,21 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
         reference("feed-item", other.id),
       ]),
       replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       visibility: "read",
       page: page([]),
       replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
+    });
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "later",
+      page: page([]),
+      replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
     });
 
     const saved = bookmark();
@@ -298,12 +307,14 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       visibility: "unread",
       page: page(references),
       replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       visibility: "read",
       page: page([]),
       replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     orpcMocks.setBookmarkBulkReadValue.mockResolvedValue([]);
     orpcMocks.setFeedBulkWatchedValue.mockImplementation(
@@ -320,7 +331,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
 
     await setMixedReadValue({ references, isRead: true });
     expect(
-      bookmarksStore.getState().bookmarksDict[archivedBookmark.id]?.isRead,
+      bookmarksStore.getState().getBookmark(archivedBookmark.id)?.isRead,
     ).toBe(true);
     expect(feedItemsStore.getState().feedItemsDict[item.id]?.isWatched).toBe(
       true,
@@ -339,7 +350,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
 
     await setMixedReadValue({ references, isRead: false });
     expect(
-      bookmarksStore.getState().bookmarksDict[archivedBookmark.id]?.isRead,
+      bookmarksStore.getState().getBookmark(archivedBookmark.id)?.isRead,
     ).toBe(false);
     expect(feedItemsStore.getState().feedItemsDict[item.id]?.isWatched).toBe(
       false,
@@ -352,5 +363,45 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       items: [{ id: item.id, feedId: item.feedId }],
       isWatched: false,
     });
+  });
+
+  it("restores Bookmark projection when an optimistic read change fails", async () => {
+    const unreadBookmark = bookmark({ isSaved: false, isRead: false });
+    bookmarksStore.getState().upsert(unreadBookmark);
+    const scope = { type: "view" as const, viewId: 10 };
+    const references = [reference("bookmark", unreadBookmark.id)];
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "unread",
+      page: page(references),
+      replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
+    });
+    mixedContentStore.getState().applyPage({
+      scope,
+      visibility: "read",
+      page: page([]),
+      replacesScope: true,
+      feedItems: feedItemsStore.getState().feedItemsDict,
+    });
+    orpcMocks.setBookmarkBulkReadValue.mockRejectedValueOnce(
+      new Error("write failed"),
+    );
+
+    await expect(
+      setMixedReadValue({ references, isRead: true }),
+    ).rejects.toThrow("write failed");
+
+    expect(
+      bookmarksStore.getState().getBookmark(unreadBookmark.id)?.isRead,
+    ).toBe(false);
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "unread")]
+        ?.references,
+    ).toEqual(references);
+    expect(
+      mixedContentStore.getState().scopes[getMixedScopeKey(scope, "read")]
+        ?.references,
+    ).toEqual([]);
   });
 });

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -2,29 +2,43 @@ import { describe, expect, it } from "vitest";
 import { runClientAuditProfile } from "../../../scripts/performance/client-audit-model";
 
 describe("client performance audit model", () => {
-  it("exposes full-scope refill fan-out for list-neutral Bookmark events", () => {
-    const result = runClientAuditProfile("small");
+  it.each([
+    ["small", 12],
+    ["representative", 33],
+    ["stress", 78],
+  ] as const)(
+    "keeps %s Bookmark events entity-neutral and projection work scope-bound",
+    (profile, loadedMixedScopes) => {
+      const result = runClientAuditProfile(profile);
 
-    expect(result.fixture.loadedMixedScopes).toBe(12);
-    expect(result.operations.bookmarkProgressEvent.authoritativeRefills).toBe(
-      result.fixture.loadedMixedScopes,
-    );
-    expect(result.operations.bookmarkSave.authoritativeRefills).toBe(
-      result.fixture.loadedMixedScopes,
-    );
-    expect(
-      result.operations.bookmarkOrganizationChange.authoritativeRefills,
-    ).toBe(result.fixture.loadedMixedScopes);
-    expect(result.operations.bookmarkDelete.authoritativeRefills).toBe(
-      result.fixture.loadedMixedScopes,
-    );
-    expect(
-      result.operations.bookmarkBurstSingleFrame.authoritativeRefills,
-    ).toBe(result.fixture.loadedMixedScopes);
-    expect(
-      result.operations.bookmarkBurstSeparateFrames.authoritativeRefills,
-    ).toBe(result.fixture.loadedMixedScopes * 100);
-  });
+      expect(result.fixture.loadedMixedScopes).toBe(loadedMixedScopes);
+      expect(result.operations.bookmarkProgressEvent).toMatchObject({
+        bookmarkStoreNotifications: 1,
+        mixedStoreNotifications: 0,
+        authoritativeRefills: 0,
+      });
+      expect(result.operations.bookmarkCaptureEvent).toMatchObject({
+        bookmarkStoreNotifications: 1,
+        mixedStoreNotifications: 0,
+        authoritativeRefills: 0,
+      });
+      expect(result.operations.bookmarkSave.authoritativeRefills).toBe(1);
+      expect(
+        result.operations.bookmarkOrganizationChange.authoritativeRefills,
+      ).toBe(2);
+      expect(result.operations.bookmarkDelete.authoritativeRefills).toBe(1);
+      expect(result.operations.bookmarkBurstSingleFrame).toMatchObject({
+        bookmarkStoreNotifications: 100,
+        mixedStoreNotifications: 0,
+        authoritativeRefills: 0,
+      });
+      expect(result.operations.bookmarkBurstSeparateFrames).toMatchObject({
+        bookmarkStoreNotifications: 100,
+        mixedStoreNotifications: 0,
+        authoritativeRefills: 0,
+      });
+    },
+  );
 
   it("retains bounded list references while identifying whole-cache persistence", () => {
     const result = runClientAuditProfile("small");


### PR DESCRIPTION
## Summary
- classify Bookmark upserts before mixed-list work so progress and capture events remain entity-only
- index loaded scope membership and canonical collisions so projection work targets only genuinely changed scopes
- preserve canonical restoration, optimistic rollback, persistence hydration, and burst behavior with regression coverage
- update retained small, representative, and stress client-audit evidence

## Validation
- pnpm test:unit (35 files, 192 tests)
- pnpm typecheck
- pnpm lint (0 errors; 31 existing warnings)
- pnpm build:atomic
- pnpm benchmark:client:coverage:check
- pnpx react-doctor --verbose --scope changed (100/100, no issues)
- pnpm test:e2e:self-hosted tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts --reporter=line