### PR TITLE
Bound client synchronization and persistence

### DIFF
--- a/apps/app/benchmarks/CLIENT-AUDIT.md
+++ b/apps/app/benchmarks/CLIENT-AUDIT.md
@@ -2,12 +2,12 @@
 
 ## Result
 
-The pre-UI Bookmark foundation is not safe to extend yet. The audit found five
-release-blocking client/synchronization problems. The most serious is the same
-unbounded mixed projection observed by the server benchmark crossing the client
-boundary: representative browser synchronization exceeded libSQL's response
-limit, and list-neutral Bookmark events schedule authoritative work for every
-loaded mixed scope.
+The pre-UI Bookmark foundation is not safe to extend yet. The audit originally
+found five release-blocking client/synchronization problems. CL-02 is now
+resolved: Bookmark synchronization uses a constant-size bucket manifest,
+unchanged reconnects refill no mixed scopes, incoming pages commit as one frame
+batch, and large persisted collections use normalized or chunked IndexedDB
+records. The remaining findings continue to block the UI checkpoint.
 
 The checked [coverage ledger](client-audit-coverage.json) records a finding or an
 explicit clean result for every applicable route, component, hook, state,
@@ -61,27 +61,45 @@ Retained evidence:
 | Cold synchronization JS              |                 3.18 ms |                 45.2 ms |                 439.2 ms |
 | Whole-cache structured clone         |                 5.18 ms |                 28.9 ms |                 149.4 ms |
 
+CL-02's retained post-remediation profiles replace the final two rows with the
+following bounded measurements:
+
+| Measurement                                  |       Small | Representative |       Stress |
+| -------------------------------------------- | ----------: | -------------: | -----------: |
+| Bookmark sync request / 16 KiB budget        |    2.68 KiB |       2.68 KiB |     2.68 KiB |
+| Largest response page / 256 KiB budget       |    2.20 KiB |      13.34 KiB |    35.20 KiB |
+| Cold Bookmark commit / notifications         | 0.09 ms / 1 |    0.34 ms / 1 |  1.07 ms / 1 |
+| Unchanged warm sync / mixed refills          | 1.35 ms / 0 |    3.59 ms / 0 | 18.81 ms / 0 |
+| Normalized mutation / 512 KiB storage budget |    8.92 KiB |       8.92 KiB |     8.92 KiB |
+
 Heap deltas are diagnostic only because garbage collection may occur inside a
 sample; payload size, notification count, refill count, and synchronous duration
 are the deterministic evidence.
 
 The representative Chromium run recorded:
 
-| Scenario             | Usable / observed time |  Long task |             React work |         IndexedDB | RPC requests / bytes |
-| -------------------- | ---------------------: | ---------: | ---------------------: | ----------------: | -------------------: |
-| Cold client          |          648 ms usable |  77 ms max |  28 commits, 68 ms max | 8 reads, 7 writes |          7 / 1.55 MB |
-| Warm hydration       |          614 ms usable | 234 ms max | 19 commits, 107 ms max | 8 reads, 7 writes |           6 / 412 KB |
-| Visibility reconnect |      3.0 s observation |  87 ms max |  21 commits, 75 ms max | 0 reads, 7 writes |           6 / 412 KB |
-| Pagination           |      2.0 s observation | 119 ms max |  11 commits, 64 ms max |              none |            1 / 22 KB |
-| Native reader entry  |                 202 ms | 182 ms max |   8 commits, 83 ms max |           1 write |         2 / streamed |
+| Scenario             | Usable / observed time |  Long task |            React work |               IndexedDB | RPC requests / bytes |
+| -------------------- | ---------------------: | ---------: | --------------------: | ----------------------: | -------------------: |
+| Cold client          |          577 ms usable |  69 ms max | 26 commits, 35 ms max | 11 reads, 1,348 records |          7 / 1.49 MB |
+| Warm hydration       |          605 ms usable | 212 ms max | 20 commits, 94 ms max | 1,350 reads, 345 writes |           6 / 329 KB |
+| Visibility reconnect |      3.0 s observation |  85 ms max | 17 commits, 73 ms max |     0 reads, 345 writes |           6 / 329 KB |
+| Pagination           |      2.0 s observation | 118 ms max | 11 commits, 62 ms max |                    none |            1 / 22 KB |
+| Native reader entry  |                 220 ms | 191 ms max |  8 commits, 90 ms max |               32 writes |         2 / streamed |
 
-The mixed synchronization request failed during this representative run with
-`RESPONSE_TOO_LARGE` while `loadProjectionData` attempted to materialize all
-10,000 Feed items. The visible Feed list still became usable through the legacy
-Feed synchronization path; that does not make the Bookmark path successful.
-Capture rendering is not reachable in the app before the Serial-app Bookmark UI
-checkpoint, so the audit covers its current cache/SSE representation and records
-native Page-capture rendering as part of that later checkpoint's acceptance.
+Normalized IndexedDB counts are per-record operations rather than whole-store
+transactions. Cold load writes the authoritative retained records once; warm
+hydration reads them in batches, and reconnect changes only the bounded records
+returned by existing Feed synchronization. No scenario writes one library-sized
+structured-clone value.
+
+The original representative run failed with `RESPONSE_TOO_LARGE` while automatic
+mixed synchronization materialized all 10,000 Feed items for every scope. The
+post-remediation run passes because reconnect synchronizes Bookmark buckets only;
+mixed pages are requested on demand through their bounded page contract instead
+of being preloaded for every View and visibility. Capture rendering is not
+reachable in the app before the Serial-app Bookmark UI checkpoint, so the audit
+covers its current cache/SSE representation and records native Page-capture
+rendering as part of that later checkpoint's acceptance.
 
 ## Prioritized findings
 
@@ -101,20 +119,29 @@ scope membership; return only genuinely changed scopes; coalesce and deduplicate
 authoritative validation with bounded concurrency; make list-neutral-event zero
 refill behavior a hard regression test.
 
-### CL-02 — Critical: synchronization and persisted state scale with the library
+### CL-02 — Resolved: synchronization and persistence are incremental and bounded
 
-Every start and visibility reconnect uploads the complete Bookmark manifest and
-requests three mixed pages for every View, unchanged or not. Incoming mixed pages
-upsert each entity separately before applying the page. At stress size cold client
-processing takes 441 ms and emits 2,340 Feed-item store notifications plus 78
-mixed-store notifications. Representative Turso synchronization already crosses
-the response-size ceiling.
+Bookmark synchronization now partitions the authoritative collection into 64
+stable buckets. The client uploads one 2.68 KiB bucket-version manifest at every
+fixture size; the server publishes only changed buckets in pages capped at 50
+Bookmarks and 256 KiB. The measured stress maximum is 35.20 KiB. An unchanged
+warm reconnect publishes no Bookmark pages and performs zero mixed-scope refills,
+so View count no longer drives reconnect fan-out or `RESPONSE_TOO_LARGE`.
 
-Zustand persistence then structured-clones whole store snapshots. A fully loaded
-stress cache is 28.31 MB and takes 149 ms merely to clone; the two-second throttle
-reduces write frequency but not payload size. Remediation must use bounded,
-incremental manifests/pages and normalized per-entity or chunked persistence,
-with a warm reconnect that performs no full-scope refill when versions match.
+The subscription coordinator applies all Bookmark sync pages received in one
+animation-frame flush through one store commit and applies mixed-page Bookmark
+and Feed-item entities through one batch commit per store. Stress cold Bookmark
+processing fell from roughly 439 ms with 2,340 Feed-item and 78 mixed-store
+notifications to 1.07 ms with one Bookmark notification and no Feed-item or mixed
+notifications.
+
+The application, Bookmark, and mixed-content stores now migrate their large
+dictionaries to normalized IndexedDB records; the Feed-item order is split into
+250-ID chunks. The cache can still retain 28.31 MB until CL-04 adds page retention,
+but one entity mutation writes only the changed record and an order-preserving
+mutation writes no order chunks. The retained stress mutation fixture clones
+8.92 KiB in 9.54 ms against a 512 KiB per-mutation budget instead of cloning the
+whole 28.31 MB cache.
 
 ### CL-03 — High: list-neutral Feed-item updates still scan scope and list metadata
 
@@ -161,8 +188,8 @@ cold load, warm hydration, pagination, reader, and future Page-capture rendering
 
 - SSE chunks are animation-frame buffered, initial Feed chunks have batching,
   and full-text IDs are deduplicated and fetched in bounded batches.
-- IndexedDB writes are throttled and flushed on visibility/pagehide; no write-per-
-  chunk storm was observed. The problem is whole-cache payload size.
+- IndexedDB writes remain throttled and flush on visibility/pagehide; large
+  dictionaries are normalized per entity and ordered IDs use fixed-size chunks.
 - `useItemWindow` bounds mounted list items and pagination uses cursors. No list
   DOM proportional to 50,000 Feed items was found.
 - Subscription lifecycle listeners and abort-signal cleanup are bounded per app

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedAt": "2026-07-31",
   "scope": "All client/shared routes, components, hooks, state, subscription, persistence, rendering, styles, and browser entry code under apps/app/src.",
-  "files": 309,
+  "files": 311,
   "findings": { "CL-01": 5, "CL-02": 4, "CL-03": 8, "CL-04": 6, "CL-05": 5 },
   "coverage": [
     {
@@ -1696,7 +1696,7 @@
     {
       "file": "src/lib/data/bookmarks/manifest.ts",
       "classification": "state-sync-persistence",
-      "lines": 15,
+      "lines": 70,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."
@@ -1704,7 +1704,7 @@
     {
       "file": "src/lib/data/bookmarks/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 64,
+      "lines": 85,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
@@ -1936,10 +1936,18 @@
     {
       "file": "src/lib/data/mixed-content/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 292,
+      "lines": 294,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
+    },
+    {
+      "file": "src/lib/data/normalized-idb-storage.ts",
+      "classification": "state-sync-persistence",
+      "lines": 382,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
     },
     {
       "file": "src/lib/data/plan-success.ts",
@@ -1960,7 +1968,7 @@
     {
       "file": "src/lib/data/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 2029,
+      "lines": 1967,
       "status": "finding",
       "findings": ["CL-02", "CL-03", "CL-04"],
       "result": "Reviewed; contributes to CL-02, CL-03, CL-04."
@@ -1976,7 +1984,7 @@
     {
       "file": "src/lib/data/subscriptionCoordinator.ts",
       "classification": "state-sync-persistence",
-      "lines": 65,
+      "lines": 101,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."
@@ -2321,6 +2329,14 @@
       "file": "src/lib/query-provider.tsx",
       "classification": "client-shared",
       "lines": 19,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
+      "file": "src/lib/schemas/bulk.ts",
+      "classification": "client-shared",
+      "lines": 23,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."

--- a/apps/app/benchmarks/results/browser-client-representative.json
+++ b/apps/app/benchmarks/results/browser-client-representative.json
@@ -1,429 +1,298 @@
 {
-  "generatedAt": "2026-07-31T19:28:08.585Z",
+  "generatedAt": "2026-07-31T21:15:22.816Z",
   "environment": "local-self-hosted-chromium",
   "profile": "representative",
   "coldLoad": {
-    "durationMs": 2852.0999999940395,
-    "usableContentMs": 648.2000000029802,
-    "longTasks": [70, 65, 62, 77],
+    "durationMs": 2781.2000000029802,
+    "usableContentMs": 577.2000000029802,
+    "longTasks": [56, 69, 58],
     "commits": [
+      { "actualDuration": 19, "baseDuration": 19.30000001192093 },
       {
-        "actualDuration": 19.299999997019768,
-        "baseDuration": 17.599999964237213
+        "actualDuration": 2.2000000029802322,
+        "baseDuration": 19.30000001192093
       },
       {
-        "actualDuration": 12.299999982118607,
-        "baseDuration": 20.89999994635582
+        "actualDuration": 5.799999997019768,
+        "baseDuration": 19.200000002980232
+      },
+      { "actualDuration": 0, "baseDuration": 19.200000002980232 },
+      { "actualDuration": 5.5, "baseDuration": 18.80000001192093 },
+      {
+        "actualDuration": 15.300000011920929,
+        "baseDuration": 25.00000001490116
+      },
+      { "actualDuration": 10.5, "baseDuration": 25.799999997019768 },
+      {
+        "actualDuration": 10.200000017881393,
+        "baseDuration": 32.900000005960464
       },
       {
-        "actualDuration": 0.4000000059604645,
-        "baseDuration": 20.799999952316284
+        "actualDuration": 18.599999994039536,
+        "baseDuration": 31.399999991059303
       },
       {
-        "actualDuration": 5.5,
-        "baseDuration": 20.89999996125698
+        "actualDuration": 6.299999997019768,
+        "baseDuration": 30.799999982118607
+      },
+      { "actualDuration": 34.79999998211861, "baseDuration": 42.3999999910593 },
+      {
+        "actualDuration": 8.600000008940697,
+        "baseDuration": 36.79999998211861
+      },
+      { "actualDuration": 0, "baseDuration": 36.79999998211861 },
+      {
+        "actualDuration": 6.899999991059303,
+        "baseDuration": 36.499999955296516
       },
       {
-        "actualDuration": 0,
-        "baseDuration": 20.89999996125698
+        "actualDuration": 10.700000002980232,
+        "baseDuration": 37.59999996423721
+      },
+      { "actualDuration": 1.5, "baseDuration": 37.69999997317791 },
+      {
+        "actualDuration": 1.7999999970197678,
+        "baseDuration": 38.69999995827675
       },
       {
-        "actualDuration": 5.000000014901161,
-        "baseDuration": 20.299999967217445
+        "actualDuration": 19.700000002980232,
+        "baseDuration": 32.00000001490116
       },
       {
-        "actualDuration": 14.600000008940697,
-        "baseDuration": 26.600000008940697
+        "actualDuration": 1.4000000059604645,
+        "baseDuration": 31.60000003874302
       },
       {
-        "actualDuration": 10.100000023841858,
-        "baseDuration": 27.100000023841858
+        "actualDuration": 7.799999997019768,
+        "baseDuration": 32.20000000298023
       },
       {
-        "actualDuration": 7.200000002980232,
-        "baseDuration": 31.400000020861626
+        "actualDuration": 23.400000005960464,
+        "baseDuration": 36.09999996423721
       },
       {
-        "actualDuration": 39.19999998807907,
-        "baseDuration": 47.900000005960464
-      },
-      {
-        "actualDuration": 8.599999994039536,
-        "baseDuration": 32.5
-      },
-      {
-        "actualDuration": 22.299999997019768,
-        "baseDuration": 34.8999999910593
-      },
-      {
-        "actualDuration": 1.7000000029802322,
-        "baseDuration": 34.900000005960464
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 34.900000005960464
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 34.900000005960464
-      },
-      {
-        "actualDuration": 29.69999998807907,
-        "baseDuration": 43.99999998509884
-      },
-      {
-        "actualDuration": 2,
-        "baseDuration": 43.900000005960464
-      },
-      {
-        "actualDuration": 22.99999998509884,
-        "baseDuration": 55.79999999701977
-      },
-      {
-        "actualDuration": 0.4000000059604645,
-        "baseDuration": 55.80000002682209
-      },
-      {
-        "actualDuration": 21.099999994039536,
-        "baseDuration": 54.1000000089407
-      },
-      {
-        "actualDuration": 68.2999999821186,
-        "baseDuration": 83.29999999701977
-      },
-      {
-        "actualDuration": 5.800000011920929,
-        "baseDuration": 82.59999999403954
-      },
-      {
-        "actualDuration": 2.7999999970197678,
-        "baseDuration": 82.59999999403954
+        "actualDuration": 1.6000000089406967,
+        "baseDuration": 36.299999967217445
       },
       {
         "actualDuration": 28.700000002980232,
-        "baseDuration": 43.69999998807907
+        "baseDuration": 41.400000005960464
       },
       {
-        "actualDuration": 1.5999999940395355,
-        "baseDuration": 38.79999999701977
+        "actualDuration": 8.199999988079071,
+        "baseDuration": 47.49999998509884
       },
+      { "actualDuration": 1.5, "baseDuration": 48.69999998807907 },
       {
-        "actualDuration": 0.3999999910593033,
-        "baseDuration": 38.3999999910593
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 38.3999999910593
-      },
-      {
-        "actualDuration": 0.09999999403953552,
-        "baseDuration": 38.3999999910593
+        "actualDuration": 1.2999999970197678,
+        "baseDuration": 48.49999998509884
       }
     ],
-    "indexedDb": {
-      "reads": 8,
-      "writes": 7
-    },
-    "requests": 615,
-    "transferBytes": 1936203,
+    "indexedDb": { "reads": 11, "writes": 1348 },
+    "requests": 617,
+    "transferBytes": 2173525,
     "rpcRequests": 7,
-    "rpcTransferBytes": 1554595,
+    "rpcTransferBytes": 1486086,
     "heapBytes": 103000000
   },
   "warmHydration": {
-    "durationMs": 2819.9000000059605,
-    "usableContentMs": 614.4000000059605,
-    "longTasks": [234, 56, 62],
+    "durationMs": 2809.5,
+    "usableContentMs": 605.2999999970198,
+    "longTasks": [212, 59, 62],
     "commits": [
+      { "actualDuration": 94.1000000089407, "baseDuration": 88.39999997615814 },
       {
-        "actualDuration": 106.79999999701977,
-        "baseDuration": 99.40000003576279
+        "actualDuration": 42.69999995827675,
+        "baseDuration": 58.39999993145466
       },
       {
-        "actualDuration": 40.79999999701977,
-        "baseDuration": 51.8999999910593
+        "actualDuration": 2.6000000089406967,
+        "baseDuration": 58.29999998211861
+      },
+      { "actualDuration": 9.299999982118607, "baseDuration": 38.3999999910593 },
+      { "actualDuration": 0, "baseDuration": 38.3999999910593 },
+      {
+        "actualDuration": 6.299999997019768,
+        "baseDuration": 31.599999979138374
+      },
+      { "actualDuration": 0, "baseDuration": 31.599999979138374 },
+      {
+        "actualDuration": 24.200000017881393,
+        "baseDuration": 39.79999998211861
       },
       {
-        "actualDuration": 2.7999999970197678,
-        "baseDuration": 50.99999998509884
+        "actualDuration": 2.0999999940395355,
+        "baseDuration": 39.19999998807907
+      },
+      { "actualDuration": 22.099999994039536, "baseDuration": 28 },
+      { "actualDuration": 20, "baseDuration": 29.900000020861626 },
+      { "actualDuration": 3, "baseDuration": 29.900000005960464 },
+      {
+        "actualDuration": 27.30000001192093,
+        "baseDuration": 32.30000002682209
       },
       {
-        "actualDuration": 12.400000005960464,
-        "baseDuration": 37.5
+        "actualDuration": 1.9000000059604645,
+        "baseDuration": 32.10000002384186
       },
+      { "actualDuration": 0, "baseDuration": 32.10000002384186 },
       {
-        "actualDuration": 0,
-        "baseDuration": 37.5
-      },
-      {
-        "actualDuration": 31.100000008940697,
-        "baseDuration": 36.20000001788139
-      },
-      {
-        "actualDuration": 26.600000008940697,
-        "baseDuration": 37.400000005960464
-      },
-      {
-        "actualDuration": 1.7000000178813934,
-        "baseDuration": 36.80000001192093
-      },
-      {
-        "actualDuration": 25.99999998509884,
-        "baseDuration": 31.099999964237213
+        "actualDuration": 24.299999982118607,
+        "baseDuration": 30.899999991059303
       },
       {
         "actualDuration": 1.5999999940395355,
-        "baseDuration": 30.799999967217445
+        "baseDuration": 30.799999997019768
       },
       {
-        "actualDuration": 0,
-        "baseDuration": 30.799999967217445
+        "actualDuration": 10.499999985098839,
+        "baseDuration": 31.00000001490116
       },
       {
-        "actualDuration": 1.199999988079071,
-        "baseDuration": 30.699999943375587
+        "actualDuration": 0.800000011920929,
+        "baseDuration": 31.00000001490116
       },
       {
-        "actualDuration": 24.399999976158142,
-        "baseDuration": 30.499999955296516
-      },
-      {
-        "actualDuration": 1.7999999970197678,
-        "baseDuration": 30.39999994635582
-      },
-      {
-        "actualDuration": 26.200000002980232,
-        "baseDuration": 46.3999999910593
-      },
-      {
-        "actualDuration": 0.3999999910593033,
-        "baseDuration": 46.19999997317791
-      },
-      {
-        "actualDuration": 25.19999997317791,
-        "baseDuration": 45.39999996125698
-      },
-      {
-        "actualDuration": 3.3999999910593033,
-        "baseDuration": 47.19999997317791
-      },
-      {
-        "actualDuration": 1.0999999940395355,
-        "baseDuration": 47.499999955296516
+        "actualDuration": 2.2000000029802322,
+        "baseDuration": 32.900000020861626
       }
     ],
-    "indexedDb": {
-      "reads": 8,
-      "writes": 7
-    },
-    "requests": 614,
-    "transferBytes": 793463,
+    "indexedDb": { "reads": 1350, "writes": 345 },
+    "requests": 616,
+    "transferBytes": 1016202,
     "rpcRequests": 6,
-    "rpcTransferBytes": 411855,
+    "rpcTransferBytes": 328763,
     "heapBytes": 103000000
   },
   "reconnect": {
-    "durationMs": 3009.2000000029802,
+    "durationMs": 3020.3999999910593,
     "usableContentMs": null,
-    "longTasks": [87, 55, 51],
+    "longTasks": [85, 58, 53],
     "commits": [
       {
-        "actualDuration": 4.799999997019768,
-        "baseDuration": 51.09999996423721
+        "actualDuration": 8.599999994039536,
+        "baseDuration": 40.20000001788139
+      },
+      { "actualDuration": 1.5, "baseDuration": 39.50000001490116 },
+      {
+        "actualDuration": 6.299999997019768,
+        "baseDuration": 37.20000000298023
+      },
+      { "actualDuration": 73, "baseDuration": 84.30000001192093 },
+      { "actualDuration": 55.49999998509884, "baseDuration": 74.8999999910593 },
+      {
+        "actualDuration": 19.299999997019768,
+        "baseDuration": 33.79999999701977
+      },
+      { "actualDuration": 1.5, "baseDuration": 33.69999998807907 },
+      {
+        "actualDuration": 19.899999991059303,
+        "baseDuration": 32.799999967217445
       },
       {
-        "actualDuration": 4.9000000059604645,
-        "baseDuration": 51.19999997317791
+        "actualDuration": 1.2999999821186066,
+        "baseDuration": 32.299999967217445
+      },
+      { "actualDuration": 6.700000002980232, "baseDuration": 31 },
+      {
+        "actualDuration": 10.200000002980232,
+        "baseDuration": 32.20000000298023
       },
       {
-        "actualDuration": 75.39999996125698,
-        "baseDuration": 84.69999992847443
+        "actualDuration": 1.4000000059604645,
+        "baseDuration": 32.1000000089407
+      },
+      { "actualDuration": 1, "baseDuration": 32.400000020861626 },
+      { "actualDuration": 0, "baseDuration": 32.400000020861626 },
+      {
+        "actualDuration": 2.199999988079071,
+        "baseDuration": 34.400000005960464
       },
       {
-        "actualDuration": 51.400000005960464,
-        "baseDuration": 68.49999998509884
+        "actualDuration": 2.5999999940395355,
+        "baseDuration": 34.80000001192093
       },
       {
-        "actualDuration": 21.200000017881393,
-        "baseDuration": 33.50000001490116
-      },
-      {
-        "actualDuration": 1.7000000029802322,
-        "baseDuration": 33.400000020861626
-      },
-      {
-        "actualDuration": 19.299999982118607,
-        "baseDuration": 31.599999949336052
-      },
-      {
-        "actualDuration": 1.5999999940395355,
-        "baseDuration": 31.39999996125698
-      },
-      {
-        "actualDuration": 21.30000001192093,
-        "baseDuration": 33.50000002980232
-      },
-      {
-        "actualDuration": 1.8999999910593033,
-        "baseDuration": 33.80000001192093
-      },
-      {
-        "actualDuration": 20.69999998807907,
-        "baseDuration": 32.89999997615814
-      },
-      {
-        "actualDuration": 1.5999999940395355,
-        "baseDuration": 32.99999997019768
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 32.99999997019768
-      },
-      {
-        "actualDuration": 1.2999999970197678,
-        "baseDuration": 33.19999997317791
-      },
-      {
-        "actualDuration": 22.700000002980232,
-        "baseDuration": 46.49999998509884
-      },
-      {
-        "actualDuration": 21.900000005960464,
-        "baseDuration": 45.69999998807907
-      },
-      {
-        "actualDuration": 2.9000000059604645,
-        "baseDuration": 46.70000000298023
-      },
-      {
-        "actualDuration": 35.29999998211861,
-        "baseDuration": 71.49999998509884
-      },
-      {
-        "actualDuration": 6,
-        "baseDuration": 70.49999998509884
-      },
-      {
-        "actualDuration": 1,
-        "baseDuration": 70.49999998509884
-      },
-      {
-        "actualDuration": 1,
-        "baseDuration": 70.49999998509884
+        "actualDuration": 2.7999999970197678,
+        "baseDuration": 35.00000001490116
       }
     ],
-    "indexedDb": {
-      "reads": 0,
-      "writes": 7
-    },
+    "indexedDb": { "reads": 0, "writes": 345 },
     "requests": 7,
-    "transferBytes": 412631,
+    "transferBytes": 329539,
     "rpcRequests": 6,
-    "rpcTransferBytes": 411855,
+    "rpcTransferBytes": 328763,
     "heapBytes": 103000000
   },
   "pagination": {
-    "durationMs": 2010.300000011921,
+    "durationMs": 2022.3999999910593,
     "usableContentMs": null,
-    "longTasks": [119],
+    "longTasks": [118],
     "commits": [
+      { "actualDuration": 23.799999997019768, "baseDuration": 51.5 },
       {
-        "actualDuration": 25.099999994039536,
-        "baseDuration": 70.50000001490116
+        "actualDuration": 0.4000000059604645,
+        "baseDuration": 51.29999999701977
+      },
+      { "actualDuration": 27.5, "baseDuration": 54.6000000089407 },
+      { "actualDuration": 62.29999999701977, "baseDuration": 77.5 },
+      {
+        "actualDuration": 19.900000005960464,
+        "baseDuration": 34.900000005960464
       },
       {
-        "actualDuration": 0.5,
-        "baseDuration": 70.40000002086163
+        "actualDuration": 15.500000014901161,
+        "baseDuration": 31.30000001192093
       },
       {
-        "actualDuration": 25,
-        "baseDuration": 69.70000000298023
+        "actualDuration": 6.799999997019768,
+        "baseDuration": 30.899999991059303
       },
       {
-        "actualDuration": 63.79999999701977,
-        "baseDuration": 75.79999999701977
+        "actualDuration": 13.200000002980232,
+        "baseDuration": 36.60000002384186
+      },
+      { "actualDuration": 0, "baseDuration": 36.60000002384186 },
+      {
+        "actualDuration": 2.5999999940395355,
+        "baseDuration": 36.400000020861626
       },
       {
-        "actualDuration": 21.600000008940697,
-        "baseDuration": 33.6000000089407
-      },
-      {
-        "actualDuration": 14.899999976158142,
-        "baseDuration": 26.899999976158142
-      },
-      {
-        "actualDuration": 7,
-        "baseDuration": 26.599999994039536
-      },
-      {
-        "actualDuration": 14.600000008940697,
-        "baseDuration": 33.19999997317791
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 33.19999997317791
-      },
-      {
-        "actualDuration": 0.8999999910593033,
-        "baseDuration": 33.09999996423721
-      },
-      {
-        "actualDuration": 1.2000000029802322,
-        "baseDuration": 33.29999998211861
+        "actualDuration": 2.7999999970197678,
+        "baseDuration": 36.60000002384186
       }
     ],
-    "indexedDb": {
-      "reads": 0,
-      "writes": 0
-    },
+    "indexedDb": { "reads": 0, "writes": 0 },
     "requests": 3,
-    "transferBytes": 23992,
+    "transferBytes": 23964,
     "rpcRequests": 1,
-    "rpcTransferBytes": 22497,
+    "rpcTransferBytes": 22467,
     "heapBytes": 103000000
   },
   "reader": {
-    "durationMs": 201.90000000596046,
+    "durationMs": 220.1000000089407,
     "usableContentMs": null,
-    "longTasks": [182],
+    "longTasks": [191],
     "commits": [
-      {
-        "actualDuration": 82.59999999403954,
-        "baseDuration": 103.2999999821186
-      },
-      {
-        "actualDuration": 71.7999999821186,
-        "baseDuration": 74.09999996423721
-      },
+      { "actualDuration": 90.2999999821186, "baseDuration": 115.3999999910593 },
+      { "actualDuration": 70.1000000089407, "baseDuration": 71.49999995529652 },
       {
         "actualDuration": 0.699999988079071,
-        "baseDuration": 71.39999996125698
+        "baseDuration": 69.19999994337559
+      },
+      { "actualDuration": 0, "baseDuration": 69.19999994337559 },
+      {
+        "actualDuration": 2.9000000059604645,
+        "baseDuration": 25.399999991059303
       },
       {
-        "actualDuration": 0,
-        "baseDuration": 71.39999996125698
+        "actualDuration": 0.6000000089406967,
+        "baseDuration": 23.599999994039536
       },
-      {
-        "actualDuration": 2.800000011920929,
-        "baseDuration": 30.19999998807907
-      },
-      {
-        "actualDuration": 0.5,
-        "baseDuration": 28.099999979138374
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 28.099999979138374
-      },
-      {
-        "actualDuration": 0,
-        "baseDuration": 28.099999979138374
-      }
+      { "actualDuration": 0, "baseDuration": 23.599999994039536 },
+      { "actualDuration": 0, "baseDuration": 23.599999994039536 }
     ],
-    "indexedDb": {
-      "reads": 0,
-      "writes": 1
-    },
+    "indexedDb": { "reads": 0, "writes": 32 },
     "requests": 2,
     "transferBytes": 0,
     "rpcRequests": 2,

--- a/apps/app/benchmarks/results/client-representative.json
+++ b/apps/app/benchmarks/results/client-representative.json
@@ -13,74 +13,92 @@
     "mixedContent": 101376,
     "total": 5601202
   },
+  "synchronizationBytes": {
+    "request": 2743,
+    "maximumResponsePage": 13663,
+    "requestBudget": 16384,
+    "responseBudget": 262144
+  },
+  "persistenceMutationBytes": {
+    "measured": 9133,
+    "budget": 524288
+  },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 1.5205839999999853,
-      "heapDeltaBytes": 1033184,
+      "durationMs": 1.8421660000001339,
+      "heapDeltaBytes": 679288,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 33
     },
     "bookmarkProgressEvent": {
-      "durationMs": 1.0634169999999585,
-      "heapDeltaBytes": 959192,
+      "durationMs": 1.2994160000000647,
+      "heapDeltaBytes": 903464,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 33
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 1.1337500000000205,
-      "heapDeltaBytes": 910592,
+      "durationMs": 1.5335000000000036,
+      "heapDeltaBytes": 903072,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 33
     },
     "bookmarkDelete": {
-      "durationMs": 2.168624999999963,
-      "heapDeltaBytes": 1915952,
+      "durationMs": 2.4017079999998714,
+      "heapDeltaBytes": 1913168,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 33
     },
     "feedProgressEvent": {
-      "durationMs": 2.1870839999999703,
-      "heapDeltaBytes": 1158688,
+      "durationMs": 2.3144999999999527,
+      "heapDeltaBytes": 1158616,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 99.77208299999995,
-      "heapDeltaBytes": -9496416,
+      "durationMs": 115.72966599999995,
+      "heapDeltaBytes": -10970344,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 33
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 86.81987500000002,
-      "heapDeltaBytes": 14908408,
+      "durationMs": 108.65587499999992,
+      "heapDeltaBytes": 14719808,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 3300
     },
     "coldSynchronization": {
-      "durationMs": 45.199833999999896,
-      "heapDeltaBytes": -26493728,
+      "durationMs": 0.33845799999994597,
+      "heapDeltaBytes": -20280,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 990,
-      "mixedStoreNotifications": 33,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
-    "persistenceStructuredClone": {
-      "durationMs": 28.924750000000017,
-      "heapDeltaBytes": 11461016,
+    "warmSynchronization": {
+      "durationMs": 3.5850000000000364,
+      "heapDeltaBytes": 8726680,
+      "bookmarkStoreNotifications": 0,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "normalizedPersistenceMutation": {
+      "durationMs": 2.8331249999998818,
+      "heapDeltaBytes": 939152,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/benchmarks/results/client-small.json
+++ b/apps/app/benchmarks/results/client-small.json
@@ -13,41 +13,51 @@
     "mixedContent": 36819,
     "total": 576051
   },
+  "synchronizationBytes": {
+    "request": 2743,
+    "maximumResponsePage": 2250,
+    "requestBudget": 16384,
+    "responseBudget": 262144
+  },
+  "persistenceMutationBytes": {
+    "measured": 9133,
+    "budget": 524288
+  },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 8.213124999999991,
-      "heapDeltaBytes": 742928,
+      "durationMs": 13.873458999999912,
+      "heapDeltaBytes": 406712,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 12
     },
     "bookmarkProgressEvent": {
-      "durationMs": 0.5942079999999805,
-      "heapDeltaBytes": 803760,
+      "durationMs": 1.1071249999999964,
+      "heapDeltaBytes": 371840,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 12
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 0.3978749999999991,
-      "heapDeltaBytes": 357760,
+      "durationMs": 0.44966599999997925,
+      "heapDeltaBytes": 337656,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 12
     },
     "bookmarkDelete": {
-      "durationMs": 0.2352499999999509,
-      "heapDeltaBytes": 282720,
+      "durationMs": 0.24691699999993943,
+      "heapDeltaBytes": 168896,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 12
     },
     "feedProgressEvent": {
-      "durationMs": 0.0831670000000031,
+      "durationMs": 0.10704099999998107,
       "heapDeltaBytes": 18920,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
@@ -55,32 +65,40 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 41.667790999999966,
-      "heapDeltaBytes": -56356320,
+      "durationMs": 39.77012500000001,
+      "heapDeltaBytes": -19757904,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 12
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 33.803290999999945,
-      "heapDeltaBytes": 7861288,
+      "durationMs": 40.07012499999996,
+      "heapDeltaBytes": 7761752,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 1200
     },
     "coldSynchronization": {
-      "durationMs": 3.181082999999944,
-      "heapDeltaBytes": -11202536,
+      "durationMs": 0.09016700000006495,
+      "heapDeltaBytes": 48032,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 360,
-      "mixedStoreNotifications": 12,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
-    "persistenceStructuredClone": {
-      "durationMs": 5.184750000000008,
-      "heapDeltaBytes": 1165848,
+    "warmSynchronization": {
+      "durationMs": 1.352292000000034,
+      "heapDeltaBytes": 2110672,
+      "bookmarkStoreNotifications": 0,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "normalizedPersistenceMutation": {
+      "durationMs": 0.12574999999992542,
+      "heapDeltaBytes": 46768,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/benchmarks/results/client-stress.json
+++ b/apps/app/benchmarks/results/client-stress.json
@@ -13,33 +13,43 @@
     "mixedContent": 241091,
     "total": 28309249
   },
+  "synchronizationBytes": {
+    "request": 2743,
+    "maximumResponsePage": 36049,
+    "requestBudget": 16384,
+    "responseBudget": 262144
+  },
+  "persistenceMutationBytes": {
+    "measured": 9133,
+    "budget": 524288
+  },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 4.546667000000014,
-      "heapDeltaBytes": 2935696,
+      "durationMs": 4.622583000000077,
+      "heapDeltaBytes": 2759216,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 78
     },
     "bookmarkProgressEvent": {
-      "durationMs": 3.8261250000000473,
-      "heapDeltaBytes": 2709520,
+      "durationMs": 5.108166999999867,
+      "heapDeltaBytes": 2702672,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 78
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 3.809374999999932,
-      "heapDeltaBytes": 2705712,
+      "durationMs": 4.089249999999993,
+      "heapDeltaBytes": 2714624,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 1,
       "authoritativeRefills": 78
     },
     "bookmarkDelete": {
-      "durationMs": 1.7328330000000278,
+      "durationMs": 2.3939580000001115,
       "heapDeltaBytes": 1425520,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -47,7 +57,7 @@
       "authoritativeRefills": 78
     },
     "feedProgressEvent": {
-      "durationMs": 13.422250000000076,
+      "durationMs": 15.063041000000112,
       "heapDeltaBytes": 6253408,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
@@ -55,32 +65,40 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 312.14591700000005,
-      "heapDeltaBytes": 7327408,
+      "durationMs": 360.062625,
+      "heapDeltaBytes": 10546000,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 78
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 302.5160840000001,
-      "heapDeltaBytes": 17731968,
+      "durationMs": 330.06620799999973,
+      "heapDeltaBytes": 29392408,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 100,
       "authoritativeRefills": 7800
     },
     "coldSynchronization": {
-      "durationMs": 439.2450839999999,
-      "heapDeltaBytes": 14182592,
+      "durationMs": 1.071957999999995,
+      "heapDeltaBytes": 642448,
       "bookmarkStoreNotifications": 1,
-      "feedItemStoreNotifications": 2340,
-      "mixedStoreNotifications": 78,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
       "authoritativeRefills": 0
     },
-    "persistenceStructuredClone": {
-      "durationMs": 149.3705419999999,
-      "heapDeltaBytes": 51175848,
+    "warmSynchronization": {
+      "durationMs": 18.81245799999988,
+      "heapDeltaBytes": 10299552,
+      "bookmarkStoreNotifications": 0,
+      "feedItemStoreNotifications": 0,
+      "mixedStoreNotifications": 0,
+      "authoritativeRefills": 0
+    },
+    "normalizedPersistenceMutation": {
+      "durationMs": 9.539458000000195,
+      "heapDeltaBytes": 3925768,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "mixedStoreNotifications": 0,

--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -14,10 +14,21 @@ import { feedItemsStore } from "~/lib/data/store";
 import { mixedContentStore } from "~/lib/data/mixed-content/store";
 import { processPublishedChunks } from "~/lib/data/subscriptionCoordinator";
 import { viewsStore } from "~/lib/data/views/store";
+import {
+  BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+  BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
+  buildBookmarkSyncManifest,
+} from "~/lib/data/bookmarks/manifest";
+import {
+  buildBookmarkSyncPages,
+  computeChangedBookmarkSyncBuckets,
+} from "~/server/mixed-content/sync";
+import { NORMALIZED_ARRAY_CHUNK_SIZE } from "~/lib/data/normalized-idb-storage";
 
 const PAGE_SIZE = 30;
 const VISIBILITIES: VisibilityFilter[] = ["unread", "read", "later"];
 const FIXTURE_TIME = new Date("2026-01-15T12:00:00.000Z");
+const NORMALIZED_PERSISTENCE_MUTATION_BUDGET_BYTES = 512 * 1_024;
 
 export type ClientAuditOperation = {
   durationMs: number;
@@ -43,6 +54,16 @@ export type ClientAuditResult = {
     mixedContent: number;
     total: number;
   };
+  synchronizationBytes: {
+    request: number;
+    maximumResponsePage: number;
+    requestBudget: number;
+    responseBudget: number;
+  };
+  persistenceMutationBytes: {
+    measured: number;
+    budget: number;
+  };
   operations: {
     bookmarkSave: ClientAuditOperation;
     bookmarkProgressEvent: ClientAuditOperation;
@@ -52,7 +73,8 @@ export type ClientAuditResult = {
     bookmarkBurstSingleFrame: ClientAuditOperation;
     bookmarkBurstSeparateFrames: ClientAuditOperation;
     coldSynchronization: ClientAuditOperation;
-    persistenceStructuredClone: ClientAuditOperation;
+    warmSynchronization: ClientAuditOperation;
+    normalizedPersistenceMutation: ClientAuditOperation;
   };
 };
 
@@ -250,21 +272,20 @@ function updatedBookmark(bookmark: ApplicationBookmark, progress: number) {
   };
 }
 
-function measurePersistenceClone() {
+function normalizedPersistenceMutationPayload() {
+  return {
+    feedItem: Object.values(feedItemsStore.getState().feedItemsDict)[0],
+    bookmark: Object.values(bookmarksStore.getState().bookmarksDict)[0],
+    mixedScope: Object.values(mixedContentStore.getState().scopes)[0],
+    orderChunk: feedItemsStore
+      .getState()
+      .feedItemsOrder.slice(0, NORMALIZED_ARRAY_CHUNK_SIZE),
+  };
+}
+
+function measureNormalizedPersistenceMutation() {
   return measure(() => {
-    structuredClone({
-      application: {
-        feedItemsDict: feedItemsStore.getState().feedItemsDict,
-        feedItemsOrder: feedItemsStore.getState().feedItemsOrder,
-      },
-      bookmarks: {
-        bookmarksDict: bookmarksStore.getState().bookmarksDict,
-      },
-      mixedContent: {
-        scopes: mixedContentStore.getState().scopes,
-        suppressedReferences: mixedContentStore.getState().suppressedReferences,
-      },
-    });
+    structuredClone(normalizedPersistenceMutationPayload());
     return 0;
   });
 }
@@ -374,40 +395,14 @@ export function runClientAuditProfile(
   });
 
   fixture = seedClientFixture(profileName);
-  const coldSynchronizationPayloads: PublishedChunk[] = [
-    {
-      source: "bookmark",
-      chunk: {
-        type: "bookmark-diff",
-        diff: fixture.bookmarks.map((bookmark) => ({
-          status: "new" as const,
-          bookmark,
-        })),
-      },
-    },
-    ...Object.values(mixedContentStore.getState().scopes).map(
-      (scope): PublishedChunk => ({
-        source: "mixed",
-        chunk: {
-          type: "mixed-content-page",
-          scope: scope.scope,
-          visibility: scope.visibility,
-          page: {
-            references: scope.references,
-            bookmarks: [],
-            feedItems: scope.references.flatMap((reference) => {
-              const item =
-                feedItemsStore.getState().feedItemsDict[reference.entityId];
-              return item ? [item] : [];
-            }),
-            cursor: null,
-            hasMore: true,
-          },
-          replacesScope: true,
-        },
-      }),
-    ),
-  ];
+  const changedBuckets = computeChangedBookmarkSyncBuckets(
+    fixture.bookmarks,
+    [],
+  );
+  const bookmarkSyncPages = changedBuckets.flatMap(buildBookmarkSyncPages);
+  const coldSynchronizationPayloads: PublishedChunk[] = bookmarkSyncPages.map(
+    (chunk) => ({ source: "bookmark", chunk }),
+  );
   resetStores();
   viewsStore.setState({
     views: fixture.views,
@@ -420,8 +415,27 @@ export function runClientAuditProfile(
   });
 
   fixture = seedClientFixture(profileName);
+  const requestManifest = buildBookmarkSyncManifest(fixture.bookmarks);
+  const warmSynchronization = measure(() => {
+    const unchangedBuckets = computeChangedBookmarkSyncBuckets(
+      fixture.bookmarks,
+      requestManifest,
+    );
+    processPublishedChunks(
+      unchangedBuckets
+        .flatMap(buildBookmarkSyncPages)
+        .map((chunk) => ({ source: "bookmark" as const, chunk })),
+    );
+    return 0;
+  });
   const payloadBytes = persistedPayloadBytes();
-  const persistenceStructuredClone = measurePersistenceClone();
+  const normalizedPersistenceMutation = measureNormalizedPersistenceMutation();
+  const persistenceMutationBytes = serialize(
+    normalizedPersistenceMutationPayload(),
+  ).byteLength;
+  const responsePageBytes = bookmarkSyncPages.map((page) =>
+    Buffer.byteLength(JSON.stringify(page)),
+  );
 
   return {
     profile: profileName,
@@ -433,6 +447,16 @@ export function runClientAuditProfile(
       referencesPerScope: PAGE_SIZE,
     },
     persistedPayloadBytes: payloadBytes,
+    synchronizationBytes: {
+      request: Buffer.byteLength(JSON.stringify(requestManifest)),
+      maximumResponsePage: Math.max(0, ...responsePageBytes),
+      requestBudget: BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+      responseBudget: BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
+    },
+    persistenceMutationBytes: {
+      measured: persistenceMutationBytes,
+      budget: NORMALIZED_PERSISTENCE_MUTATION_BUDGET_BYTES,
+    },
     operations: {
       bookmarkSave,
       bookmarkProgressEvent,
@@ -442,7 +466,8 @@ export function runClientAuditProfile(
       bookmarkBurstSingleFrame,
       bookmarkBurstSeparateFrames,
       coldSynchronization,
-      persistenceStructuredClone,
+      warmSynchronization,
+      normalizedPersistenceMutation,
     },
   };
 }

--- a/apps/app/src/lib/data/bookmarks/manifest.ts
+++ b/apps/app/src/lib/data/bookmarks/manifest.ts
@@ -1,5 +1,15 @@
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 
+export const BOOKMARK_SYNC_BUCKET_COUNT = 64;
+export const BOOKMARK_SYNC_PAGE_SIZE = 50;
+export const BOOKMARK_SYNC_REQUEST_BUDGET_BYTES = 16 * 1_024;
+export const BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES = 256 * 1_024;
+
+export type BookmarkSyncManifestEntry = {
+  bucket: number;
+  version: string;
+};
+
 export function bookmarkManifestValue(bookmark: ApplicationBookmark) {
   return [
     bookmark.updatedAt.toISOString(),
@@ -11,4 +21,49 @@ export function bookmarkManifestValue(bookmark: ApplicationBookmark) {
     bookmark.viewIds.join(","),
     bookmark.tagIds.join(","),
   ].join("|");
+}
+
+function fnv1a64(value: string) {
+  let hash = 0xcbf29ce484222325n;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= BigInt(value.charCodeAt(index));
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+export function getBookmarkSyncBucket(id: string) {
+  const hash = Number.parseInt(fnv1a64(id).slice(-8), 16);
+  return hash % BOOKMARK_SYNC_BUCKET_COUNT;
+}
+
+export function bookmarkSyncBucketVersion(bookmarks: ApplicationBookmark[]) {
+  const value = bookmarks
+    .map((bookmark) => `${bookmark.id}\0${bookmarkManifestValue(bookmark)}`)
+    .sort()
+    .join("\n");
+  return fnv1a64(value);
+}
+
+export function buildBookmarkSyncBuckets(bookmarks: ApplicationBookmark[]) {
+  const buckets = Array.from(
+    { length: BOOKMARK_SYNC_BUCKET_COUNT },
+    () => [] as ApplicationBookmark[],
+  );
+  for (const bookmark of bookmarks) {
+    buckets[getBookmarkSyncBucket(bookmark.id)]!.push(bookmark);
+  }
+  for (const bucket of buckets) {
+    bucket.sort((left, right) => left.id.localeCompare(right.id));
+  }
+  return buckets;
+}
+
+export function buildBookmarkSyncManifest(
+  bookmarks: ApplicationBookmark[],
+): BookmarkSyncManifestEntry[] {
+  return buildBookmarkSyncBuckets(bookmarks).map((bucket, index) => ({
+    bucket: index,
+    version: bookmarkSyncBucketVersion(bucket),
+  }));
 }

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -1,21 +1,21 @@
 import { createStore } from "zustand";
 import { persist } from "zustand/middleware";
-import { createIDBStorage } from "../idb-storage";
+import { createNormalizedIDBStorage } from "../normalized-idb-storage";
 import { createSelectorHooks } from "../createSelectorHooks";
-import { bookmarkManifestValue } from "./manifest";
+import { buildBookmarkSyncManifest, getBookmarkSyncBucket } from "./manifest";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
-import type {
-  BookmarkDiffEntry,
-  BookmarkManifestEntry,
-} from "~/server/mixed-content/sync";
+import type { BookmarkSyncBucketPage } from "~/server/mixed-content/sync";
+import type { BookmarkSyncManifestEntry } from "./manifest";
 
 type BookmarkStore = {
   bookmarksDict: Record<string, ApplicationBookmark>;
   reset: () => void;
   upsert: (bookmark: ApplicationBookmark) => void;
+  upsertMany: (bookmarks: ApplicationBookmark[]) => void;
   remove: (id: string) => void;
-  applyDiff: (diff: BookmarkDiffEntry[]) => void;
-  manifest: () => BookmarkManifestEntry[];
+  applySyncPage: (page: BookmarkSyncBucketPage) => void;
+  applySyncPages: (pages: BookmarkSyncBucketPage[]) => void;
+  manifest: () => BookmarkSyncManifestEntry[];
 };
 
 const vanillaBookmarkStore = createStore<BookmarkStore>()(
@@ -30,31 +30,52 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
             [bookmark.id]: bookmark,
           },
         }),
+      upsertMany: (bookmarks) => {
+        if (bookmarks.length === 0) return;
+        const bookmarksDict = { ...get().bookmarksDict };
+        for (const bookmark of bookmarks) {
+          bookmarksDict[bookmark.id] = bookmark;
+        }
+        set({ bookmarksDict });
+      },
       remove: (id) => {
         const { [id]: _removed, ...bookmarksDict } = get().bookmarksDict;
         void _removed;
         set({ bookmarksDict });
       },
-      applyDiff: (diff) => {
+      applySyncPage: (page) => {
+        get().applySyncPages([page]);
+      },
+      applySyncPages: (pages) => {
+        if (pages.length === 0) return;
         const bookmarksDict = { ...get().bookmarksDict };
-        for (const entry of diff) {
-          if (entry.status === "new" || entry.status === "updated") {
-            bookmarksDict[entry.bookmark.id] = entry.bookmark;
-          } else if (entry.status === "deleted") {
-            delete bookmarksDict[entry.id];
+        const replacedBuckets = new Set(
+          pages
+            .filter((page) => page.replacesBucket)
+            .map((page) => page.bucket),
+        );
+        if (replacedBuckets.size > 0) {
+          for (const bookmark of Object.values(bookmarksDict)) {
+            if (replacedBuckets.has(getBookmarkSyncBucket(bookmark.id))) {
+              delete bookmarksDict[bookmark.id];
+            }
+          }
+        }
+        for (const page of pages) {
+          for (const bookmark of page.bookmarks) {
+            bookmarksDict[bookmark.id] = bookmark;
           }
         }
         set({ bookmarksDict });
       },
       manifest: () =>
-        Object.values(get().bookmarksDict).map((bookmark) => ({
-          id: bookmark.id,
-          version: bookmarkManifestValue(bookmark),
-        })),
+        buildBookmarkSyncManifest(Object.values(get().bookmarksDict)),
     }),
     {
       name: "serial-bookmarks-store",
-      storage: createIDBStorage(),
+      storage: createNormalizedIDBStorage({
+        recordFields: ["bookmarksDict"],
+      }),
       partialize: (state) => ({ bookmarksDict: state.bookmarksDict }),
     },
   ),

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand";
 import { persist } from "zustand/middleware";
-import { createIDBStorage } from "../idb-storage";
+import { createNormalizedIDBStorage } from "../normalized-idb-storage";
 import { createSelectorHooks } from "../createSelectorHooks";
 import type { VisibilityFilter } from "../atoms";
 import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
@@ -267,7 +267,9 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
     }),
     {
       name: "serial-mixed-content-store",
-      storage: createIDBStorage(),
+      storage: createNormalizedIDBStorage({
+        recordFields: ["scopes", "suppressedReferences"],
+      }),
       partialize: (state) => ({
         scopes: state.scopes,
         suppressedReferences: state.suppressedReferences,

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -1,0 +1,381 @@
+import {
+  clear,
+  del,
+  delMany,
+  get,
+  getMany,
+  keys,
+  set,
+  setMany,
+} from "idb-keyval";
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+
+const WRITE_THROTTLE_MS = 2_000;
+export const NORMALIZED_WRITE_BATCH_SIZE = 100;
+export const NORMALIZED_ARRAY_CHUNK_SIZE = 250;
+
+type NormalizedStorageOptions = {
+  recordFields?: string[];
+  arrayFields?: string[];
+};
+
+type NormalizedRoot = {
+  version?: number;
+  state: Record<string, unknown>;
+  arrayLengths: Record<string, number>;
+};
+
+function normalizedPrefix(name: string) {
+  return `${name}::normalized:v1`;
+}
+
+function rootKey(name: string) {
+  return `${normalizedPrefix(name)}::root`;
+}
+
+function recordPrefix(name: string, field: string) {
+  return `${normalizedPrefix(name)}::record:${field}:`;
+}
+
+function recordKey(name: string, field: string, id: string) {
+  return `${recordPrefix(name, field)}${encodeURIComponent(id)}`;
+}
+
+function arrayPrefix(name: string, field: string) {
+  return `${normalizedPrefix(name)}::array:${field}:`;
+}
+
+function arrayKey(name: string, field: string, index: number) {
+  return `${arrayPrefix(name, field)}${index}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stateRecord<T>(
+  value: StorageValue<T> | null,
+): Record<string, unknown> {
+  return isRecord(value?.state) ? value.state : {};
+}
+
+function sameArrayChunk(previous: unknown[], next: unknown[], start: number) {
+  const end = Math.min(start + NORMALIZED_ARRAY_CHUNK_SIZE, next.length);
+  if (Math.min(start + NORMALIZED_ARRAY_CHUNK_SIZE, previous.length) !== end) {
+    return false;
+  }
+  for (let index = start; index < end; index++) {
+    if (!Object.is(previous[index], next[index])) return false;
+  }
+  return true;
+}
+
+function sameRootState(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+) {
+  const fieldNames = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  for (const key of fieldNames) {
+    if (!Object.is(previous[key], next[key])) return false;
+  }
+  return true;
+}
+
+export function planNormalizedRecordChanges(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+) {
+  const upsertIds = Object.entries(next).flatMap(([id, value]) =>
+    Object.is(previous[id], value) ? [] : [id],
+  );
+  const deleteIds = Object.keys(previous).filter((id) => !(id in next));
+  return { upsertIds, deleteIds };
+}
+
+export function planNormalizedArrayChunkChanges(
+  previous: unknown[],
+  next: unknown[],
+) {
+  const nextChunkCount = Math.ceil(next.length / NORMALIZED_ARRAY_CHUNK_SIZE);
+  const previousChunkCount = Math.ceil(
+    previous.length / NORMALIZED_ARRAY_CHUNK_SIZE,
+  );
+  const upsertChunkIndexes = Array.from(
+    { length: nextChunkCount },
+    (_, index) => index,
+  ).filter(
+    (index) =>
+      !sameArrayChunk(previous, next, index * NORMALIZED_ARRAY_CHUNK_SIZE),
+  );
+  const deleteChunkIndexes = Array.from(
+    { length: Math.max(0, previousChunkCount - nextChunkCount) },
+    (_, index) => nextChunkCount + index,
+  );
+  return { upsertChunkIndexes, deleteChunkIndexes };
+}
+
+async function writeInBatches(entries: Array<[IDBValidKey, unknown]>) {
+  for (
+    let index = 0;
+    index < entries.length;
+    index += NORMALIZED_WRITE_BATCH_SIZE
+  ) {
+    // Keep IndexedDB transactions sequential so a cold cache cannot enqueue
+    // hundreds of entity batches at once.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    await setMany(entries.slice(index, index + NORMALIZED_WRITE_BATCH_SIZE));
+  }
+}
+
+async function deleteInBatches(entries: IDBValidKey[]) {
+  for (
+    let index = 0;
+    index < entries.length;
+    index += NORMALIZED_WRITE_BATCH_SIZE
+  ) {
+    // Deletion batches share the same bounded transaction budget as writes.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    await delMany(entries.slice(index, index + NORMALIZED_WRITE_BATCH_SIZE));
+  }
+}
+
+async function readNormalized<T>(
+  name: string,
+  options: NormalizedStorageOptions,
+): Promise<StorageValue<T> | null> {
+  const root = await get<NormalizedRoot>(rootKey(name));
+  if (!root) return null;
+
+  const state = { ...root.state };
+  const databaseKeys = await keys<IDBValidKey>();
+
+  for (const field of options.recordFields ?? []) {
+    const prefix = recordPrefix(name, field);
+    const entityKeys = databaseKeys.filter(
+      (key): key is string => typeof key === "string" && key.startsWith(prefix),
+    );
+    const record: Record<string, unknown> = {};
+    for (
+      let index = 0;
+      index < entityKeys.length;
+      index += NORMALIZED_WRITE_BATCH_SIZE
+    ) {
+      const keyBatch = entityKeys.slice(
+        index,
+        index + NORMALIZED_WRITE_BATCH_SIZE,
+      );
+      // Hydrate sequentially to cap the number of records simultaneously
+      // materialized on the main thread.
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop
+      const values = await getMany(keyBatch);
+      for (const [valueIndex, value] of values.entries()) {
+        if (value === undefined) continue;
+        const key = keyBatch[valueIndex]!;
+        record[decodeURIComponent(key.slice(prefix.length))] = value;
+      }
+    }
+    state[field] = record;
+  }
+
+  for (const field of options.arrayFields ?? []) {
+    const length = root.arrayLengths[field] ?? 0;
+    const chunkCount = Math.ceil(length / NORMALIZED_ARRAY_CHUNK_SIZE);
+    // Stores currently configure at most one ordered array; keep this await at
+    // the field boundary so future arrays cannot amplify hydration memory.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const chunks = await getMany<unknown[]>(
+      Array.from({ length: chunkCount }, (_, index) =>
+        arrayKey(name, field, index),
+      ),
+    );
+    state[field] = chunks.flatMap((chunk) => chunk ?? []).slice(0, length);
+  }
+
+  return { state: state as T, version: root.version };
+}
+
+async function writeNormalized<T>(input: {
+  name: string;
+  previous: StorageValue<T> | null;
+  next: StorageValue<T>;
+  options: NormalizedStorageOptions;
+}) {
+  const { name, previous, next, options } = input;
+  const previousState = stateRecord(previous);
+  const nextState = stateRecord(next);
+  const recordFields = new Set(options.recordFields ?? []);
+  const arrayFields = new Set(options.arrayFields ?? []);
+
+  for (const field of recordFields) {
+    const previousRecord = isRecord(previousState[field])
+      ? previousState[field]
+      : {};
+    const nextRecord = isRecord(nextState[field]) ? nextState[field] : {};
+    const changes = planNormalizedRecordChanges(previousRecord, nextRecord);
+    const upserts: Array<[IDBValidKey, unknown]> = changes.upsertIds.map(
+      (id) => [recordKey(name, field, id), nextRecord[id]],
+    );
+    const deletions = changes.deleteIds.map((id) => recordKey(name, field, id));
+    // Each record collection is drained before the next one to preserve the
+    // storage transaction budget.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    await writeInBatches(upserts);
+    await deleteInBatches(deletions);
+  }
+
+  const arrayLengths: Record<string, number> = {};
+  for (const field of arrayFields) {
+    const previousArray = Array.isArray(previousState[field])
+      ? previousState[field]
+      : [];
+    const nextArray = Array.isArray(nextState[field]) ? nextState[field] : [];
+    arrayLengths[field] = nextArray.length;
+    const changes = planNormalizedArrayChunkChanges(previousArray, nextArray);
+    const changedChunks: Array<[IDBValidKey, unknown]> = [];
+    for (const index of changes.upsertChunkIndexes) {
+      const start = index * NORMALIZED_ARRAY_CHUNK_SIZE;
+      changedChunks.push([
+        arrayKey(name, field, index),
+        nextArray.slice(start, start + NORMALIZED_ARRAY_CHUNK_SIZE),
+      ]);
+    }
+    await writeInBatches(changedChunks);
+    await deleteInBatches(
+      changes.deleteChunkIndexes.map((index) => arrayKey(name, field, index)),
+    );
+  }
+
+  const rootState = Object.fromEntries(
+    Object.entries(nextState).filter(
+      ([field]) => !recordFields.has(field) && !arrayFields.has(field),
+    ),
+  );
+  const previousRootState = Object.fromEntries(
+    Object.entries(previousState).filter(
+      ([field]) => !recordFields.has(field) && !arrayFields.has(field),
+    ),
+  );
+  const rootChanged =
+    previous?.version !== next.version ||
+    !sameRootState(previousRootState, rootState) ||
+    [...arrayFields].some(
+      (field) =>
+        (Array.isArray(previousState[field])
+          ? previousState[field].length
+          : 0) !== arrayLengths[field],
+    );
+  if (rootChanged || previous === null) {
+    await set(rootKey(name), {
+      state: rootState,
+      version: next.version,
+      arrayLengths,
+    } satisfies NormalizedRoot);
+  }
+}
+
+/**
+ * Zustand storage that keeps large dictionaries as individual IndexedDB
+ * records and ordered arrays in fixed-size chunks. A one-entity mutation can
+ * therefore write one entity instead of structured-cloning the whole cache.
+ */
+export function createNormalizedIDBStorage<T>(
+  options: NormalizedStorageOptions,
+): PersistStorage<T> {
+  if (typeof window === "undefined") {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+
+  let lastValue: StorageValue<T> | null = null;
+  let pending: { name: string; value: StorageValue<T> } | null = null;
+  let writeTimeout: ReturnType<typeof setTimeout> | null = null;
+  let writeChain = Promise.resolve();
+
+  const reportWriteError = (name: string, error: unknown) => {
+    const isDOMException = error instanceof DOMException;
+    const shouldClear =
+      isDOMException &&
+      (error.name === "QuotaExceededError" ||
+        error.name === "InvalidStateError");
+    if (shouldClear) {
+      console.warn(
+        `[normalized-idb-storage] ${error.name} writing "${name}" — clearing cached data`,
+      );
+      void clear();
+    } else {
+      console.warn("[normalized-idb-storage] write failed:", name, error);
+    }
+  };
+
+  const flush = () => {
+    writeTimeout = null;
+    const current = pending;
+    pending = null;
+    if (!current) return;
+    writeChain = writeChain
+      .then(async () => {
+        await writeNormalized({
+          name: current.name,
+          previous: lastValue,
+          next: current.value,
+          options,
+        });
+        lastValue = current.value;
+      })
+      .catch((error: unknown) => reportWriteError(current.name, error));
+  };
+
+  const flushPending = () => {
+    if (writeTimeout !== null) clearTimeout(writeTimeout);
+    flush();
+  };
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flushPending();
+  });
+  window.addEventListener("pagehide", flushPending);
+
+  return {
+    getItem: async (name) => {
+      const normalized = await readNormalized<T>(name, options);
+      if (normalized) {
+        lastValue = normalized;
+        return normalized;
+      }
+
+      const legacy = (await get<StorageValue<T>>(name)) ?? null;
+      if (legacy) {
+        await writeNormalized({
+          name,
+          previous: null,
+          next: legacy,
+          options,
+        });
+        await del(name);
+        lastValue = legacy;
+      }
+      return legacy;
+    },
+    setItem: (name, value) => {
+      pending = { name, value };
+      if (writeTimeout === null) {
+        writeTimeout = setTimeout(flush, WRITE_THROTTLE_MS);
+      }
+    },
+    removeItem: async (name) => {
+      if (writeTimeout !== null) clearTimeout(writeTimeout);
+      writeTimeout = null;
+      pending = null;
+      lastValue = null;
+      const prefix = normalizedPrefix(name);
+      const matchingKeys = (await keys<IDBValidKey>()).filter(
+        (key) => typeof key === "string" && key.startsWith(prefix),
+      );
+      await deleteInBatches(matchingKeys);
+      await del(name);
+    },
+  };
+}

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -9,7 +9,7 @@ import { feedCategoriesStore } from "./feed-categories/store";
 import { mergeFeedItem } from "./feed-items/mergeFeedItem";
 import { clearPendingFeedItemOverrides } from "./feed-items/pendingMutations";
 import { feedsStore } from "./feeds/store";
-import { createIDBStorage } from "./idb-storage";
+import { createNormalizedIDBStorage } from "./normalized-idb-storage";
 import { loadingActor } from "./loading-machine";
 import {
   applyScopeMembershipUpdate,
@@ -125,6 +125,7 @@ export type ApplicationStore = {
   feedStatusDict: Record<number, FetchFeedsStatus>;
   setFeedItemsDict: (itemsDict: Record<string, ApplicationFeedItem>) => void;
   setFeedItem: (id: string, item: ApplicationFeedItem) => void;
+  setFeedItems: (items: ApplicationFeedItem[]) => void;
   fetchFeedItemsForFeed: (feedId: number) => Promise<void>;
   fetchNewData: () => Promise<void>;
   revalidateView: (viewId: number) => Promise<void>;
@@ -245,6 +246,18 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             item,
           ),
         }),
+      setFeedItems: (items) => {
+        if (items.length === 0) return;
+        const feedItemsDict = { ...get().feedItemsDict };
+        for (const item of items) feedItemsDict[item.id] = item;
+        set({
+          feedItemsDict,
+          scopeFeedItemIds: reconcileScopeMembershipsForItems(
+            get().scopeFeedItemIds,
+            items,
+          ),
+        });
+      },
       fetchFeedItemsLastFetchedAt: null,
       hasInitialData: false,
       currentViewId: null,
@@ -1850,7 +1863,10 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
     }),
     {
       name: "serial-application-store",
-      storage: createIDBStorage(),
+      storage: createNormalizedIDBStorage({
+        recordFields: ["feedItemsDict"],
+        arrayFields: ["feedItemsOrder"],
+      }),
       version: 1,
       partialize: (state) => ({
         feedItemsDict: state.feedItemsDict,

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -4,6 +4,44 @@ import { mixedContentStore } from "./mixed-content/store";
 import { viewsStore } from "./views/store";
 import type { LoadedMixedScope } from "./mixed-content/store";
 import type { PublishedChunk } from "~/server/api/publisher";
+import type { BookmarkSyncBucketPage } from "~/server/mixed-content/sync";
+
+const pendingBookmarkSyncBuckets = new Map<
+  number,
+  { version: string; bookmarks: BookmarkSyncBucketPage["bookmarks"] }
+>();
+
+function completeBookmarkSyncPages(payloads: PublishedChunk[]) {
+  const completed: BookmarkSyncBucketPage[] = [];
+  for (const payload of payloads) {
+    if (
+      payload.source !== "bookmark" ||
+      payload.chunk.type !== "bookmark-sync-bucket"
+    ) {
+      continue;
+    }
+    const page = payload.chunk;
+    if (page.replacesBucket) {
+      pendingBookmarkSyncBuckets.set(page.bucket, {
+        version: page.version,
+        bookmarks: [],
+      });
+    }
+    const pending = pendingBookmarkSyncBuckets.get(page.bucket);
+    if (!pending || pending.version !== page.version) continue;
+    pending.bookmarks.push(...page.bookmarks);
+    if (page.completesBucket) {
+      completed.push({
+        ...page,
+        bookmarks: pending.bookmarks,
+        replacesBucket: true,
+        completesBucket: true,
+      });
+      pendingBookmarkSyncBuckets.delete(page.bucket);
+    }
+  }
+  return completed;
+}
 
 export function processPublishedChunks(payloads: PublishedChunk[]) {
   const feedPayloads = payloads.filter(
@@ -12,16 +50,15 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
   if (feedPayloads.length > 0)
     feedItemsStore.getState().processChunks(feedPayloads);
 
+  const bookmarkSyncPages = completeBookmarkSyncPages(payloads);
+  bookmarksStore.getState().applySyncPages(bookmarkSyncPages);
+
   const affectedScopes = new Map<string, LoadedMixedScope>();
   for (const payload of payloads) {
     if (payload.source === "mixed") {
       const { chunk } = payload;
-      for (const bookmark of chunk.page.bookmarks) {
-        bookmarksStore.getState().upsert(bookmark);
-      }
-      for (const item of chunk.page.feedItems) {
-        feedItemsStore.getState().setFeedItem(item.id, item);
-      }
+      bookmarksStore.getState().upsertMany(chunk.page.bookmarks);
+      feedItemsStore.getState().setFeedItems(chunk.page.feedItems);
       mixedContentStore.getState().applyPage({
         scope: chunk.scope,
         visibility: chunk.visibility,
@@ -32,8 +69,7 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
     }
     if (payload.source !== "bookmark") continue;
     const { chunk } = payload;
-    if (chunk.type === "bookmark-diff") {
-      bookmarksStore.getState().applyDiff(chunk.diff);
+    if (chunk.type === "bookmark-sync-bucket") {
       continue;
     }
     if (chunk.type === "bookmark-upsert") {

--- a/apps/app/src/server/api/routers/mixedContentRouter.ts
+++ b/apps/app/src/server/api/routers/mixedContentRouter.ts
@@ -1,15 +1,22 @@
 import { z } from "zod";
-import { eq } from "drizzle-orm";
 import type { MixedContentScope } from "~/server/mixed-content/projection";
 import { getClientChannel } from "~/server/api/channels";
-import { INITIAL_ITEMS_PER_VIEW, ITEMS_PER_PAGE } from "~/server/api/constants";
+import { ITEMS_PER_PAGE } from "~/server/api/constants";
 import { publisher } from "~/server/api/publisher";
 import { visibilityFilterSchema } from "~/lib/data/atoms";
-import { INBOX_VIEW_ID } from "~/lib/data/views/constants";
-import { views } from "~/server/db/schema";
 import { protectedProcedure } from "~/server/orpc/base";
-import { queryMixedContentPage } from "~/server/mixed-content/projection";
-import { buildBookmarkDiff } from "~/server/mixed-content/sync";
+import {
+  loadApplicationBookmarks,
+  queryMixedContentPage,
+} from "~/server/mixed-content/projection";
+import {
+  buildBookmarkSyncPages,
+  computeChangedBookmarkSyncBuckets,
+} from "~/server/mixed-content/sync";
+import {
+  BOOKMARK_SYNC_BUCKET_COUNT,
+  BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+} from "~/lib/data/bookmarks/manifest";
 
 const clientIdSchema = z
   .string()
@@ -31,9 +38,29 @@ const cursorSchema = z
   })
   .nullable();
 
-const manifestSchema = z.array(
-  z.object({ id: z.string().min(1), version: z.string() }),
-);
+const manifestSchema = z
+  .array(
+    z.object({
+      bucket: z
+        .number()
+        .int()
+        .min(0)
+        .max(BOOKMARK_SYNC_BUCKET_COUNT - 1),
+      version: z.string().min(1).max(64),
+    }),
+  )
+  .max(BOOKMARK_SYNC_BUCKET_COUNT)
+  .refine(
+    (manifest) =>
+      new Set(manifest.map(({ bucket }) => bucket)).size === manifest.length,
+    "Bookmark synchronization buckets must be unique",
+  )
+  .refine(
+    (manifest) =>
+      new TextEncoder().encode(JSON.stringify(manifest)).byteLength <=
+      BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+    "Bookmark synchronization manifest exceeds the request budget",
+  );
 
 async function publishPage(input: {
   database: Parameters<typeof queryMixedContentPage>[0]["database"];
@@ -84,46 +111,37 @@ export const synchronize = protectedProcedure
   .input(
     z.object({
       clientId: clientIdSchema,
-      bookmarkManifest: manifestSchema.max(10_000).default([]),
+      bookmarkManifest: manifestSchema.default([]),
     }),
   )
   .handler(async ({ context, input }) => {
     const userId = context.user.id;
     const clientChannel = getClientChannel(userId, input.clientId);
-    const [bookmarkDiff, customViews] = await Promise.all([
-      buildBookmarkDiff({
-        database: context.db,
-        userId,
-        clientManifest: input.bookmarkManifest,
-      }),
-      context.db
-        .select({ id: views.id })
-        .from(views)
-        .where(eq(views.userId, userId)),
-    ]);
-    await publisher.publish(clientChannel, {
-      source: "bookmark",
-      chunk: { type: "bookmark-diff", diff: bookmarkDiff },
+    const serverBookmarks = await loadApplicationBookmarks({
+      database: context.db,
+      userId,
     });
-
-    const scopes: MixedContentScope[] = [
-      { type: "view", viewId: INBOX_VIEW_ID },
-      ...customViews.map(({ id }) => ({ type: "view" as const, viewId: id })),
-    ];
-    const visibilities = ["unread", "read", "later"] as const;
-    await Promise.all(
-      scopes.flatMap((scope) =>
-        visibilities.map((visibility) =>
-          publishPage({
-            database: context.db,
-            userId,
-            clientId: input.clientId,
-            scope,
-            visibility,
-            limit: INITIAL_ITEMS_PER_VIEW,
-          }),
-        ),
-      ),
+    const changedBuckets = computeChangedBookmarkSyncBuckets(
+      serverBookmarks,
+      input.bookmarkManifest,
     );
-    return { status: "completed" as const };
+    let publishedPages = 0;
+    for (const bucket of changedBuckets) {
+      const pages = buildBookmarkSyncPages(bucket);
+      for (const chunk of pages) {
+        // Publish sequentially so one synchronization cannot enqueue the whole
+        // Bookmark library in the publisher's response buffer.
+        // react-doctor-disable-next-line react-doctor/async-await-in-loop
+        await publisher.publish(clientChannel, {
+          source: "bookmark",
+          chunk,
+        });
+        publishedPages++;
+      }
+    }
+    return {
+      status: "completed" as const,
+      changedBuckets: changedBuckets.length,
+      publishedPages,
+    };
   });

--- a/apps/app/src/server/mixed-content/sync.ts
+++ b/apps/app/src/server/mixed-content/sync.ts
@@ -6,24 +6,29 @@ import type {
 } from "./projection";
 import type { db as defaultDatabase } from "~/server/db";
 import type { VisibilityFilter } from "~/lib/data/atoms";
-import { bookmarkManifestValue } from "~/lib/data/bookmarks/manifest";
+import type { BookmarkSyncManifestEntry } from "~/lib/data/bookmarks/manifest";
+import {
+  BOOKMARK_SYNC_PAGE_SIZE,
+  BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
+  bookmarkSyncBucketVersion,
+  buildBookmarkSyncBuckets,
+} from "~/lib/data/bookmarks/manifest";
 import { getUserChannel } from "~/server/api/channels";
 import { publisher } from "~/server/api/publisher";
 
 type MixedContentDatabase = typeof defaultDatabase;
 
-export type BookmarkManifestEntry = {
-  id: string;
+export type BookmarkSyncBucketPage = {
+  type: "bookmark-sync-bucket";
+  bucket: number;
   version: string;
+  bookmarks: ApplicationBookmark[];
+  replacesBucket: boolean;
+  completesBucket: boolean;
 };
 
-export type BookmarkDiffEntry =
-  | { status: "unchanged"; id: string }
-  | { status: "new" | "updated"; bookmark: ApplicationBookmark }
-  | { status: "deleted"; id: string };
-
 export type BookmarkSyncChunk =
-  | { type: "bookmark-diff"; diff: BookmarkDiffEntry[] }
+  | BookmarkSyncBucketPage
   | { type: "bookmark-upsert"; bookmark: ApplicationBookmark }
   | { type: "bookmark-delete"; id: string; canonicalUrl: string };
 
@@ -35,37 +40,72 @@ export type MixedContentChunk = {
   replacesScope: boolean;
 };
 
-export function computeBookmarkDiff(
+export function computeChangedBookmarkSyncBuckets(
   serverBookmarks: ApplicationBookmark[],
-  clientManifest: BookmarkManifestEntry[],
-): BookmarkDiffEntry[] {
+  clientManifest: BookmarkSyncManifestEntry[],
+) {
   const clientVersions = new Map(
-    clientManifest.map((entry) => [entry.id, entry.version]),
+    clientManifest.map((entry) => [entry.bucket, entry.version]),
   );
-  const serverIds = new Set(serverBookmarks.map((bookmark) => bookmark.id));
-  const diff: BookmarkDiffEntry[] = serverBookmarks.map((bookmark) => {
-    const clientVersion = clientVersions.get(bookmark.id);
-    if (clientVersion === undefined) return { status: "new", bookmark };
-    if (clientVersion === bookmarkManifestValue(bookmark)) {
-      return { status: "unchanged", id: bookmark.id };
-    }
-    return { status: "updated", bookmark };
-  });
-
-  for (const entry of clientManifest) {
-    if (!serverIds.has(entry.id))
-      diff.push({ status: "deleted", id: entry.id });
-  }
-  return diff;
+  return buildBookmarkSyncBuckets(serverBookmarks).flatMap(
+    (bookmarks, bucket) => {
+      const version = bookmarkSyncBucketVersion(bookmarks);
+      return clientVersions.get(bucket) === version
+        ? []
+        : [{ bucket, version, bookmarks }];
+    },
+  );
 }
 
-export async function buildBookmarkDiff(input: {
-  database: MixedContentDatabase;
-  userId: string;
-  clientManifest: BookmarkManifestEntry[];
-}) {
-  const serverBookmarks = await loadApplicationBookmarks(input);
-  return computeBookmarkDiff(serverBookmarks, input.clientManifest);
+function serializedBytes(value: unknown) {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+export function buildBookmarkSyncPages(input: {
+  bucket: number;
+  version: string;
+  bookmarks: ApplicationBookmark[];
+}): BookmarkSyncBucketPage[] {
+  const bookmarkPages: ApplicationBookmark[][] = [];
+  let current: ApplicationBookmark[] = [];
+
+  for (const bookmark of input.bookmarks) {
+    const candidate = [...current, bookmark];
+    const exceedsCount = candidate.length > BOOKMARK_SYNC_PAGE_SIZE;
+    const exceedsBytes =
+      serializedBytes({
+        type: "bookmark-sync-bucket",
+        bucket: input.bucket,
+        version: input.version,
+        bookmarks: candidate,
+        replacesBucket: bookmarkPages.length === 0,
+        completesBucket: false,
+      }) > BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES;
+    if ((exceedsCount || exceedsBytes) && current.length > 0) {
+      bookmarkPages.push(current);
+      current = [bookmark];
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0 || bookmarkPages.length === 0) {
+    bookmarkPages.push(current);
+  }
+
+  return bookmarkPages.map((bookmarks, index) => {
+    const page = {
+      type: "bookmark-sync-bucket" as const,
+      bucket: input.bucket,
+      version: input.version,
+      bookmarks,
+      replacesBucket: index === 0,
+      completesBucket: index === bookmarkPages.length - 1,
+    };
+    if (serializedBytes(page) > BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES) {
+      throw new Error("One Bookmark exceeds the synchronization byte budget");
+    }
+    return page;
+  });
 }
 
 export async function loadApplicationBookmark(input: {

--- a/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
@@ -11,7 +11,7 @@ import {
 import { signIn } from "../fixtures/auth";
 import type { Page } from "@playwright/test";
 
-async function persistedStore(page: Page, key: string) {
+async function persistedValue(page: Page, key: string) {
   return page.evaluate(async (storeKey) => {
     const database = await new Promise<IDBDatabase>((resolve, reject) => {
       const request = indexedDB.open("keyval-store");
@@ -31,6 +31,26 @@ async function persistedStore(page: Page, key: string) {
   }, key);
 }
 
+async function persistedKeys(page: Page) {
+  return page.evaluate(async () => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("keyval-store");
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+    try {
+      return await new Promise<IDBValidKey[]>((resolve, reject) => {
+        const transaction = database.transaction("keyval", "readonly");
+        const request = transaction.objectStore("keyval").getAllKeys();
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => resolve(request.result);
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
+
 test.describe("Bookmark mixed-content synchronization", () => {
   let testEmail: string;
 
@@ -38,7 +58,7 @@ test.describe("Bookmark mixed-content synchronization", () => {
     if (testEmail) await cleanupUser(SELF_HOSTED_TURSO_PORT, testEmail);
   });
 
-  test("hydrates separate Bookmark and mixed caches with canonical suppression", async ({
+  test("hydrates normalized Bookmarks without eagerly refilling every mixed scope", async ({
     page,
   }) => {
     const { email, password, feedItemId } = await seedArticleData(
@@ -57,49 +77,22 @@ test.describe("Bookmark mixed-content synchronization", () => {
     await expect
       .poll(
         async () => {
-          const bookmarkCache = (await persistedStore(
+          const bookmarkCache = (await persistedValue(
             page,
-            "serial-bookmarks-store",
-          )) as {
-            state?: { bookmarksDict?: Record<string, { captureHash: string }> };
-          } | null;
-          return bookmarkCache?.state?.bookmarksDict?.[bookmarkId]?.captureHash;
+            `serial-bookmarks-store::normalized:v1::record:bookmarksDict:${encodeURIComponent(bookmarkId)}`,
+          )) as { captureHash?: string } | null;
+          return bookmarkCache?.captureHash;
         },
         { timeout: 30_000 },
       )
       .toBe(`hash-${bookmarkId}`);
 
-    await expect
-      .poll(
-        async () => {
-          const mixedCache = (await persistedStore(
-            page,
-            "serial-mixed-content-store",
-          )) as {
-            state?: {
-              scopes?: Record<
-                string,
-                { references: Array<{ entityKind: string; entityId: string }> }
-              >;
-            };
-          } | null;
-          const scopes = mixedCache?.state?.scopes;
-          return {
-            saved:
-              scopes?.[`view:${viewId}:later`]?.references.map(
-                ({ entityKind, entityId }) => ({ entityKind, entityId }),
-              ) ?? null,
-            unread:
-              scopes?.[`view:${viewId}:unread`]?.references.map(
-                ({ entityKind, entityId }) => ({ entityKind, entityId }),
-              ) ?? null,
-          };
-        },
-        { timeout: 30_000 },
-      )
-      .toEqual({
-        saved: [{ entityKind: "bookmark", entityId: bookmarkId }],
-        unread: [],
-      });
+    const mixedScopePrefix =
+      "serial-mixed-content-store::normalized:v1::record:scopes:";
+    const mixedScopeKeys = (await persistedKeys(page)).filter(
+      (key) => typeof key === "string" && key.startsWith(mixedScopePrefix),
+    );
+    expect(mixedScopeKeys).toEqual([]);
+    expect(viewId).toBeGreaterThan(0);
   });
 });

--- a/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
@@ -17,8 +17,17 @@ import {
   partitionMixedReadTargets,
   setMixedReadValue,
 } from "~/lib/data/mixed-content/mutations";
-import { bookmarkManifestValue } from "~/lib/data/bookmarks/manifest";
-import { computeBookmarkDiff } from "~/server/mixed-content/sync";
+import {
+  BOOKMARK_SYNC_BUCKET_COUNT,
+  BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+  BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
+  buildBookmarkSyncManifest,
+  getBookmarkSyncBucket,
+} from "~/lib/data/bookmarks/manifest";
+import {
+  buildBookmarkSyncPages,
+  computeChangedBookmarkSyncBuckets,
+} from "~/server/mixed-content/sync";
 
 const NOW = new Date("2026-07-30T12:00:00.000Z");
 
@@ -172,6 +181,45 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     ).toHaveLength(2);
   });
 
+  it("commits every incoming mixed page with one entity-store notification", () => {
+    const bookmarks = Array.from({ length: 30 }, (_, index) =>
+      bookmark({ id: `bookmark-${index}` }),
+    );
+    const items = Array.from({ length: 30 }, (_, index) =>
+      feedItem(`feed-${index}`, `https://example.com/feed-${index}`),
+    );
+    let bookmarkNotifications = 0;
+    let feedNotifications = 0;
+    const unsubscribeBookmarks = bookmarksStore.subscribe(
+      () => bookmarkNotifications++,
+    );
+    const unsubscribeFeedItems = feedItemsStore.subscribe(
+      () => feedNotifications++,
+    );
+
+    processPublishedChunks([
+      {
+        source: "mixed",
+        chunk: {
+          type: "mixed-content-page",
+          scope: { type: "view", viewId: 10 },
+          visibility: "later",
+          page: {
+            ...page([]),
+            bookmarks,
+            feedItems: items,
+          },
+          replacesScope: true,
+        },
+      },
+    ]);
+
+    unsubscribeBookmarks();
+    unsubscribeFeedItems();
+    expect(bookmarkNotifications).toBe(1);
+    expect(feedNotifications).toBe(1);
+  });
+
   it("suppresses matching Feed items immediately, moves Bookmark visibility, restores on deletion, and reports scopes for refill", () => {
     const matchingOne = feedItem(
       "feed-match-one",
@@ -252,7 +300,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     ]);
   });
 
-  it("reconciles entity, state, organization, progress, and capture metadata through the manifest", () => {
+  it("uses a constant-size bucket manifest and returns only changed authoritative buckets", () => {
     const cached = bookmark();
     const updated = bookmark({
       progress: 8,
@@ -263,24 +311,107 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       capturedAt: new Date("2026-07-30T12:02:00Z"),
       updatedAt: new Date("2026-07-30T12:02:00Z"),
     });
+    const unchangedManifest = buildBookmarkSyncManifest([cached]);
+    expect(unchangedManifest).toHaveLength(BOOKMARK_SYNC_BUCKET_COUNT);
+    expect(JSON.stringify(unchangedManifest).length).toBeLessThan(
+      BOOKMARK_SYNC_REQUEST_BUDGET_BYTES,
+    );
     expect(
-      computeBookmarkDiff(
-        [cached],
-        [{ id: cached.id, version: bookmarkManifestValue(cached) }],
-      ),
-    ).toEqual([{ status: "unchanged", id: cached.id }]);
-    expect(
-      computeBookmarkDiff(
-        [updated],
-        [
-          { id: cached.id, version: bookmarkManifestValue(cached) },
-          { id: "deleted-offline", version: "old" },
-        ],
-      ),
-    ).toEqual([
-      { status: "updated", bookmark: updated },
-      { status: "deleted", id: "deleted-offline" },
+      computeChangedBookmarkSyncBuckets([cached], unchangedManifest),
+    ).toEqual([]);
+
+    const changed = computeChangedBookmarkSyncBuckets(
+      [updated],
+      unchangedManifest,
+    );
+    expect(changed).toHaveLength(1);
+    expect(changed[0]).toMatchObject({
+      bucket: getBookmarkSyncBucket(cached.id),
+      bookmarks: [updated],
+    });
+    const pages = buildBookmarkSyncPages(changed[0]!);
+    expect(pages).toHaveLength(1);
+    expect(JSON.stringify(pages[0]).length).toBeLessThan(
+      BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
+    );
+  });
+
+  it("replaces one changed bucket without deleting cached entities in unchanged buckets", () => {
+    const first = bookmark({ id: "bucket-source" });
+    let secondIndex = 0;
+    let second = bookmark({ id: `other-${secondIndex}` });
+    while (
+      getBookmarkSyncBucket(second.id) === getBookmarkSyncBucket(first.id)
+    ) {
+      secondIndex++;
+      second = bookmark({ id: `other-${secondIndex}` });
+    }
+    bookmarksStore.getState().upsertMany([first, second]);
+    const updated = bookmark({
+      id: first.id,
+      title: "Updated title",
+      updatedAt: new Date(NOW.getTime() + 1),
+    });
+    const [syncPage] = buildBookmarkSyncPages({
+      bucket: getBookmarkSyncBucket(first.id),
+      version: "changed-version",
+      bookmarks: [updated],
+    });
+    bookmarksStore.getState().applySyncPage(syncPage!);
+
+    expect(bookmarksStore.getState().bookmarksDict).toEqual({
+      [updated.id]: updated,
+      [second.id]: second,
+    });
+  });
+
+  it("commits a changed sync bucket only after its final bounded page arrives", () => {
+    const bucket = getBookmarkSyncBucket("paged-bookmark");
+    const first = bookmark({ id: "paged-bookmark" });
+    let secondIndex = 0;
+    let second = bookmark({ id: `paged-bookmark-${secondIndex}` });
+    while (getBookmarkSyncBucket(second.id) !== bucket) {
+      secondIndex++;
+      second = bookmark({ id: `paged-bookmark-${secondIndex}` });
+    }
+    let notifications = 0;
+    const unsubscribe = bookmarksStore.subscribe(() => notifications++);
+
+    processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-sync-bucket",
+          bucket,
+          version: "paged-version",
+          bookmarks: [first],
+          replacesBucket: true,
+          completesBucket: false,
+        },
+      },
     ]);
+    expect(notifications).toBe(0);
+
+    processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-sync-bucket",
+          bucket,
+          version: "paged-version",
+          bookmarks: [second],
+          replacesBucket: false,
+          completesBucket: true,
+        },
+      },
+    ]);
+    unsubscribe();
+
+    expect(notifications).toBe(1);
+    expect(bookmarksStore.getState().bookmarksDict).toMatchObject({
+      [first.id]: first,
+      [second.id]: second,
+    });
   });
 
   it("marks mixed and section-level references read and supports undo", async () => {

--- a/apps/app/tests/unit/data/normalized-idb-storage.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  NORMALIZED_ARRAY_CHUNK_SIZE,
+  planNormalizedArrayChunkChanges,
+  planNormalizedRecordChanges,
+} from "~/lib/data/normalized-idb-storage";
+
+describe("normalized IndexedDB persistence", () => {
+  it("plans one record write for one entity mutation in a stress-sized cache", () => {
+    const previous = Object.fromEntries(
+      Array.from({ length: 50_000 }, (_, index) => [
+        `entity-${index}`,
+        { id: `entity-${index}`, progress: 0 },
+      ]),
+    );
+    const next = {
+      ...previous,
+      "entity-25": { id: "entity-25", progress: 1 },
+    };
+
+    expect(planNormalizedRecordChanges(previous, next)).toEqual({
+      upsertIds: ["entity-25"],
+      deleteIds: [],
+    });
+  });
+
+  it("writes no order chunks when an entity mutation preserves ordering", () => {
+    const previous = Array.from(
+      { length: NORMALIZED_ARRAY_CHUNK_SIZE * 20 },
+      (_, index) => `entity-${index}`,
+    );
+
+    expect(planNormalizedArrayChunkChanges(previous, previous)).toEqual({
+      upsertChunkIndexes: [],
+      deleteChunkIndexes: [],
+    });
+  });
+
+  it("limits an append to the final order chunk", () => {
+    const previous = Array.from(
+      { length: NORMALIZED_ARRAY_CHUNK_SIZE + 10 },
+      (_, index) => `entity-${index}`,
+    );
+    const next = [...previous, "new-entity"];
+
+    expect(planNormalizedArrayChunkChanges(previous, next)).toEqual({
+      upsertChunkIndexes: [1],
+      deleteChunkIndexes: [],
+    });
+  });
+});

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -37,4 +37,33 @@ describe("client performance audit model", () => {
       1,
     );
   });
+
+  it("keeps synchronization pages and normalized persistence mutations within explicit budgets", () => {
+    const result = runClientAuditProfile("stress");
+
+    expect(result.synchronizationBytes.request).toBeLessThanOrEqual(
+      result.synchronizationBytes.requestBudget,
+    );
+    expect(result.synchronizationBytes.maximumResponsePage).toBeLessThanOrEqual(
+      result.synchronizationBytes.responseBudget,
+    );
+    expect(result.persistenceMutationBytes.measured).toBeLessThanOrEqual(
+      result.persistenceMutationBytes.budget,
+    );
+    expect(
+      result.operations.coldSynchronization.bookmarkStoreNotifications,
+    ).toBeLessThanOrEqual(128);
+    expect(
+      result.operations.coldSynchronization.feedItemStoreNotifications,
+    ).toBe(0);
+    expect(result.operations.warmSynchronization).toMatchObject({
+      bookmarkStoreNotifications: 0,
+      feedItemStoreNotifications: 0,
+      mixedStoreNotifications: 0,
+      authoritativeRefills: 0,
+    });
+    expect(
+      result.operations.normalizedPersistenceMutation.durationMs,
+    ).toBeLessThan(50);
+  });
 });


### PR DESCRIPTION
## Summary
- replace per-Bookmark warm manifests with a fixed 64-bucket digest and bounded changed-bucket pages
- stop automatic all-scope mixed-content refill and batch incoming page commits
- normalize large IndexedDB dictionaries and chunk ordered collections with legacy migration
- retain deterministic and Chromium cold/warm/reconnect performance evidence

## Validation
- `pnpm test:unit` (36 files, 199 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 31 pre-existing warnings)
- `pnpm benchmark:client:coverage:check`
- small, representative, and stress client benchmark profiles
- representative Chromium performance profile
- `pnpm build:atomic`
- `pnpx react-doctor@latest . --verbose --scope changed` (0 issues)