### PR TITLE
Bound client page retention

### DIFF
--- a/apps/app/benchmarks/CLIENT-AUDIT.md
+++ b/apps/app/benchmarks/CLIENT-AUDIT.md
@@ -82,6 +82,32 @@ Heap deltas are diagnostic only because garbage collection may occur inside a
 sample; payload size, notification count, refill count, and synchronous duration
 are the deterministic evidence.
 
+## CL-04 retention remediation evidence
+
+Cursor-loaded Feed-item and mixed-content pages now have deterministic retention
+instead of accumulating for the lifetime of the client. Each scope keeps at most
+eight in-memory pages or 8 MiB, including the current page and a two-page
+navigation buffer. IndexedDB keeps at most the newest six complete pages or
+4 MiB. Visible list entities, open-reader entities, and pending optimistic
+entities are pinned; distant pages and unreferenced Feed entities are evicted and
+remain reloadable from their cursor.
+
+The deterministic pagination scenario reaches the same plateau after 12 and 24
+pages at every fixture scale:
+
+| Pagination point | Memory pages | Feed entities / scope refs | Retained heap model | IndexedDB pages / bytes | Mounted items |
+| ---------------- | -----------: | -------------------------: | ------------------: | ----------------------: | ------------: |
+| After 12 pages   |            8 |                  240 / 240 |              130 KB |             6 / 90.0 KB |           180 |
+| After 24 pages   |            8 |                  240 / 240 |              130 KB |             6 / 90.1 KB |           180 |
+
+The full-library payload row above remains the original CL-02/CL-04 baseline:
+that fixture deliberately seeds whole dictionaries directly. The pagination
+plateau exercises the production page-retention boundary and is the relevant
+post-remediation evidence. Store integration coverage also verifies that an
+evicted page cannot collect an entity pinned by the reader or an optimistic
+mutation, and the list window includes keyboard-selected entities without
+exceeding its mounted-item cap.
+
 The representative Chromium run recorded:
 
 | Scenario             | Usable / observed time |  Long task |            React work |               IndexedDB | RPC requests / bytes |

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -1960,7 +1960,7 @@
     {
       "file": "src/lib/data/mixed-content/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 378,
+      "lines": 377,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
@@ -2000,7 +2000,7 @@
     {
       "file": "src/lib/data/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 2162,
+      "lines": 2163,
       "status": "finding",
       "findings": ["CL-02", "CL-03", "CL-04"],
       "result": "Reviewed; contributes to CL-02, CL-03, CL-04."

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedAt": "2026-07-31",
   "scope": "All client/shared routes, components, hooks, state, subscription, persistence, rendering, styles, and browser entry code under apps/app/src.",
-  "files": 312,
+  "files": 316,
   "findings": { "CL-01": 6, "CL-02": 4, "CL-03": 8, "CL-04": 6, "CL-05": 5 },
   "coverage": [
     {
@@ -104,7 +104,7 @@
     {
       "file": "src/app/_app.read.$id.tsx",
       "classification": "route",
-      "lines": 299,
+      "lines": 301,
       "status": "finding",
       "findings": ["CL-05"],
       "result": "Reviewed; contributes to CL-05."
@@ -136,7 +136,7 @@
     {
       "file": "src/app/_app.watch.$id.tsx",
       "classification": "route",
-      "lines": 74,
+      "lines": 76,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -1848,7 +1848,15 @@
     {
       "file": "src/lib/data/feed-items/pendingMutations.ts",
       "classification": "state-sync-persistence",
-      "lines": 100,
+      "lines": 111,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
+      "file": "src/lib/data/feed-page-retention.ts",
+      "classification": "state-sync-persistence",
+      "lines": 179,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -1936,7 +1944,15 @@
     {
       "file": "src/lib/data/mixed-content/mutations.ts",
       "classification": "state-sync-persistence",
-      "lines": 86,
+      "lines": 100,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
+      "file": "src/lib/data/mixed-content/page-retention.ts",
+      "classification": "state-sync-persistence",
+      "lines": 204,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -1944,7 +1960,7 @@
     {
       "file": "src/lib/data/mixed-content/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 325,
+      "lines": 378,
       "status": "finding",
       "findings": ["CL-01", "CL-02", "CL-04"],
       "result": "Reviewed; contributes to CL-01, CL-02, CL-04."
@@ -1953,6 +1969,14 @@
       "file": "src/lib/data/normalized-idb-storage.ts",
       "classification": "state-sync-persistence",
       "lines": 382,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
+      "file": "src/lib/data/page-retention.ts",
+      "classification": "state-sync-persistence",
+      "lines": 180,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -1976,7 +2000,7 @@
     {
       "file": "src/lib/data/store.ts",
       "classification": "state-sync-persistence",
-      "lines": 2021,
+      "lines": 2162,
       "status": "finding",
       "findings": ["CL-02", "CL-03", "CL-04"],
       "result": "Reviewed; contributes to CL-02, CL-03, CL-04."
@@ -1992,7 +2016,7 @@
     {
       "file": "src/lib/data/subscriptionCoordinator.ts",
       "classification": "state-sync-persistence",
-      "lines": 109,
+      "lines": 120,
       "status": "finding",
       "findings": ["CL-01"],
       "result": "Reviewed; contributes to CL-01."
@@ -2200,7 +2224,7 @@
     {
       "file": "src/lib/hooks/useItemWindow.ts",
       "classification": "hook",
-      "lines": 53,
+      "lines": 59,
       "status": "finding",
       "findings": ["CL-04"],
       "result": "Reviewed; contributes to CL-04."
@@ -2241,6 +2265,14 @@
       "file": "src/lib/hooks/useRefreshFeedItem.ts",
       "classification": "hook",
       "lines": 38,
+      "status": "clean",
+      "findings": [],
+      "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
+    },
+    {
+      "file": "src/lib/hooks/useRetentionPin.ts",
+      "classification": "hook",
+      "lines": 24,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."

--- a/apps/app/benchmarks/client-audit-coverage.json
+++ b/apps/app/benchmarks/client-audit-coverage.json
@@ -752,7 +752,7 @@
     {
       "file": "src/components/feed/MarkVisibleAsReadButton.tsx",
       "classification": "component",
-      "lines": 148,
+      "lines": 165,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -2456,7 +2456,7 @@
     {
       "file": "src/lib/undo/types.ts",
       "classification": "client-shared",
-      "lines": 7,
+      "lines": 8,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."
@@ -2464,7 +2464,7 @@
     {
       "file": "src/lib/undo/useUndoToast.tsx",
       "classification": "hook",
-      "lines": 29,
+      "lines": 41,
       "status": "clean",
       "findings": [],
       "result": "Reviewed; no independent data-volume, synchronization, persistence, network-fan-out, render-amplification, or memory-growth finding."

--- a/apps/app/benchmarks/results/browser-client-representative.json
+++ b/apps/app/benchmarks/results/browser-client-representative.json
@@ -1,304 +1,329 @@
 {
-  "generatedAt": "2026-07-31T21:29:43.177Z",
+  "generatedAt": "2026-07-31T22:34:32.138Z",
   "environment": "local-self-hosted-chromium",
   "profile": "representative",
   "coldLoad": {
-    "durationMs": 2791.7000000029802,
-    "usableContentMs": 586.7000000029802,
-    "longTasks": [57, 72],
+    "durationMs": 2780.5999999940395,
+    "usableContentMs": 577.2999999970198,
+    "longTasks": [55, 62],
     "commits": [
       {
-        "actualDuration": 19.299999997019768,
-        "baseDuration": 19.700000002980232
+        "actualDuration": 21.799999982118607,
+        "baseDuration": 21.99999998509884
       },
       {
-        "actualDuration": 2.2999999970197678,
-        "baseDuration": 19.799999997019768
+        "actualDuration": 2.000000014901161,
+        "baseDuration": 21.99999998509884
       },
       {
-        "actualDuration": 5.9000000059604645,
-        "baseDuration": 19.700000017881393
-      },
-      { "actualDuration": 0, "baseDuration": 19.700000017881393 },
-      {
-        "actualDuration": 5.9000000059604645,
-        "baseDuration": 19.50000001490116
-      },
-      { "actualDuration": 15.5, "baseDuration": 26.100000008940697 },
-      {
-        "actualDuration": 10.300000011920929,
-        "baseDuration": 26.30000002682209
+        "actualDuration": 5.200000002980232,
+        "baseDuration": 21.49999998509884
       },
       {
-        "actualDuration": 7.0999999940395355,
-        "baseDuration": 30.900000005960464
-      },
-      { "actualDuration": 18.5, "baseDuration": 32.30000004172325 },
-      {
-        "actualDuration": 6.199999988079071,
-        "baseDuration": 31.900000035762787
+        "actualDuration": 0.10000000894069672,
+        "baseDuration": 21.49999998509884
       },
       {
-        "actualDuration": 36.599999994039536,
-        "baseDuration": 45.200000032782555
+        "actualDuration": 5.4000000059604645,
+        "baseDuration": 21.69999998807907
       },
       {
-        "actualDuration": 8.200000002980232,
-        "baseDuration": 34.40000005066395
+        "actualDuration": 14.599999994039536,
+        "baseDuration": 24.499999955296516
       },
-      { "actualDuration": 0, "baseDuration": 34.40000005066395 },
-      { "actualDuration": 7, "baseDuration": 34.80000004172325 },
+      { "actualDuration": 10, "baseDuration": 24.89999993145466 },
+      { "actualDuration": 6.799999982118607, "baseDuration": 29.2999999076128 },
       {
-        "actualDuration": 19.700000002980232,
-        "baseDuration": 33.10000003874302
-      },
-      { "actualDuration": 1.5, "baseDuration": 33.000000044703484 },
-      {
-        "actualDuration": 21.700000002980232,
-        "baseDuration": 34.400000005960464
+        "actualDuration": 15.899999991059303,
+        "baseDuration": 29.799999952316284
       },
       {
-        "actualDuration": 1.7999999970197678,
-        "baseDuration": 34.10000002384186
-      },
-      { "actualDuration": 24.5, "baseDuration": 37.30000005662441 },
-      {
-        "actualDuration": 2.2999999970197678,
-        "baseDuration": 37.200000032782555
+        "actualDuration": 14.000000014901161,
+        "baseDuration": 37.19999997317791
       },
       {
-        "actualDuration": 30.799999997019768,
-        "baseDuration": 43.90000006556511
+        "actualDuration": 28.900000005960464,
+        "baseDuration": 37.79999999701977
       },
       {
-        "actualDuration": 8.200000002980232,
-        "baseDuration": 49.40000009536743
+        "actualDuration": 8.499999985098839,
+        "baseDuration": 29.400000005960464
+      },
+      { "actualDuration": 0, "baseDuration": 29.400000005960464 },
+      {
+        "actualDuration": 8.900000005960464,
+        "baseDuration": 31.399999976158142
       },
       {
-        "actualDuration": 2.4000000059604645,
-        "baseDuration": 51.50000008940697
+        "actualDuration": 9.300000011920929,
+        "baseDuration": 29.19999998807907
       },
       {
-        "actualDuration": 1.5999999940395355,
-        "baseDuration": 50.70000007748604
-      }
-    ],
-    "indexedDb": { "reads": 11, "writes": 1348 },
-    "requests": 618,
-    "transferBytes": 2174398,
-    "rpcRequests": 7,
-    "rpcTransferBytes": 1486959,
-    "heapBytes": 91700000
-  },
-  "warmHydration": {
-    "durationMs": 2755.6000000089407,
-    "usableContentMs": 549.1000000089407,
-    "longTasks": [203, 68],
-    "commits": [
-      { "actualDuration": 94.6000000089407, "baseDuration": 89.40000000596046 },
-      {
-        "actualDuration": 35.19999998807907,
-        "baseDuration": 51.69999994337559
+        "actualDuration": 1.5000000149011612,
+        "baseDuration": 29.099999994039536
       },
       {
-        "actualDuration": 10.400000005960464,
-        "baseDuration": 31.499999955296516
-      },
-      {
-        "actualDuration": 1.300000011920929,
-        "baseDuration": 31.599999949336052
-      },
-      { "actualDuration": 0, "baseDuration": 31.599999949336052 },
-      {
-        "actualDuration": 19.899999991059303,
-        "baseDuration": 25.799999952316284
-      },
-      {
-        "actualDuration": 16.299999997019768,
-        "baseDuration": 25.599999964237213
-      },
-      {
-        "actualDuration": 18.399999991059303,
-        "baseDuration": 24.69999995827675
-      },
-      {
-        "actualDuration": 2.9000000059604645,
-        "baseDuration": 25.799999952316284
-      },
-      {
-        "actualDuration": 1.2000000029802322,
-        "baseDuration": 25.999999970197678
-      },
-      {
-        "actualDuration": 26.00000001490116,
-        "baseDuration": 30.600000008940697
-      },
-      {
-        "actualDuration": 2.7000000029802322,
-        "baseDuration": 31.599999994039536
-      },
-      { "actualDuration": 0, "baseDuration": 31.599999994039536 },
-      {
-        "actualDuration": 27.19999998807907,
-        "baseDuration": 32.69999995827675
-      },
-      {
-        "actualDuration": 1.7999999970197678,
-        "baseDuration": 32.39999994635582
-      },
-      {
-        "actualDuration": 10.400000005960464,
-        "baseDuration": 31.39999994635582
-      },
-      {
-        "actualDuration": 0.7000000029802322,
-        "baseDuration": 31.299999952316284
-      },
-      {
-        "actualDuration": 2.2999999970197678,
-        "baseDuration": 33.19999995827675
-      }
-    ],
-    "indexedDb": { "reads": 1350, "writes": 345 },
-    "requests": 617,
-    "transferBytes": 1016563,
-    "rpcRequests": 6,
-    "rpcTransferBytes": 329124,
-    "heapBytes": 91700000
-  },
-  "reconnect": {
-    "durationMs": 3018,
-    "usableContentMs": null,
-    "longTasks": [90, 62, 56],
-    "commits": [
-      {
-        "actualDuration": 8.299999982118607,
-        "baseDuration": 40.19999994337559
+        "actualDuration": 15.099999994039536,
+        "baseDuration": 27.799999997019768
       },
       {
         "actualDuration": 1.4000000059604645,
-        "baseDuration": 39.299999952316284
-      },
-      { "actualDuration": 6, "baseDuration": 37.09999996423721 },
-      { "actualDuration": 78, "baseDuration": 89.19999995827675 },
-      {
-        "actualDuration": 59.20000000298023,
-        "baseDuration": 77.99999995529652
+        "baseDuration": 27.599999994039536
       },
       {
-        "actualDuration": 19.299999982118607,
-        "baseDuration": 33.3999999165535
+        "actualDuration": 15.900000005960464,
+        "baseDuration": 28.399999991059303
       },
       {
-        "actualDuration": 1.4999999850988388,
-        "baseDuration": 33.199999913573265
+        "actualDuration": 1.5999999940395355,
+        "baseDuration": 28.49999998509884
+      },
+      { "actualDuration": 12.899999991059303, "baseDuration": 27 },
+      { "actualDuration": 2, "baseDuration": 27.200000002980232 },
+      {
+        "actualDuration": 3.2999999970197678,
+        "baseDuration": 30.299999997019768
       },
       {
-        "actualDuration": 20.19999997317791,
-        "baseDuration": 32.29999992251396
-      },
-      { "actualDuration": 1.5, "baseDuration": 32.199999928474426 },
+        "actualDuration": 1.3999999910593033,
+        "baseDuration": 28.399999991059303
+      }
+    ],
+    "indexedDb": { "reads": 11, "writes": 1348 },
+    "requests": 622,
+    "transferBytes": 2175756,
+    "rpcRequests": 7,
+    "rpcTransferBytes": 1488317,
+    "heapBytes": 97400000
+  },
+  "warmHydration": {
+    "durationMs": 2729.5999999940395,
+    "usableContentMs": 522.1999999880791,
+    "longTasks": [184],
+    "commits": [
       {
-        "actualDuration": 7.199999988079071,
-        "baseDuration": 32.09999993443489
-      },
-      {
-        "actualDuration": 10.600000008940697,
-        "baseDuration": 33.09999996423721
-      },
-      { "actualDuration": 1.5, "baseDuration": 32.999999955296516 },
-      {
-        "actualDuration": 1.0999999940395355,
-        "baseDuration": 33.29999993741512
-      },
-      { "actualDuration": 0, "baseDuration": 33.29999993741512 },
-      {
-        "actualDuration": 2.5999999940395355,
-        "baseDuration": 35.499999940395355
+        "actualDuration": 84.69999998807907,
+        "baseDuration": 79.90000002086163
       },
       {
-        "actualDuration": 2.7000000029802322,
-        "baseDuration": 35.69999994337559
+        "actualDuration": 29.400000005960464,
+        "baseDuration": 42.599999979138374
+      },
+      { "actualDuration": 10.599999994039536, "baseDuration": 25 },
+      {
+        "actualDuration": 1.2999999970197678,
+        "baseDuration": 24.799999997019768
+      },
+      { "actualDuration": 0, "baseDuration": 24.799999997019768 },
+      { "actualDuration": 1.5, "baseDuration": 25.100000008940697 },
+      {
+        "actualDuration": 12.599999994039536,
+        "baseDuration": 18.80000001192093
+      },
+      {
+        "actualDuration": 10.700000017881393,
+        "baseDuration": 18.500000029802322
+      },
+      {
+        "actualDuration": 10.200000002980232,
+        "baseDuration": 19.10000005364418
+      },
+      {
+        "actualDuration": 1.6000000089406967,
+        "baseDuration": 18.800000086426735
+      },
+      {
+        "actualDuration": 9.599999979138374,
+        "baseDuration": 18.400000020861626
+      },
+      {
+        "actualDuration": 1.5999999940395355,
+        "baseDuration": 18.400000020861626
+      },
+      {
+        "actualDuration": 15.499999970197678,
+        "baseDuration": 21.69999997317791
+      },
+      {
+        "actualDuration": 1.9000000059604645,
+        "baseDuration": 22.00000001490116
+      },
+      { "actualDuration": 0, "baseDuration": 22.00000001490116 },
+      {
+        "actualDuration": 10.400000005960464,
+        "baseDuration": 22.500000059604645
+      },
+      {
+        "actualDuration": 1.300000011920929,
+        "baseDuration": 22.000000059604645
+      },
+      { "actualDuration": 4, "baseDuration": 21.700000077486038 },
+      {
+        "actualDuration": 0.09999999403953552,
+        "baseDuration": 21.700000062584877
+      },
+      { "actualDuration": 3.5, "baseDuration": 21.400000035762787 },
+      { "actualDuration": 0.5, "baseDuration": 21.30000004172325 },
+      {
+        "actualDuration": 4.700000002980232,
+        "baseDuration": 25.800000056624413
+      }
+    ],
+    "indexedDb": { "reads": 1350, "writes": 345 },
+    "requests": 621,
+    "transferBytes": 1017307,
+    "rpcRequests": 6,
+    "rpcTransferBytes": 329868,
+    "heapBytes": 97400000
+  },
+  "reconnect": {
+    "durationMs": 3021.8999999910593,
+    "usableContentMs": null,
+    "longTasks": [74],
+    "commits": [
+      {
+        "actualDuration": 10.400000005960464,
+        "baseDuration": 34.70000006258488
+      },
+      {
+        "actualDuration": 1.2999999970197678,
+        "baseDuration": 31.30000004172325
+      },
+      {
+        "actualDuration": 6.299999997019768,
+        "baseDuration": 27.200000032782555
+      },
+      {
+        "actualDuration": 60.69999997317791,
+        "baseDuration": 71.19999994337559
+      },
+      {
+        "actualDuration": 42.00000001490116,
+        "baseDuration": 58.20000000298023
+      },
+      {
+        "actualDuration": 8.299999997019768,
+        "baseDuration": 33.49999997019768
+      },
+      {
+        "actualDuration": 1.4000000059604645,
+        "baseDuration": 33.69999995827675
+      },
+      { "actualDuration": 13, "baseDuration": 30.30000001192093 },
+      {
+        "actualDuration": 1.3999999910593033,
+        "baseDuration": 30.200000002980232
+      },
+      { "actualDuration": 3.5, "baseDuration": 29.799999997019768 },
+      {
+        "actualDuration": 7.700000017881393,
+        "baseDuration": 28.400000020861626
+      },
+      { "actualDuration": 1.3999999910593033, "baseDuration": 28.5 },
+      {
+        "actualDuration": 0.4000000059604645,
+        "baseDuration": 28.50000001490116
+      },
+      { "actualDuration": 0, "baseDuration": 28.50000001490116 },
+      {
+        "actualDuration": 3.2000000029802322,
+        "baseDuration": 31.50000001490116
+      },
+      { "actualDuration": 3.5, "baseDuration": 31.80000001192093 },
+      {
+        "actualDuration": 3.2000000029802322,
+        "baseDuration": 31.50000001490116
       }
     ],
     "indexedDb": { "reads": 0, "writes": 345 },
     "requests": 7,
-    "transferBytes": 329900,
+    "transferBytes": 330644,
     "rpcRequests": 6,
-    "rpcTransferBytes": 329124,
-    "heapBytes": 91700000
+    "rpcTransferBytes": 329868,
+    "heapBytes": 97400000
   },
   "pagination": {
-    "durationMs": 2019.5,
+    "durationMs": 2019.2000000029802,
     "usableContentMs": null,
-    "longTasks": [124],
+    "longTasks": [104],
     "commits": [
       {
-        "actualDuration": 1.2999999970197678,
-        "baseDuration": 34.29999993741512
+        "actualDuration": 30.799999982118607,
+        "baseDuration": 56.49999998509884
       },
-      { "actualDuration": 36, "baseDuration": 62.999999925494194 },
-      { "actualDuration": 1, "baseDuration": 62.999999925494194 },
+      { "actualDuration": 0.5, "baseDuration": 56.3999999910593 },
       {
-        "actualDuration": 32.400000020861626,
-        "baseDuration": 58.39999996125698
-      },
-      { "actualDuration": 66.2000000178814, "baseDuration": 79.99999998509884 },
-      { "actualDuration": 20.5, "baseDuration": 34.39999996125698 },
-      {
-        "actualDuration": 15.600000008940697,
-        "baseDuration": 29.69999995827675
+        "actualDuration": 26.19999997317791,
+        "baseDuration": 51.49999998509884
       },
       {
-        "actualDuration": 7.4000000059604645,
-        "baseDuration": 29.19999995827675
-      },
-      { "actualDuration": 16, "baseDuration": 37.29999992251396 },
-      {
-        "actualDuration": 0.09999999403953552,
-        "baseDuration": 37.29999992251396
+        "actualDuration": 56.900000005960464,
+        "baseDuration": 72.30000001192093
       },
       {
-        "actualDuration": 2.2999999970197678,
-        "baseDuration": 38.29999992251396
+        "actualDuration": 14.400000005960464,
+        "baseDuration": 30.000000029802322
       },
-      { "actualDuration": 2.5, "baseDuration": 38.3999999165535 }
+      {
+        "actualDuration": 13.099999979138374,
+        "baseDuration": 28.900000020861626
+      },
+      {
+        "actualDuration": 7.200000002980232,
+        "baseDuration": 28.600000008940697
+      },
+      {
+        "actualDuration": 13.199999988079071,
+        "baseDuration": 34.80000001192093
+      },
+      {
+        "actualDuration": 0.19999998807907104,
+        "baseDuration": 34.80000001192093
+      },
+      {
+        "actualDuration": 2.8999999910593033,
+        "baseDuration": 34.400000005960464
+      },
+      {
+        "actualDuration": 4.5999999940395355,
+        "baseDuration": 36.099999994039536
+      }
     ],
     "indexedDb": { "reads": 0, "writes": 0 },
     "requests": 3,
-    "transferBytes": 23964,
+    "transferBytes": 23997,
     "rpcRequests": 1,
-    "rpcTransferBytes": 22467,
-    "heapBytes": 91700000
+    "rpcTransferBytes": 22500,
+    "heapBytes": 97400000
   },
   "reader": {
-    "durationMs": 232.90000000596046,
+    "durationMs": 230.19999998807907,
     "usableContentMs": null,
-    "longTasks": [201],
+    "longTasks": [198],
     "commits": [
       {
-        "actualDuration": 95.59999997913837,
-        "baseDuration": 119.49999991059303
+        "actualDuration": 101.39999997615814,
+        "baseDuration": 125.69999995827675
       },
-      { "actualDuration": 71.5, "baseDuration": 73.50000002980232 },
+      { "actualDuration": 67.7000000178814, "baseDuration": 69.49999998509884 },
       {
-        "actualDuration": 0.5999999940395355,
-        "baseDuration": 70.80000001192093
+        "actualDuration": 0.6000000089406967,
+        "baseDuration": 66.99999998509884
       },
-      { "actualDuration": 0, "baseDuration": 70.80000001192093 },
-      { "actualDuration": 3, "baseDuration": 29.69999998807907 },
-      { "actualDuration": 0.5, "baseDuration": 27.49999998509884 },
+      { "actualDuration": 0, "baseDuration": 66.99999998509884 },
       {
-        "actualDuration": 0.09999999403953552,
-        "baseDuration": 27.599999979138374
+        "actualDuration": 2.5999999940395355,
+        "baseDuration": 26.299999952316284
       },
-      { "actualDuration": 0, "baseDuration": 27.49999998509884 }
+      { "actualDuration": 0.5, "baseDuration": 24.399999976158142 },
+      { "actualDuration": 0, "baseDuration": 24.299999967217445 },
+      { "actualDuration": 0, "baseDuration": 24.299999967217445 }
     ],
     "indexedDb": { "reads": 0, "writes": 32 },
     "requests": 2,
-    "transferBytes": 0,
+    "transferBytes": 9,
     "rpcRequests": 2,
     "rpcTransferBytes": 0,
-    "heapBytes": 91700000
+    "heapBytes": 97400000
   }
 }

--- a/apps/app/benchmarks/results/client-representative.json
+++ b/apps/app/benchmarks/results/client-representative.json
@@ -10,8 +10,8 @@
   "persistedPayloadBytes": {
     "application": 4974404,
     "bookmarks": 525422,
-    "mixedContent": 101328,
-    "total": 5601154
+    "mixedContent": 157386,
+    "total": 5657212
   },
   "synchronizationBytes": {
     "request": 2743,
@@ -20,13 +20,42 @@
     "responseBudget": 262144
   },
   "persistenceMutationBytes": {
-    "measured": 9173,
+    "measured": 10881,
     "budget": 524288
+  },
+  "retention": {
+    "budgets": {
+      "memoryPages": 8,
+      "memoryBytes": 8388608,
+      "indexedDbPages": 6,
+      "indexedDbBytes": 4194304,
+      "mountedItems": 180
+    },
+    "afterTwelvePages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144790,
+      "retainedHeapBytes": 130203,
+      "persistedPages": 6,
+      "persistedBytes": 90038,
+      "mountedItems": 180
+    },
+    "afterTwentyFourPages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144773,
+      "retainedHeapBytes": 130248,
+      "persistedPages": 6,
+      "persistedBytes": 90070,
+      "mountedItems": 180
+    }
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 0.7958750000000236,
-      "heapDeltaBytes": 193544,
+      "durationMs": 1.1322500000001128,
+      "heapDeltaBytes": 565032,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -35,7 +64,7 @@
       "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 0.08062500000005457,
+      "durationMs": 0.1124170000000504,
       "heapDeltaBytes": 4624,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -45,7 +74,7 @@
       "authoritativeRefills": 0
     },
     "bookmarkCaptureEvent": {
-      "durationMs": 0.052500000000009095,
+      "durationMs": 0.05645800000002055,
       "heapDeltaBytes": 3816,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -55,8 +84,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 0.2514160000000629,
-      "heapDeltaBytes": 137360,
+      "durationMs": 0.482291000000032,
+      "heapDeltaBytes": 526760,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -65,8 +94,8 @@
       "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 0.19737499999996544,
-      "heapDeltaBytes": 60416,
+      "durationMs": 0.5172499999998763,
+      "heapDeltaBytes": 435400,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -75,8 +104,8 @@
       "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 0.14566599999989194,
-      "heapDeltaBytes": 4440,
+      "durationMs": 4.370749999999816,
+      "heapDeltaBytes": 4159160,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "feedItemProjectionNotifications": 0,
@@ -85,8 +114,8 @@
       "authoritativeRefills": 0
     },
     "feedProgressBurst": {
-      "durationMs": 0.1409169999999449,
-      "heapDeltaBytes": 379128,
+      "durationMs": 405.89883399999985,
+      "heapDeltaBytes": 26411776,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 100,
       "feedItemProjectionNotifications": 0,
@@ -95,8 +124,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 0.16620800000009694,
-      "heapDeltaBytes": 166168,
+      "durationMs": 0.1645419999999831,
+      "heapDeltaBytes": 166232,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -105,8 +134,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 0.2017919999998412,
-      "heapDeltaBytes": 702640,
+      "durationMs": 0.19087500000000546,
+      "heapDeltaBytes": 575456,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -115,7 +144,7 @@
       "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 0.21670800000015333,
+      "durationMs": 0.25854199999980665,
       "heapDeltaBytes": 210544,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -125,8 +154,8 @@
       "authoritativeRefills": 0
     },
     "warmSynchronization": {
-      "durationMs": 4.932833000000073,
-      "heapDeltaBytes": -19557728,
+      "durationMs": 3.5559579999999187,
+      "heapDeltaBytes": 8679464,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -135,8 +164,8 @@
       "authoritativeRefills": 0
     },
     "normalizedPersistenceMutation": {
-      "durationMs": 1.7465420000000904,
-      "heapDeltaBytes": 916768,
+      "durationMs": 1.7714169999999285,
+      "heapDeltaBytes": 922240,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,

--- a/apps/app/benchmarks/results/client-small.json
+++ b/apps/app/benchmarks/results/client-small.json
@@ -10,8 +10,8 @@
   "persistedPayloadBytes": {
     "application": 487535,
     "bookmarks": 51697,
-    "mixedContent": 36781,
-    "total": 576013
+    "mixedContent": 56984,
+    "total": 596216
   },
   "synchronizationBytes": {
     "request": 2743,
@@ -20,13 +20,42 @@
     "responseBudget": 262144
   },
   "persistenceMutationBytes": {
-    "measured": 9173,
+    "measured": 10881,
     "budget": 524288
+  },
+  "retention": {
+    "budgets": {
+      "memoryPages": 8,
+      "memoryBytes": 8388608,
+      "indexedDbPages": 6,
+      "indexedDbBytes": 4194304,
+      "mountedItems": 180
+    },
+    "afterTwelvePages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144790,
+      "retainedHeapBytes": 130203,
+      "persistedPages": 6,
+      "persistedBytes": 90038,
+      "mountedItems": 180
+    },
+    "afterTwentyFourPages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144773,
+      "retainedHeapBytes": 130248,
+      "persistedPages": 6,
+      "persistedBytes": 90070,
+      "mountedItems": 180
+    }
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 0.6906250000001819,
-      "heapDeltaBytes": 127416,
+      "durationMs": 0.8592499999999745,
+      "heapDeltaBytes": 270672,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -35,7 +64,7 @@
       "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 0.05075000000010732,
+      "durationMs": 0.07616699999994125,
       "heapDeltaBytes": 4624,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -45,8 +74,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkCaptureEvent": {
-      "durationMs": 0.030708000000004176,
-      "heapDeltaBytes": 3816,
+      "durationMs": 0.04395799999997507,
+      "heapDeltaBytes": 4832,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -55,8 +84,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 0.19404099999997015,
-      "heapDeltaBytes": 132112,
+      "durationMs": 0.3033339999999498,
+      "heapDeltaBytes": 282056,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -65,8 +94,8 @@
       "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 0.18937499999992724,
-      "heapDeltaBytes": 59864,
+      "durationMs": 0.2466669999998885,
+      "heapDeltaBytes": 195272,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -75,8 +104,8 @@
       "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 0.07904099999996106,
-      "heapDeltaBytes": 4440,
+      "durationMs": 0.3299170000000231,
+      "heapDeltaBytes": 1564144,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "feedItemProjectionNotifications": 0,
@@ -85,8 +114,8 @@
       "authoritativeRefills": 0
     },
     "feedProgressBurst": {
-      "durationMs": 0.7521669999998721,
-      "heapDeltaBytes": 143472,
+      "durationMs": 19.187415999999985,
+      "heapDeltaBytes": 16967376,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 100,
       "feedItemProjectionNotifications": 0,
@@ -95,7 +124,7 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 0.12158300000010058,
+      "durationMs": 0.14916699999980665,
       "heapDeltaBytes": 166080,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
@@ -105,8 +134,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 0.15675000000010186,
-      "heapDeltaBytes": 834912,
+      "durationMs": 0.18066699999985758,
+      "heapDeltaBytes": 585456,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -115,8 +144,8 @@
       "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 0.11779100000012477,
-      "heapDeltaBytes": 748496,
+      "durationMs": 0.10487499999999272,
+      "heapDeltaBytes": 309600,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -125,8 +154,8 @@
       "authoritativeRefills": 0
     },
     "warmSynchronization": {
-      "durationMs": 1.2537919999999758,
-      "heapDeltaBytes": 1956328,
+      "durationMs": 1.2450420000000122,
+      "heapDeltaBytes": 1831032,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -135,8 +164,8 @@
       "authoritativeRefills": 0
     },
     "normalizedPersistenceMutation": {
-      "durationMs": 0.13562499999989086,
-      "heapDeltaBytes": 51928,
+      "durationMs": 0.13416699999993398,
+      "heapDeltaBytes": 57344,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,

--- a/apps/app/benchmarks/results/client-stress.json
+++ b/apps/app/benchmarks/results/client-stress.json
@@ -10,8 +10,8 @@
   "persistedPayloadBytes": {
     "application": 25403859,
     "bookmarks": 2664299,
-    "mixedContent": 240894,
-    "total": 28309052
+    "mixedContent": 376209,
+    "total": 28444367
   },
   "synchronizationBytes": {
     "request": 2743,
@@ -20,13 +20,42 @@
     "responseBudget": 262144
   },
   "persistenceMutationBytes": {
-    "measured": 9173,
+    "measured": 10881,
     "budget": 524288
+  },
+  "retention": {
+    "budgets": {
+      "memoryPages": 8,
+      "memoryBytes": 8388608,
+      "indexedDbPages": 6,
+      "indexedDbBytes": 4194304,
+      "mountedItems": 180
+    },
+    "afterTwelvePages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144790,
+      "retainedHeapBytes": 130203,
+      "persistedPages": 6,
+      "persistedBytes": 90038,
+      "mountedItems": 180
+    },
+    "afterTwentyFourPages": {
+      "pages": 8,
+      "entities": 240,
+      "scopeReferences": 240,
+      "retainedBytes": 144773,
+      "retainedHeapBytes": 130248,
+      "persistedPages": 6,
+      "persistedBytes": 90070,
+      "mountedItems": 180
+    }
   },
   "operations": {
     "bookmarkSave": {
-      "durationMs": 0.7185829999998532,
-      "heapDeltaBytes": 133296,
+      "durationMs": 1.4760000000001128,
+      "heapDeltaBytes": 1063152,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -35,7 +64,7 @@
       "authoritativeRefills": 1
     },
     "bookmarkProgressEvent": {
-      "durationMs": 0.09129200000006676,
+      "durationMs": 0.12641700000017408,
       "heapDeltaBytes": 4624,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
@@ -45,8 +74,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkCaptureEvent": {
-      "durationMs": 0.0812909999999647,
-      "heapDeltaBytes": 3816,
+      "durationMs": 0.09487500000000182,
+      "heapDeltaBytes": 12896,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -55,8 +84,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkOrganizationChange": {
-      "durationMs": 0.2792909999998301,
-      "heapDeltaBytes": 155768,
+      "durationMs": 0.818000000000211,
+      "heapDeltaBytes": 1061848,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -65,8 +94,8 @@
       "authoritativeRefills": 2
     },
     "bookmarkDelete": {
-      "durationMs": 0.26516700000001947,
-      "heapDeltaBytes": 62216,
+      "durationMs": 0.8116250000000491,
+      "heapDeltaBytes": 961776,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -75,8 +104,8 @@
       "authoritativeRefills": 1
     },
     "feedProgressEvent": {
-      "durationMs": 0.12745799999993324,
-      "heapDeltaBytes": 6672,
+      "durationMs": 23.847917000000052,
+      "heapDeltaBytes": 16876160,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 1,
       "feedItemProjectionNotifications": 0,
@@ -85,8 +114,8 @@
       "authoritativeRefills": 0
     },
     "feedProgressBurst": {
-      "durationMs": 0.18170800000007148,
-      "heapDeltaBytes": 143384,
+      "durationMs": 2280.053208,
+      "heapDeltaBytes": 113311240,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 100,
       "feedItemProjectionNotifications": 0,
@@ -95,8 +124,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSingleFrame": {
-      "durationMs": 0.13512500000001637,
-      "heapDeltaBytes": 164480,
+      "durationMs": 0.14233299999978044,
+      "heapDeltaBytes": 164496,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -105,8 +134,8 @@
       "authoritativeRefills": 0
     },
     "bookmarkBurstSeparateFrames": {
-      "durationMs": 0.20570800000018608,
-      "heapDeltaBytes": 522376,
+      "durationMs": 0.2281250000005457,
+      "heapDeltaBytes": 560384,
       "bookmarkStoreNotifications": 100,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -115,8 +144,8 @@
       "authoritativeRefills": 0
     },
     "coldSynchronization": {
-      "durationMs": 1.0486249999999018,
-      "heapDeltaBytes": -32652360,
+      "durationMs": 0.7432079999998678,
+      "heapDeltaBytes": 717448,
       "bookmarkStoreNotifications": 1,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -125,8 +154,8 @@
       "authoritativeRefills": 0
     },
     "warmSynchronization": {
-      "durationMs": 18.72708300000022,
-      "heapDeltaBytes": 10261224,
+      "durationMs": 17.73308300000008,
+      "heapDeltaBytes": 10501992,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,
@@ -135,8 +164,8 @@
       "authoritativeRefills": 0
     },
     "normalizedPersistenceMutation": {
-      "durationMs": 9.912874999999985,
-      "heapDeltaBytes": 3873088,
+      "durationMs": 9.34625000000051,
+      "heapDeltaBytes": 3878344,
       "bookmarkStoreNotifications": 0,
       "feedItemStoreNotifications": 0,
       "feedItemProjectionNotifications": 0,

--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -24,6 +24,11 @@ import {
   computeChangedBookmarkSyncBuckets,
 } from "~/server/mixed-content/sync";
 import { NORMALIZED_ARRAY_CHUNK_SIZE } from "~/lib/data/normalized-idb-storage";
+import {
+  CLIENT_PAGE_RETENTION_BUDGETS,
+  getBoundedItemWindow,
+  selectPersistedPages,
+} from "~/lib/data/page-retention";
 
 const PAGE_SIZE = 30;
 const VISIBILITIES: VisibilityFilter[] = ["unread", "read", "later"];
@@ -66,6 +71,17 @@ export type ClientAuditResult = {
     measured: number;
     budget: number;
   };
+  retention: {
+    budgets: {
+      memoryPages: number;
+      memoryBytes: number;
+      indexedDbPages: number;
+      indexedDbBytes: number;
+      mountedItems: number;
+    };
+    afterTwelvePages: RetentionPlateauMetrics;
+    afterTwentyFourPages: RetentionPlateauMetrics;
+  };
   operations: {
     bookmarkSave: ClientAuditOperation;
     bookmarkProgressEvent: ClientAuditOperation;
@@ -80,6 +96,17 @@ export type ClientAuditResult = {
     warmSynchronization: ClientAuditOperation;
     normalizedPersistenceMutation: ClientAuditOperation;
   };
+};
+
+type RetentionPlateauMetrics = {
+  pages: number;
+  entities: number;
+  scopeReferences: number;
+  retainedBytes: number;
+  retainedHeapBytes: number;
+  persistedPages: number;
+  persistedBytes: number;
+  mountedItems: number;
 };
 
 function makeBookmark(index: number): ApplicationBookmark {
@@ -361,6 +388,75 @@ function persistedPayloadBytes() {
   };
 }
 
+function measureRetentionPlateau(pageCount: number): RetentionPlateauMetrics {
+  resetStores();
+  const scopeKey = "view:1:unread";
+  let requestCursor: { postedAt: Date; id: string } | null = null;
+  for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+    const pageItems = Array.from({ length: PAGE_SIZE }, (_, itemIndex) =>
+      makeFeedItem(pageIndex * PAGE_SIZE + itemIndex),
+    );
+    const state = feedItemsStore.getState();
+    feedItemsStore.setState({
+      feedItemsDict: {
+        ...state.feedItemsDict,
+        ...Object.fromEntries(pageItems.map((item) => [item.id, item])),
+      },
+      feedItemsOrder: [
+        ...state.feedItemsOrder,
+        ...pageItems.map((item) => item.id),
+      ],
+    });
+    const nextCursor = {
+      postedAt: pageItems[pageItems.length - 1]!.postedAt,
+      id: pageItems[pageItems.length - 1]!.id,
+    };
+    feedItemsStore.getState().retainFeedItemPage({
+      scopeKey,
+      itemIds: pageItems.map((item) => item.id),
+      requestCursor,
+      nextCursor,
+      replacesScope: pageIndex === 0,
+    });
+    requestCursor = nextCursor;
+  }
+
+  const state = feedItemsStore.getState();
+  const pages = state.retainedFeedPages[scopeKey] ?? [];
+  const persistedPages = selectPersistedPages(pages);
+  const persistedEntityIds = new Set(
+    persistedPages.flatMap((page) => page.entityIds),
+  );
+  const persistedBytes = serialize({
+    pages: persistedPages,
+    feedItems: Object.fromEntries(
+      Object.entries(state.feedItemsDict).filter(([id]) =>
+        persistedEntityIds.has(id),
+      ),
+    ),
+  }).byteLength;
+  const scopeReferences = state.scopeFeedItemIds[scopeKey] ?? [];
+  return {
+    pages: pages.length,
+    entities: Object.keys(state.feedItemsDict).length,
+    scopeReferences: scopeReferences.length,
+    retainedBytes: state.retainedFeedPageBytes,
+    retainedHeapBytes: serialize({
+      feedItemsDict: state.feedItemsDict,
+      feedItemsOrder: state.feedItemsOrder,
+      scopeReferences,
+      pages,
+    }).byteLength,
+    persistedPages: persistedPages.length,
+    persistedBytes,
+    mountedItems: getBoundedItemWindow({
+      itemIds: scopeReferences,
+      renderEnd: scopeReferences.length,
+      selectedItemId: null,
+    }).itemIds.length,
+  };
+}
+
 export function runClientAuditProfile(
   profileName: BenchmarkProfileName,
 ): ClientAuditResult {
@@ -517,6 +613,8 @@ export function runClientAuditProfile(
   const responsePageBytes = bookmarkSyncPages.map((page) =>
     Buffer.byteLength(JSON.stringify(page)),
   );
+  const afterTwelvePages = measureRetentionPlateau(12);
+  const afterTwentyFourPages = measureRetentionPlateau(24);
 
   return {
     profile: profileName,
@@ -537,6 +635,17 @@ export function runClientAuditProfile(
     persistenceMutationBytes: {
       measured: persistenceMutationBytes,
       budget: NORMALIZED_PERSISTENCE_MUTATION_BUDGET_BYTES,
+    },
+    retention: {
+      budgets: {
+        memoryPages: CLIENT_PAGE_RETENTION_BUDGETS.memory.maxPages,
+        memoryBytes: CLIENT_PAGE_RETENTION_BUDGETS.memory.maxBytes,
+        indexedDbPages: CLIENT_PAGE_RETENTION_BUDGETS.indexedDb.maxPages,
+        indexedDbBytes: CLIENT_PAGE_RETENTION_BUDGETS.indexedDb.maxBytes,
+        mountedItems: CLIENT_PAGE_RETENTION_BUDGETS.mountedItems,
+      },
+      afterTwelvePages,
+      afterTwentyFourPages,
     },
     operations: {
       bookmarkSave,

--- a/apps/app/src/app/_app.read.$id.tsx
+++ b/apps/app/src/app/_app.read.$id.tsx
@@ -44,6 +44,7 @@ import { useViewFeeds } from "~/lib/data/view-feeds/store";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { ArticleSidebars } from "~/components/feed/read/ArticleSidebars";
+import { useRetentionPin } from "~/lib/hooks/useRetentionPin";
 
 const parser = unified()
   .use(rehypeParse, { fragment: true })
@@ -67,6 +68,7 @@ export const Route = createFileRoute("/_app/read/$id")({
 function ReadPage() {
   const params = Route.useParams();
   const router = useRouter();
+  useRetentionPin("feed-item", params.id);
 
   const [articleStyle] = useFlagState("ARTICLE_STYLE");
 

--- a/apps/app/src/app/_app.watch.$id.tsx
+++ b/apps/app/src/app/_app.watch.$id.tsx
@@ -10,6 +10,7 @@ import useIsInactive from "~/lib/hooks/useIsInactive";
 import { useFeedItemValue } from "~/lib/data/store";
 import { useOpenOriginalShortcut } from "~/lib/hooks/useOpenOriginalShortcut";
 import { useRefreshFeedItem } from "~/lib/hooks/useRefreshFeedItem";
+import { useRetentionPin } from "~/lib/hooks/useRetentionPin";
 
 export const Route = createFileRoute("/_app/watch/$id")({
   component: WatchVideoPage,
@@ -17,6 +18,7 @@ export const Route = createFileRoute("/_app/watch/$id")({
 
 function WatchVideoPage() {
   const params = Route.useParams();
+  useRetentionPin("feed-item", params.id);
 
   const { view } = useView();
   const { zoom, isVertical } = useZoom();

--- a/apps/app/src/components/feed/MarkVisibleAsReadButton.tsx
+++ b/apps/app/src/components/feed/MarkVisibleAsReadButton.tsx
@@ -30,6 +30,12 @@ import {
   getFirstRenderedFeedItemId,
   useScrollToFeedItem,
 } from "~/lib/hooks/useScrollToFeedItem";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
+
+let nextUndoRetentionOwnerId = 0;
 
 export function MarkVisibleAsReadButton() {
   const [isLoading, setIsLoading] = useState(false);
@@ -76,11 +82,9 @@ export function MarkVisibleAsReadButton() {
 
       await bulkMutation.mutateAsync({ items, isWatched: true });
 
-      showUndoToast({
-        message: `Marked ${items.length} item${items.length === 1 ? "" : "s"} as read`,
-        onUndo: async () => {
-          await setBulkWatchedValue({ items, isWatched: false });
-        },
+      const undoRetentionOwner = `undo:mark-visible:${++nextUndoRetentionOwnerId}`;
+      setRetainedEntityPins(undoRetentionOwner, {
+        feedItemIds: items.map((item) => item.id),
       });
 
       // Determine active filter type (priority: feed > category > view)
@@ -89,26 +93,39 @@ export function MarkVisibleAsReadButton() {
 
       // Force one refill request after the mutation. Marking items as read can
       // make a previously exhausted page eligible for fresh unread content.
-      switch (activeFilterType) {
-        case "feed": {
-          await fetchMoreItemsForFeed(feedFilter, visibilityFilter, {
-            force: true,
-          });
-          break;
-        }
-        case "category": {
-          await fetchMoreItemsForCategory(categoryFilter, visibilityFilter, {
-            force: true,
-          });
-          break;
-        }
-        default: {
-          if (viewFilter?.id) {
-            await fetchMoreItems(viewFilter.id, visibilityFilter, {
+      try {
+        switch (activeFilterType) {
+          case "feed": {
+            await fetchMoreItemsForFeed(feedFilter, visibilityFilter, {
               force: true,
             });
+            break;
+          }
+          case "category": {
+            await fetchMoreItemsForCategory(categoryFilter, visibilityFilter, {
+              force: true,
+            });
+            break;
+          }
+          default: {
+            if (viewFilter?.id) {
+              await fetchMoreItems(viewFilter.id, visibilityFilter, {
+                force: true,
+              });
+            }
           }
         }
+      } finally {
+        // The refill response reflects the completed mark-as-read mutation.
+        // Exposing Undo afterward prevents a fast shortcut from restoring the
+        // item before that older response replaces the scope membership.
+        showUndoToast({
+          message: `Marked ${items.length} item${items.length === 1 ? "" : "s"} as read`,
+          onUndo: async () => {
+            await setBulkWatchedValue({ items, isWatched: false });
+          },
+          onDismiss: () => clearRetainedEntityPins(undoRetentionOwner),
+        });
       }
 
       selectFirstRenderedItem();

--- a/apps/app/src/lib/data/feed-items/pendingMutations.ts
+++ b/apps/app/src/lib/data/feed-items/pendingMutations.ts
@@ -1,4 +1,8 @@
 import type { ApplicationFeedItem } from "~/server/db/schema";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
 
 type PendingFieldOverride<T> = {
   token: object;
@@ -23,6 +27,9 @@ function setPendingFieldOverride<T>(
   pendingFeedItemOverrides.set(itemId, {
     ...pendingFeedItemOverrides.get(itemId),
     [field]: { token, value, updatedAt },
+  });
+  setRetainedEntityPins(`optimistic:feed-item:${itemId}`, {
+    feedItemIds: [itemId],
   });
   return token;
 }
@@ -66,6 +73,7 @@ export function clearPendingFeedItemOverride(
 
   if (Object.keys(nextOverrides).length === 0) {
     pendingFeedItemOverrides.delete(itemId);
+    clearRetainedEntityPins(`optimistic:feed-item:${itemId}`);
   } else {
     pendingFeedItemOverrides.set(itemId, nextOverrides);
   }
@@ -95,5 +103,8 @@ export function applyPendingFeedItemOverrides(item: ApplicationFeedItem) {
 }
 
 export function clearPendingFeedItemOverrides() {
+  for (const itemId of pendingFeedItemOverrides.keys()) {
+    clearRetainedEntityPins(`optimistic:feed-item:${itemId}`);
+  }
   pendingFeedItemOverrides.clear();
 }

--- a/apps/app/src/lib/data/feed-page-retention.ts
+++ b/apps/app/src/lib/data/feed-page-retention.ts
@@ -1,0 +1,178 @@
+import {
+  CLIENT_PAGE_RETENTION_BUDGETS,
+  cursorRetentionKey,
+  enforcePageRetention,
+  estimateRetainedBytes,
+  getRetainedEntityPins,
+  getRetainedPageMetrics,
+  selectPersistedPages,
+} from "./page-retention";
+import type { RetainedCursorPage } from "./page-retention";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+
+type RetainedFeedPageValue = {
+  itemIds: string[];
+};
+
+export type RetainedFeedPage = RetainedCursorPage<RetainedFeedPageValue>;
+
+export type RetainFeedItemPageInput = {
+  scopeKey: string;
+  itemIds: string[];
+  requestCursor: unknown;
+  nextCursor: unknown;
+  replacesScope: boolean;
+};
+
+export type FeedPageRetentionState = {
+  feedItemsDict: Record<string, ApplicationFeedItem>;
+  feedItemsOrder: string[];
+  scopeFeedItemIds: Record<string, string[]>;
+  retainedFeedPages: Record<string, RetainedFeedPage[]>;
+  retainedFeedPageBytes: number;
+  pageOwnedFeedItemIds: Record<string, true>;
+};
+
+function retainedPageBytes(
+  retainedFeedPages: Record<string, RetainedFeedPage[]>,
+) {
+  return Object.values(retainedFeedPages).reduce(
+    (total, pages) => total + getRetainedPageMetrics(pages).bytes,
+    0,
+  );
+}
+
+export function applyFeedItemPageRetention(
+  state: FeedPageRetentionState,
+  {
+    scopeKey,
+    itemIds,
+    requestCursor,
+    nextCursor,
+    replacesScope,
+  }: RetainFeedItemPageInput,
+): FeedPageRetentionState {
+  const sourcePages = replacesScope
+    ? []
+    : (state.retainedFeedPages[scopeKey] ?? []);
+  const requestCursorKey = cursorRetentionKey(requestCursor);
+  const nextCursorKey = cursorRetentionKey(nextCursor);
+  const key = `${requestCursorKey}->${nextCursorKey}`;
+  const existingIndex = sourcePages.findIndex((page) => page.key === key);
+  const existingPage =
+    existingIndex >= 0 ? sourcePages[existingIndex] : undefined;
+  const mergedItemIds = [
+    ...new Set([...(existingPage?.value.itemIds ?? []), ...itemIds]),
+  ];
+  const value = { itemIds: mergedItemIds };
+  const page: RetainedFeedPage = {
+    key,
+    requestCursorKey,
+    nextCursorKey,
+    entityIds: mergedItemIds,
+    value,
+    byteSize: estimateRetainedBytes(
+      mergedItemIds.flatMap((id) => {
+        const item = state.feedItemsDict[id];
+        return item ? [item] : [];
+      }),
+    ),
+    sequence:
+      existingPage?.sequence ??
+      Math.max(-1, ...sourcePages.map((candidate) => candidate.sequence)) + 1,
+  };
+  const candidatePages = [...sourcePages];
+  if (existingIndex >= 0) {
+    candidatePages[existingIndex] = page;
+  } else {
+    candidatePages.push(page);
+  }
+  const pinnedEntityIds = getRetainedEntityPins("feed-item");
+  const pages = enforcePageRetention({
+    pages: candidatePages,
+    budget: CLIENT_PAGE_RETENTION_BUDGETS.memory,
+    pinnedEntityIds,
+  });
+  const retainedFeedPages = {
+    ...state.retainedFeedPages,
+    [scopeKey]: pages,
+  };
+  const retainedEntityIds = new Set(
+    Object.values(retainedFeedPages).flatMap((scopePages) =>
+      scopePages.flatMap((candidate) => candidate.entityIds),
+    ),
+  );
+  const pageOwnedFeedItemIds = { ...state.pageOwnedFeedItemIds };
+  for (const id of itemIds) pageOwnedFeedItemIds[id] = true;
+
+  const feedItemsDict = { ...state.feedItemsDict };
+  for (const id of Object.keys(pageOwnedFeedItemIds)) {
+    if (retainedEntityIds.has(id) || pinnedEntityIds.has(id)) continue;
+    delete feedItemsDict[id];
+    delete pageOwnedFeedItemIds[id];
+  }
+  const existingScopeIds = replacesScope
+    ? []
+    : (state.scopeFeedItemIds[scopeKey] ?? []);
+  const targetScopeIds = [...new Set([...existingScopeIds, ...itemIds])];
+  const scopeFeedItemIds = Object.fromEntries(
+    Object.entries({
+      ...state.scopeFeedItemIds,
+      [scopeKey]: targetScopeIds,
+    }).map(([candidateScopeKey, ids]) => [
+      candidateScopeKey,
+      ids.filter((id) => feedItemsDict[id] !== undefined),
+    ]),
+  );
+  return {
+    retainedFeedPages,
+    retainedFeedPageBytes: retainedPageBytes(retainedFeedPages),
+    pageOwnedFeedItemIds,
+    feedItemsDict,
+    feedItemsOrder: state.feedItemsOrder.filter(
+      (id) => feedItemsDict[id] !== undefined,
+    ),
+    scopeFeedItemIds,
+  };
+}
+
+export function getPersistedFeedItemRetentionState(
+  state: FeedPageRetentionState,
+): FeedPageRetentionState {
+  const retainedFeedPages = Object.fromEntries(
+    Object.entries(state.retainedFeedPages).map(([scopeKey, pages]) => [
+      scopeKey,
+      selectPersistedPages(pages),
+    ]),
+  );
+  const persistedPageEntityIds = new Set(
+    Object.values(retainedFeedPages).flatMap((pages) =>
+      pages.flatMap((page) => page.entityIds),
+    ),
+  );
+  const pinnedEntityIds = getRetainedEntityPins("feed-item");
+  const shouldPersistItem = (id: string) =>
+    state.pageOwnedFeedItemIds[id] !== true ||
+    persistedPageEntityIds.has(id) ||
+    pinnedEntityIds.has(id);
+  const feedItemsDict = Object.fromEntries(
+    Object.entries(state.feedItemsDict).filter(([id]) => shouldPersistItem(id)),
+  );
+  return {
+    feedItemsDict,
+    feedItemsOrder: state.feedItemsOrder.filter(shouldPersistItem),
+    scopeFeedItemIds: Object.fromEntries(
+      Object.entries(state.scopeFeedItemIds).map(([scopeKey, ids]) => [
+        scopeKey,
+        ids.filter(shouldPersistItem),
+      ]),
+    ),
+    retainedFeedPages,
+    retainedFeedPageBytes: retainedPageBytes(retainedFeedPages),
+    pageOwnedFeedItemIds: Object.fromEntries(
+      Object.keys(state.pageOwnedFeedItemIds)
+        .filter((id) => shouldPersistItem(id))
+        .map((id) => [id, true as const]),
+    ),
+  };
+}

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -2,6 +2,10 @@ import { setBulkWatchedValue } from "../feed-items/mutations";
 import { bookmarksStore } from "../bookmarks/store";
 import { feedItemsStore } from "../store";
 import { viewsStore } from "../views/store";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "../page-retention";
 import { mixedContentStore } from "./store";
 import type { MixedContentReference } from "~/server/mixed-content/projection";
 import { orpcRouterClient } from "~/lib/orpc";
@@ -33,6 +37,12 @@ export async function setMixedReadValue(input: {
     .map((id) => bookmarksStore.getState().getBookmark(id))
     .filter((bookmark) => bookmark !== undefined);
   const now = new Date();
+
+  for (const bookmarkId of targets.bookmarkIds) {
+    setRetainedEntityPins(`optimistic:bookmark:${bookmarkId}`, {
+      bookmarkIds: [bookmarkId],
+    });
+  }
 
   for (const bookmark of previousBookmarks) {
     const optimisticBookmark = {
@@ -79,6 +89,10 @@ export async function setMixedReadValue(input: {
       });
     }
     throw error;
+  } finally {
+    for (const bookmarkId of targets.bookmarkIds) {
+      clearRetainedEntityPins(`optimistic:bookmark:${bookmarkId}`);
+    }
   }
 
   return targets;

--- a/apps/app/src/lib/data/mixed-content/page-retention.ts
+++ b/apps/app/src/lib/data/mixed-content/page-retention.ts
@@ -1,0 +1,203 @@
+import {
+  CLIENT_PAGE_RETENTION_BUDGETS,
+  cursorRetentionKey,
+  enforcePageRetention,
+  estimateRetainedBytes,
+  getRetainedEntityPins,
+  selectPersistedPages,
+} from "../page-retention";
+import type { RetainedCursorPage } from "../page-retention";
+import type { VisibilityFilter } from "../atoms";
+import type {
+  MixedContentCursor,
+  MixedContentPage,
+  MixedContentReference,
+  MixedContentScope,
+} from "~/server/mixed-content/projection";
+
+type MixedPageRetentionValue = {
+  referenceKeys: string[];
+};
+
+export type LoadedMixedScope = {
+  scope: MixedContentScope;
+  visibility: VisibilityFilter;
+  references: MixedContentReference[];
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>;
+  cursor: MixedContentCursor;
+  hasMore: boolean;
+};
+
+export type SuppressedReferences = Record<
+  string,
+  Record<string, MixedContentReference[]>
+>;
+
+export type PersistedMixedContentState = {
+  scopes: Record<string, LoadedMixedScope>;
+  suppressedReferences: SuppressedReferences;
+};
+
+export function mixedReferenceKey(reference: MixedContentReference) {
+  return `${reference.entityKind}:${reference.entityId}`;
+}
+
+export function retainedMixedReferenceKeys(
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>,
+) {
+  return new Set(pages.flatMap((page) => page.value.referenceKeys));
+}
+
+export function mergeRetainedMixedPage({
+  pages,
+  page,
+  requestCursor,
+  replacesScope,
+}: {
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>;
+  page: MixedContentPage;
+  requestCursor: unknown;
+  replacesScope: boolean;
+}) {
+  const sourcePages = replacesScope ? [] : pages;
+  const requestCursorKey = cursorRetentionKey(requestCursor);
+  const nextCursorKey = cursorRetentionKey(page.cursor);
+  const key = `${requestCursorKey}->${nextCursorKey}`;
+  const referenceKeys = page.references.map(mixedReferenceKey);
+  const existingIndex = sourcePages.findIndex(
+    (candidate) => candidate.key === key,
+  );
+  const sequence =
+    existingIndex >= 0
+      ? sourcePages[existingIndex]!.sequence
+      : Math.max(-1, ...sourcePages.map((candidate) => candidate.sequence)) + 1;
+  const value = { referenceKeys };
+  const retainedPage: RetainedCursorPage<MixedPageRetentionValue> = {
+    key,
+    requestCursorKey,
+    nextCursorKey,
+    entityIds: page.references.map((reference) => reference.entityId),
+    value,
+    byteSize: estimateRetainedBytes(value),
+    sequence,
+  };
+  const nextPages = [...sourcePages];
+  if (existingIndex >= 0) {
+    nextPages[existingIndex] = retainedPage;
+  } else {
+    nextPages.push(retainedPage);
+  }
+  return enforcePageRetention({
+    pages: nextPages,
+    budget: CLIENT_PAGE_RETENTION_BUDGETS.memory,
+    pinnedEntityIds: getMixedRetentionPins(),
+  });
+}
+
+export function updateBookmarkPageMembership(
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>,
+  bookmarkId: string,
+  isRetained: boolean,
+) {
+  const bookmarkKey = `bookmark:${bookmarkId}`;
+  const nextPages = pages.map((page) => {
+    const referenceKeys = page.value.referenceKeys.filter(
+      (key) => key !== bookmarkKey,
+    );
+    const value = { referenceKeys };
+    return {
+      ...page,
+      entityIds: page.entityIds.filter((id) => id !== bookmarkId),
+      value,
+      byteSize: estimateRetainedBytes(value),
+    };
+  });
+  if (!isRetained || nextPages.length === 0) return nextPages;
+
+  const latestPage = nextPages[nextPages.length - 1]!;
+  const value = {
+    referenceKeys: [...latestPage.value.referenceKeys, bookmarkKey],
+  };
+  nextPages[nextPages.length - 1] = {
+    ...latestPage,
+    entityIds: [...latestPage.entityIds, bookmarkId],
+    value,
+    byteSize: estimateRetainedBytes(value),
+  };
+  return nextPages;
+}
+
+export function getMixedRetentionPins() {
+  return new Set([
+    ...getRetainedEntityPins("feed-item"),
+    ...getRetainedEntityPins("bookmark"),
+  ]);
+}
+
+export function filterSuppressedReferences(
+  suppressedReferences: SuppressedReferences,
+  retainedKeysByScope: Record<string, ReadonlySet<string>>,
+  pinnedEntityIds: ReadonlySet<string> = new Set(),
+) {
+  return Object.fromEntries(
+    Object.entries(suppressedReferences).flatMap(
+      ([bookmarkId, referencesByScope]) => {
+        const nextReferencesByScope = Object.fromEntries(
+          Object.entries(referencesByScope).flatMap(
+            ([scopeKey, references]) => {
+              const retainedKeys = retainedKeysByScope[scopeKey];
+              const retainedReferences = retainedKeys
+                ? references.filter(
+                    (reference) =>
+                      retainedKeys.has(mixedReferenceKey(reference)) ||
+                      pinnedEntityIds.has(reference.entityId),
+                  )
+                : references;
+              return retainedReferences.length > 0
+                ? [[scopeKey, retainedReferences]]
+                : [];
+            },
+          ),
+        );
+        return Object.keys(nextReferencesByScope).length > 0
+          ? [[bookmarkId, nextReferencesByScope]]
+          : [];
+      },
+    ),
+  );
+}
+
+export function getPersistedMixedContentState(state: {
+  scopes: Record<string, LoadedMixedScope>;
+  suppressedReferences: SuppressedReferences;
+}): PersistedMixedContentState {
+  const scopes = Object.fromEntries(
+    Object.entries(state.scopes).map(([key, scope]) => {
+      const pages = selectPersistedPages(scope.pages);
+      const retainedKeys = retainedMixedReferenceKeys(pages);
+      return [
+        key,
+        {
+          ...scope,
+          pages,
+          references: scope.references.filter((reference) =>
+            retainedKeys.has(mixedReferenceKey(reference)),
+          ),
+        },
+      ];
+    }),
+  );
+  const retainedKeysByScope = Object.fromEntries(
+    Object.entries(scopes).map(([key, scope]) => [
+      key,
+      retainedMixedReferenceKeys(scope.pages),
+    ]),
+  );
+  return {
+    scopes,
+    suppressedReferences: filterSuppressedReferences(
+      state.suppressedReferences,
+      retainedKeysByScope,
+    ),
+  };
+}

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -18,7 +18,21 @@ import {
   replaceScopeInIndexes,
   uniqueReferences,
 } from "./bookmarkProjection";
-import type { LoadedMixedScope, ProjectionIndexes } from "./bookmarkProjection";
+import {
+  filterSuppressedReferences,
+  getMixedRetentionPins,
+  getPersistedMixedContentState,
+  mergeRetainedMixedPage,
+  mixedReferenceKey,
+  retainedMixedReferenceKeys,
+  updateBookmarkPageMembership,
+} from "./page-retention";
+import type { ProjectionIndexes } from "./bookmarkProjection";
+import type {
+  LoadedMixedScope,
+  PersistedMixedContentState,
+  SuppressedReferences,
+} from "./page-retention";
 import type { VisibilityFilter } from "../atoms";
 import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
 import type {
@@ -29,12 +43,7 @@ import type {
 } from "~/server/mixed-content/projection";
 
 export { getMixedScopeKey } from "./bookmarkProjection";
-export type { LoadedMixedScope } from "./bookmarkProjection";
-
-type SuppressedReferences = Record<
-  string,
-  Record<string, MixedContentReference[]>
->;
+export type { LoadedMixedScope } from "./page-retention";
 
 type MixedContentStore = {
   scopes: Record<string, LoadedMixedScope>;
@@ -62,7 +71,7 @@ type MixedContentStore = {
 };
 
 const vanillaMixedContentStore = createStore<MixedContentStore>()(
-  persist(
+  persist<MixedContentStore, [], [], PersistedMixedContentState>(
     (set, get) => ({
       scopes: {},
       suppressedReferences: {},
@@ -79,6 +88,15 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
         const key = getMixedScopeKey(scope, visibility);
         const current = get();
         const existing = current.scopes[key];
+        const requestCursor = replacesScope ? null : existing?.cursor;
+        const pages = mergeRetainedMixedPage({
+          pages: existing?.pages ?? [],
+          page,
+          requestCursor,
+          replacesScope,
+        });
+        const retainedKeys = retainedMixedReferenceKeys(pages);
+        const pinnedEntityIds = getMixedRetentionPins();
         const nextScope = {
           scope,
           visibility,
@@ -86,7 +104,12 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             replacesScope
               ? page.references
               : [...(existing?.references ?? []), ...page.references],
+          ).filter(
+            (reference) =>
+              retainedKeys.has(mixedReferenceKey(reference)) ||
+              pinnedEntityIds.has(reference.entityId),
           ),
+          pages,
           cursor: page.cursor,
           hasMore: page.hasMore,
         };
@@ -103,7 +126,16 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             feedItems,
           });
         }
-        set({ scopes, projectionIndexes, projectionIndexesComplete: true });
+        set({
+          scopes,
+          suppressedReferences: filterSuppressedReferences(
+            current.suppressedReferences,
+            { [key]: retainedKeys },
+            pinnedEntityIds,
+          ),
+          projectionIndexes,
+          projectionIndexesComplete: true,
+        });
       },
       reprojectUpsert: ({ bookmark, previousBookmark, feedItems, views }) => {
         if (!isBookmarkProjectionChange(previousBookmark, bookmark)) return [];
@@ -201,7 +233,19 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           references = uniqueReferences(references);
           if (referencesEqual(scopeState.references, references)) continue;
 
-          const nextScope = { ...scopeState, references };
+          const nextScope = {
+            ...scopeState,
+            references,
+            pages: updateBookmarkPageMembership(
+              scopeState.pages,
+              bookmark.id,
+              references.some(
+                (reference) =>
+                  reference.entityKind === "bookmark" &&
+                  reference.entityId === bookmark.id,
+              ),
+            ),
+          };
           if (scopes === current.scopes) scopes = { ...current.scopes };
           scopes[key] = nextScope;
           replaceScopeInIndexes({
@@ -266,7 +310,15 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           ]);
           if (referencesEqual(scopeState.references, references)) continue;
 
-          const nextScope = { ...scopeState, references };
+          const nextScope = {
+            ...scopeState,
+            references,
+            pages: updateBookmarkPageMembership(
+              scopeState.pages,
+              bookmarkId,
+              false,
+            ),
+          };
           if (scopes === current.scopes) scopes = { ...current.scopes };
           scopes[key] = nextScope;
           replaceScopeInIndexes({
@@ -301,14 +353,15 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
       storage: createNormalizedIDBStorage({
         recordFields: ["scopes", "suppressedReferences"],
       }),
-      partialize: (state) => ({
-        scopes: state.scopes,
-        suppressedReferences: state.suppressedReferences,
-      }),
+      partialize: getPersistedMixedContentState,
       merge: (persistedState, currentState) => {
-        const persisted = persistedState as
-          Partial<MixedContentStore> | undefined;
-        const scopes = persisted?.scopes ?? {};
+        const persisted = persistedState as Partial<MixedContentStore>;
+        const scopes = Object.fromEntries(
+          Object.entries(persisted?.scopes ?? {}).map(([key, scope]) => [
+            key,
+            { ...scope, pages: scope.pages ?? [] },
+          ]),
+        );
         return {
           ...currentState,
           ...(persisted ?? {}),

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -38,7 +38,6 @@ import type { ApplicationFeedItem, ApplicationView } from "~/server/db/schema";
 import type {
   ApplicationBookmark,
   MixedContentPage,
-  MixedContentReference,
   MixedContentScope,
 } from "~/server/mixed-content/projection";
 

--- a/apps/app/src/lib/data/page-retention.ts
+++ b/apps/app/src/lib/data/page-retention.ts
@@ -1,0 +1,179 @@
+export type RetainedCursorPage<T> = {
+  key: string;
+  requestCursorKey: string;
+  nextCursorKey: string;
+  entityIds: string[];
+  value: T;
+  byteSize: number;
+  sequence: number;
+};
+
+export type PageRetentionBudget = {
+  maxPages: number;
+  maxBytes: number;
+  navigationBufferPages: number;
+};
+
+export const CLIENT_PAGE_RETENTION_BUDGETS = {
+  memory: {
+    maxPages: 8,
+    maxBytes: 8 * 1_024 * 1_024,
+    navigationBufferPages: 2,
+  },
+  indexedDb: {
+    maxPages: 6,
+    maxBytes: 4 * 1_024 * 1_024,
+    navigationBufferPages: 0,
+  },
+  mountedItems: 180,
+} as const satisfies {
+  memory: PageRetentionBudget;
+  indexedDb: PageRetentionBudget;
+  mountedItems: number;
+};
+
+type RetentionPins = {
+  feedItemIds: Set<string>;
+  bookmarkIds: Set<string>;
+};
+
+const pinsByOwner = new Map<string, RetentionPins>();
+
+function sortedPages<T>(pages: Array<RetainedCursorPage<T>>) {
+  return [...pages].sort(
+    (left, right) =>
+      left.sequence - right.sequence || left.key.localeCompare(right.key),
+  );
+}
+
+export function getRetainedPageMetrics<T>(pages: Array<RetainedCursorPage<T>>) {
+  const entityIds = new Set(pages.flatMap((page) => page.entityIds));
+  return {
+    pages: pages.length,
+    entities: entityIds.size,
+    bytes: pages.reduce((total, page) => total + page.byteSize, 0),
+  };
+}
+
+export function enforcePageRetention<T>({
+  pages,
+  budget,
+  pinnedEntityIds,
+}: {
+  pages: Array<RetainedCursorPage<T>>;
+  budget: PageRetentionBudget;
+  pinnedEntityIds: ReadonlySet<string>;
+}) {
+  const retained = sortedPages(pages);
+  if (retained.length === 0) return retained;
+
+  const protectedKeys = new Set(
+    retained
+      .slice(-Math.max(1, budget.navigationBufferPages + 1))
+      .map((page) => page.key),
+  );
+  for (const page of retained) {
+    if (page.entityIds.some((id) => pinnedEntityIds.has(id))) {
+      protectedKeys.add(page.key);
+    }
+  }
+
+  let metrics = getRetainedPageMetrics(retained);
+  while (
+    retained.length > 0 &&
+    (metrics.pages > budget.maxPages || metrics.bytes > budget.maxBytes)
+  ) {
+    const evictionIndex = retained.findIndex(
+      (page) => !protectedKeys.has(page.key),
+    );
+    if (evictionIndex < 0) break;
+    retained.splice(evictionIndex, 1);
+    metrics = getRetainedPageMetrics(retained);
+  }
+
+  return retained;
+}
+
+export function selectPersistedPages<T>(
+  pages: Array<RetainedCursorPage<T>>,
+  budget: PageRetentionBudget = CLIENT_PAGE_RETENTION_BUDGETS.indexedDb,
+) {
+  return enforcePageRetention({
+    pages,
+    budget,
+    pinnedEntityIds: new Set<string>(),
+  });
+}
+
+function normalizeForRetentionKey(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalizeForRetentionKey);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, normalizeForRetentionKey(child)]),
+    );
+  }
+  return value;
+}
+
+export function cursorRetentionKey(cursor: unknown) {
+  return cursor == null
+    ? "root"
+    : JSON.stringify(normalizeForRetentionKey(cursor));
+}
+
+export function estimateRetainedBytes(value: unknown) {
+  return new TextEncoder().encode(
+    JSON.stringify(normalizeForRetentionKey(value)),
+  ).byteLength;
+}
+
+export function getBoundedItemWindow({
+  itemIds,
+  renderEnd,
+  selectedItemId,
+  maxMountedItems = CLIENT_PAGE_RETENTION_BUDGETS.mountedItems,
+}: {
+  itemIds: string[];
+  renderEnd: number;
+  selectedItemId: string | null;
+  maxMountedItems?: number;
+}) {
+  let end = Math.min(Math.max(renderEnd, 0), itemIds.length);
+  let start = Math.max(0, end - maxMountedItems);
+  const selectedIndex = selectedItemId ? itemIds.indexOf(selectedItemId) : -1;
+  if (selectedIndex >= 0 && (selectedIndex < start || selectedIndex >= end)) {
+    start = selectedIndex;
+    end = Math.min(itemIds.length, start + maxMountedItems);
+    start = Math.max(0, end - maxMountedItems);
+  }
+  return { start, end, itemIds: itemIds.slice(start, end) };
+}
+
+export function setRetainedEntityPins(
+  owner: string,
+  pins: {
+    feedItemIds?: Iterable<string>;
+    bookmarkIds?: Iterable<string>;
+  },
+) {
+  pinsByOwner.set(owner, {
+    feedItemIds: new Set(pins.feedItemIds),
+    bookmarkIds: new Set(pins.bookmarkIds),
+  });
+}
+
+export function clearRetainedEntityPins(owner: string) {
+  pinsByOwner.delete(owner);
+}
+
+export function getRetainedEntityPins(kind: "feed-item" | "bookmark") {
+  const ids = new Set<string>();
+  for (const pins of pinsByOwner.values()) {
+    const source = kind === "feed-item" ? pins.feedItemIds : pins.bookmarkIds;
+    for (const id of source) ids.add(id);
+  }
+  return ids;
+}

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -7,6 +7,10 @@ import { getDataSubscriptionClientId } from "./clientChannel";
 import { contentCategoriesStore } from "./content-categories/store";
 import { createSelectorHooks } from "./createSelectorHooks";
 import { feedCategoriesStore } from "./feed-categories/store";
+import {
+  applyFeedItemPageRetention,
+  getPersistedFeedItemRetentionState,
+} from "./feed-page-retention";
 import { mergeFeedItem } from "./feed-items/mergeFeedItem";
 import { hasFeedItemListProjectionChanged } from "./feed-items/listProjection";
 import { clearPendingFeedItemOverrides } from "./feed-items/pendingMutations";
@@ -23,6 +27,10 @@ import {
 } from "./scopeMembership";
 import { viewFeedsStore } from "./view-feeds/store";
 import { viewsStore } from "./views/store";
+import type {
+  RetainedFeedPage,
+  RetainFeedItemPageInput,
+} from "./feed-page-retention";
 import type { VisibilityFilter } from "./atoms";
 import type { FetchFeedsStatus } from "~/server/rss/fetchFeeds";
 import type { ApplicationFeedItem } from "~/server/db/schema";
@@ -125,10 +133,17 @@ export type ApplicationStore = {
   feedItemsDict: Record<string, ApplicationFeedItem>;
   feedItemProjectionRevision: number;
   scopeFeedItemIds: Record<string, string[]>;
+  retainedFeedPages: Record<string, RetainedFeedPage[]>;
+  retainedFeedPageBytes: number;
+  pageOwnedFeedItemIds: Record<string, true>;
+  retainFeedItemPage: (input: RetainFeedItemPageInput) => void;
   feedStatusDict: Record<number, FetchFeedsStatus>;
   setFeedItemsDict: (itemsDict: Record<string, ApplicationFeedItem>) => void;
   setFeedItem: (id: string, item: ApplicationFeedItem) => void;
-  setFeedItems: (items: ApplicationFeedItem[]) => void;
+  setFeedItems: (
+    items: ApplicationFeedItem[],
+    retention?: RetainFeedItemPageInput,
+  ) => void;
   fetchFeedItemsForFeed: (feedId: number) => Promise<void>;
   fetchNewData: () => Promise<void>;
   revalidateView: (viewId: number) => Promise<void>;
@@ -205,6 +220,17 @@ export type ApplicationStore = {
   scheduleFulltextFetch: () => void;
 };
 
+function getPersistedApplicationState(state: ApplicationStore) {
+  const retainedState = getPersistedFeedItemRetentionState(state);
+  return {
+    ...retainedState,
+    currentViewId: state.currentViewId,
+    viewFeedIds: state.viewFeedIds,
+    hasInitialData: state.hasInitialData,
+    fetchFeedItemsLastFetchedAt: state.fetchFeedItemsLastFetchedAt,
+  };
+}
+
 const vanillaApplicationStore = createStore<ApplicationStore>()(
   persist(
     (set, get) => ({
@@ -215,6 +241,9 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           feedItemsDict: {},
           feedItemProjectionRevision: get().feedItemProjectionRevision + 1,
           scopeFeedItemIds: {},
+          retainedFeedPages: {},
+          retainedFeedPageBytes: 0,
+          pageOwnedFeedItemIds: {},
           feedStatusDict: {},
           fetchFeedItemsLastFetchedAt: null,
           hasInitialData: false,
@@ -238,6 +267,11 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
       feedItemsDict: {},
       feedItemProjectionRevision: 0,
       scopeFeedItemIds: {},
+      retainedFeedPages: {},
+      retainedFeedPageBytes: 0,
+      pageOwnedFeedItemIds: {},
+      retainFeedItemPage: (input) =>
+        set(applyFeedItemPageRetention(get(), input)),
       feedStatusDict: {},
       setFeedItemsDict: (itemsDict) =>
         set({
@@ -267,7 +301,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             : state.scopeFeedItemIds,
         });
       },
-      setFeedItems: (items) => {
+      setFeedItems: (items, retention) => {
         if (items.length === 0) return;
 
         const state = get();
@@ -283,20 +317,30 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           feedItemsDict[item.id] = item;
         }
 
-        set({
+        const scopeFeedItemIds =
+          projectionChangedItems.length > 0
+            ? reconcileScopeMembershipsForItems(
+                state.scopeFeedItemIds,
+                projectionChangedItems,
+              )
+            : state.scopeFeedItemIds;
+        const projectionState = {
+          ...state,
           feedItemsDict,
           feedItemProjectionRevision:
             projectionChangedItems.length > 0
               ? state.feedItemProjectionRevision + 1
               : state.feedItemProjectionRevision,
-          scopeFeedItemIds:
-            projectionChangedItems.length > 0
-              ? reconcileScopeMembershipsForItems(
-                  state.scopeFeedItemIds,
-                  projectionChangedItems,
-                )
-              : state.scopeFeedItemIds,
-        });
+          scopeFeedItemIds,
+        };
+        set(
+          retention
+            ? {
+                ...projectionState,
+                ...applyFeedItemPageRetention(projectionState, retention),
+              }
+            : projectionState,
+        );
       },
       fetchFeedItemsLastFetchedAt: null,
       hasInitialData: false,
@@ -457,6 +501,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 },
               },
             });
+            get().retainFeedItemPage({
+              scopeKey: getFeedItemScopeKey("view", viewId, visibilityFilter),
+              itemIds: chunk.feedItems.map((item) => item.id),
+              requestCursor: null,
+              nextCursor: chunk.nextCursor,
+              replacesScope: chunk.replacesScope === true,
+            });
           }
 
           // Mark visibility filter as fetched
@@ -588,6 +639,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                   },
                 },
               },
+            });
+            get().retainFeedItemPage({
+              scopeKey: getFeedItemScopeKey("view", viewId, visibilityFilter),
+              itemIds: chunk.feedItems.map((item) => item.id),
+              requestCursor: paginationState.cursor,
+              nextCursor: chunk.nextCursor,
+              replacesScope: chunk.replacesScope === true,
             });
           }
         } catch (error) {
@@ -1239,6 +1297,15 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 }
 
                 set(updates);
+                if (viewId !== undefined) {
+                  get().retainFeedItemPage({
+                    scopeKey: getFeedItemScopeKey("view", viewId, vf),
+                    itemIds: getServerItemIdsFromDiff(initialChunk.diff),
+                    requestCursor: null,
+                    nextCursor: initialChunk.cursor,
+                    replacesScope: true,
+                  });
+                }
                 break;
               }
 
@@ -1332,6 +1399,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 }
 
                 set(updates);
+                get().retainFeedItemPage({
+                  scopeKey: getFeedItemScopeKey("view", viewId, vf),
+                  itemIds: initialChunk.items.map((item) => item.id),
+                  requestCursor: null,
+                  nextCursor: initialChunk.cursor,
+                  replacesScope: true,
+                });
 
                 // Schedule a debounced fulltext fetch
                 if (hasNewPending) {
@@ -1455,6 +1529,10 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 isFetching: false,
               };
               const scopeKey = getFeedItemScopeKey("view", chunk.viewId, vf);
+              const requestCursor =
+                chunk.replacesScope === true
+                  ? null
+                  : get().viewPaginationState[chunk.viewId]?.[vf]?.cursor;
 
               set({
                 feedItemsDict,
@@ -1482,6 +1560,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                   ]),
                 },
               });
+              get().retainFeedItemPage({
+                scopeKey,
+                itemIds: getServerItemIdsFromDiff(chunk.diff),
+                requestCursor,
+                nextCursor: chunk.cursor,
+                replacesScope: chunk.replacesScope === true,
+              });
               break;
             }
 
@@ -1491,14 +1576,20 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 
               const visibilityFilter =
                 chunk.visibilityFilter as VisibilityFilter;
+              const scopeKey = getFeedItemScopeKey(
+                "view",
+                chunk.viewId,
+                visibilityFilter,
+              );
+              const requestCursor =
+                chunk.replacesScope === true
+                  ? null
+                  : get().viewPaginationState[chunk.viewId]?.[visibilityFilter]
+                      ?.cursor;
               set({
                 scopeFeedItemIds: applyMergedScopeMembershipUpdate({
                   scopeFeedItemIds: get().scopeFeedItemIds,
-                  scopeKey: getFeedItemScopeKey(
-                    "view",
-                    chunk.viewId,
-                    visibilityFilter,
-                  ),
+                  scopeKey,
                   itemIds: chunk.feedItems.map((item) => item.id),
                   replace: chunk.replacesScope === true,
                   feedItemsDict: get().feedItemsDict,
@@ -1523,6 +1614,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                   ]),
                 },
               });
+              get().retainFeedItemPage({
+                scopeKey,
+                itemIds: chunk.feedItems.map((item) => item.id),
+                requestCursor,
+                nextCursor: chunk.nextCursor,
+                replacesScope: chunk.replacesScope === true,
+              });
             }
             break;
           }
@@ -1538,14 +1636,20 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 
             // Update pagination state for this feed/visibility filter
             const visibilityFilter = chunk.visibilityFilter as VisibilityFilter;
+            const scopeKey = getFeedItemScopeKey(
+              "feed",
+              chunk.feedId,
+              visibilityFilter,
+            );
+            const requestCursor =
+              chunk.replacesScope === true
+                ? null
+                : get().feedPaginationState[chunk.feedId]?.[visibilityFilter]
+                    ?.cursor;
             set({
               scopeFeedItemIds: applyMergedScopeMembershipUpdate({
                 scopeFeedItemIds: get().scopeFeedItemIds,
-                scopeKey: getFeedItemScopeKey(
-                  "feed",
-                  chunk.feedId,
-                  visibilityFilter,
-                ),
+                scopeKey,
                 itemIds: chunk.feedItems.map((item) => item.id),
                 replace: chunk.replacesScope === true,
                 feedItemsDict: get().feedItemsDict,
@@ -1570,6 +1674,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 ]),
               },
             });
+            get().retainFeedItemPage({
+              scopeKey,
+              itemIds: chunk.feedItems.map((item) => item.id),
+              requestCursor,
+              nextCursor: chunk.nextCursor,
+              replacesScope: chunk.replacesScope === true,
+            });
             break;
           }
 
@@ -1584,14 +1695,21 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 
             // Update pagination state for this category/visibility filter
             const visibilityFilter = chunk.visibilityFilter as VisibilityFilter;
+            const scopeKey = getFeedItemScopeKey(
+              "category",
+              chunk.categoryId,
+              visibilityFilter,
+            );
+            const requestCursor =
+              chunk.replacesScope === true
+                ? null
+                : get().categoryPaginationState[chunk.categoryId]?.[
+                    visibilityFilter
+                  ]?.cursor;
             set({
               scopeFeedItemIds: applyMergedScopeMembershipUpdate({
                 scopeFeedItemIds: get().scopeFeedItemIds,
-                scopeKey: getFeedItemScopeKey(
-                  "category",
-                  chunk.categoryId,
-                  visibilityFilter,
-                ),
+                scopeKey,
                 itemIds: chunk.feedItems.map((item) => item.id),
                 replace: chunk.replacesScope === true,
                 feedItemsDict: get().feedItemsDict,
@@ -1615,6 +1733,13 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                   visibilityFilter,
                 ]),
               },
+            });
+            get().retainFeedItemPage({
+              scopeKey,
+              itemIds: chunk.feedItems.map((item) => item.id),
+              requestCursor,
+              nextCursor: chunk.nextCursor,
+              replacesScope: chunk.replacesScope === true,
             });
             break;
           }
@@ -1740,6 +1865,22 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             }
 
             set(updates);
+            for (const payload of pendingInitialViewDiffs) {
+              const chunk = payload.chunk;
+              const visibilityFilter =
+                chunk.visibilityFilter as VisibilityFilter;
+              get().retainFeedItemPage({
+                scopeKey: getFeedItemScopeKey(
+                  "view",
+                  chunk.viewId,
+                  visibilityFilter,
+                ),
+                itemIds: getServerItemIdsFromDiff(chunk.diff),
+                requestCursor: null,
+                nextCursor: chunk.cursor,
+                replacesScope: true,
+              });
+            }
             pendingInitialViewDiffs = [];
           }
 
@@ -1908,17 +2049,17 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
         arrayFields: ["feedItemsOrder"],
       }),
       version: 1,
-      partialize: (state) => ({
-        feedItemsDict: state.feedItemsDict,
-        feedItemsOrder: state.feedItemsOrder,
-        currentViewId: state.currentViewId,
-        viewFeedIds: state.viewFeedIds,
-        hasInitialData: state.hasInitialData,
-        fetchFeedItemsLastFetchedAt: state.fetchFeedItemsLastFetchedAt,
-      }),
+      partialize: getPersistedApplicationState,
       merge: (persisted, current) => {
         const persistedState = persisted as Partial<ApplicationStore>;
-        const merged = { ...current, ...persistedState };
+        const merged = {
+          ...current,
+          ...persistedState,
+          scopeFeedItemIds: persistedState.scopeFeedItemIds ?? {},
+          retainedFeedPages: persistedState.retainedFeedPages ?? {},
+          retainedFeedPageBytes: persistedState.retainedFeedPageBytes ?? 0,
+          pageOwnedFeedItemIds: persistedState.pageOwnedFeedItemIds ?? {},
+        };
 
         // Cross-reference hydrated feed items against the feeds store's
         // cached feed list. If a feed was deleted on another client and that

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -2051,7 +2051,8 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
       version: 1,
       partialize: getPersistedApplicationState,
       merge: (persisted, current) => {
-        const persistedState = persisted as Partial<ApplicationStore>;
+        const persistedState =
+          (persisted as Partial<ApplicationStore> | undefined) ?? {};
         const merged = {
           ...current,
           ...persistedState,

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -1,6 +1,6 @@
 import { bookmarksStore } from "./bookmarks/store";
 import { feedItemsStore } from "./store";
-import { mixedContentStore } from "./mixed-content/store";
+import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
 import { viewsStore } from "./views/store";
 import type { LoadedMixedScope } from "./mixed-content/store";
 import type { PublishedChunk } from "~/server/api/publisher";
@@ -57,8 +57,19 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
   for (const payload of payloads) {
     if (payload.source === "mixed") {
       const { chunk } = payload;
+      const scopeKey = getMixedScopeKey(chunk.scope, chunk.visibility);
+      const requestCursor =
+        chunk.replacesScope === true
+          ? null
+          : mixedContentStore.getState().scopes[scopeKey]?.cursor;
       bookmarksStore.getState().upsertMany(chunk.page.bookmarks);
-      feedItemsStore.getState().setFeedItems(chunk.page.feedItems);
+      feedItemsStore.getState().setFeedItems(chunk.page.feedItems, {
+        scopeKey: `mixed:${scopeKey}`,
+        itemIds: chunk.page.feedItems.map((item) => item.id),
+        requestCursor,
+        nextCursor: chunk.page.cursor,
+        replacesScope: chunk.replacesScope,
+      });
       mixedContentStore.getState().applyPage({
         scope: chunk.scope,
         visibility: chunk.visibility,

--- a/apps/app/src/lib/hooks/useItemWindow.ts
+++ b/apps/app/src/lib/hooks/useItemWindow.ts
@@ -3,6 +3,11 @@
 import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { selectedItemIdAtom } from "~/lib/data/atoms";
+import {
+  clearRetainedEntityPins,
+  getBoundedItemWindow,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
 import { getSavedHomeRenderedItemCount } from "~/lib/scroll";
 import { ITEMS_PER_PAGE } from "~/server/api/constants";
 
@@ -29,24 +34,25 @@ export function useItemWindow(itemIds: string[], listKey: string) {
     }
   }, [itemIds, listKey]);
 
-  const visibleItems = itemIds.slice(0, renderCount);
-
   // Auto-expand window if keyboard navigation selects an item outside the
   // visible range so scroll-to-item always finds a DOM node.
   const selectedItemId = useAtomValue(selectedItemIdAtom);
+  const itemWindow = getBoundedItemWindow({
+    itemIds,
+    renderEnd: renderCount,
+    selectedItemId,
+  });
+  const visibleItems = itemWindow.itemIds;
+
   useEffect(() => {
-    if (!selectedItemId) return;
-    const index = itemIds.indexOf(selectedItemId);
-    if (index >= 0 && index >= renderCount) {
-      setRenderCount((prev) =>
-        Math.min(Math.max(prev, index + ITEMS_PER_PAGE), itemIds.length),
-      );
-    }
-  }, [selectedItemId, itemIds, renderCount]);
+    const owner = `visible-list:${listKey}`;
+    setRetainedEntityPins(owner, { feedItemIds: visibleItems });
+    return () => clearRetainedEntityPins(owner);
+  }, [listKey, visibleItems]);
 
   const expandWindow = useCallback((itemCount: number) => {
     setRenderCount((prev) => Math.min(prev + ITEMS_PER_PAGE, itemCount));
   }, []);
 
-  return { visibleItems, expandWindow, renderCount };
+  return { visibleItems, expandWindow, renderCount: itemWindow.end };
 }

--- a/apps/app/src/lib/hooks/useRetentionPin.ts
+++ b/apps/app/src/lib/hooks/useRetentionPin.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
+
+export function useRetentionPin(
+  entityKind: "feed-item" | "bookmark",
+  entityId: string,
+  reason: "reader" | "optimistic" = "reader",
+) {
+  useEffect(() => {
+    const owner = `${reason}:${entityKind}:${entityId}`;
+    setRetainedEntityPins(owner, {
+      ...(entityKind === "feed-item"
+        ? { feedItemIds: [entityId] }
+        : { bookmarkIds: [entityId] }),
+    });
+    return () => clearRetainedEntityPins(owner);
+  }, [entityId, entityKind, reason]);
+}

--- a/apps/app/src/lib/undo/types.ts
+++ b/apps/app/src/lib/undo/types.ts
@@ -1,6 +1,7 @@
 export interface UndoAction {
   message: string;
   onUndo: () => void | Promise<void>;
+  onDismiss?: () => void;
 }
 
 export const UNDO_TOAST_DURATION_MS = 10_000;

--- a/apps/app/src/lib/undo/useUndoToast.tsx
+++ b/apps/app/src/lib/undo/useUndoToast.tsx
@@ -8,21 +8,33 @@ import type { UndoAction } from "./types";
 
 export function showUndoToast(action: UndoAction) {
   const state = undoStore.getState();
+  let isFinalized = false;
+  let toastId: string | number | null = null;
+
+  const finalize = () => {
+    if (isFinalized) return;
+    isFinalized = true;
+
+    try {
+      action.onDismiss?.();
+    } finally {
+      const currentState = undoStore.getState();
+      if (currentState.activeToastId === toastId) {
+        currentState.clearActiveUndo();
+      }
+    }
+  };
 
   if (state.activeToastId !== null) {
     toast.dismiss(state.activeToastId);
   }
   state.clearActiveUndo();
 
-  const toastId = toast.custom(
-    (t) => <UndoToast toastId={t} action={action} />,
-    {
-      duration: UNDO_TOAST_DURATION_MS,
-      onDismiss: () => {
-        undoStore.getState().clearActiveUndo();
-      },
-    },
-  );
+  toastId = toast.custom((t) => <UndoToast toastId={t} action={action} />, {
+    duration: UNDO_TOAST_DURATION_MS,
+    onDismiss: finalize,
+    onAutoClose: finalize,
+  });
 
   undoStore.getState().setActiveUndo(action, toastId);
 }

--- a/apps/app/tests/unit/data/feed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/feed-page-retention.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
+import { feedItemsStore } from "~/lib/data/store";
+
+const SCOPE_KEY = "view:7:unread";
+
+function makeItem(pageIndex: number, itemIndex: number): ApplicationFeedItem {
+  const id = `page-${pageIndex}-item-${itemIndex}`;
+  const date = new Date(Date.UTC(2026, 0, 1, 0, pageIndex, itemIndex));
+  return {
+    id,
+    feedId: 7,
+    contentId: id,
+    title: id,
+    author: "Serial test",
+    url: `https://example.com/${id}`,
+    thumbnail: "",
+    content: `<p>${id}</p>`,
+    contentSnippet: id,
+    isWatched: false,
+    isWatchLater: false,
+    progress: 0,
+    duration: 1,
+    orientation: "horizontal",
+    platform: "website",
+    postedAt: date,
+    createdAt: date,
+    updatedAt: date,
+    isWatchedUpdatedAt: null,
+    isWatchLaterUpdatedAt: null,
+    contentHash: id,
+  };
+}
+
+function seedAndRetainPages(pageCount: number) {
+  const items = Array.from({ length: pageCount }, (_page, pageIndex) =>
+    Array.from({ length: 30 }, (_item, itemIndex) =>
+      makeItem(pageIndex, itemIndex),
+    ),
+  );
+  feedItemsStore.setState({
+    feedItemsDict: Object.fromEntries(
+      items.flat().map((item) => [item.id, item]),
+    ),
+    feedItemsOrder: items.flat().map((item) => item.id),
+  });
+  for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+    feedItemsStore.getState().retainFeedItemPage({
+      scopeKey: SCOPE_KEY,
+      itemIds: items[pageIndex]!.map((item) => item.id),
+      requestCursor: pageIndex === 0 ? null : { id: `cursor-${pageIndex - 1}` },
+      nextCursor: { id: `cursor-${pageIndex}` },
+      replacesScope: pageIndex === 0,
+    });
+  }
+}
+
+afterEach(() => {
+  feedItemsStore.getState().reset();
+  clearRetainedEntityPins("reader:test");
+});
+
+describe("Feed-item page retention", () => {
+  it("plateaus pages, entities, scope references, and retained bytes", () => {
+    seedAndRetainPages(12);
+
+    const state = feedItemsStore.getState();
+    expect(state.retainedFeedPages[SCOPE_KEY]).toHaveLength(8);
+    expect(state.scopeFeedItemIds[SCOPE_KEY]).toHaveLength(240);
+    expect(Object.keys(state.feedItemsDict)).toHaveLength(240);
+    expect(state.retainedFeedPageBytes).toBeGreaterThan(0);
+    expect(state.scopeFeedItemIds[SCOPE_KEY]).not.toContain("page-0-item-0");
+    expect(state.scopeFeedItemIds[SCOPE_KEY]).toContain("page-11-item-29");
+  });
+
+  it("does not collect an entity pinned by an open reader", () => {
+    setRetainedEntityPins("reader:test", {
+      feedItemIds: ["page-0-item-0"],
+    });
+
+    seedAndRetainPages(12);
+
+    const state = feedItemsStore.getState();
+    expect(state.retainedFeedPages[SCOPE_KEY]).toHaveLength(8);
+    expect(state.feedItemsDict["page-0-item-0"]).toBeDefined();
+    expect(state.feedItemsDict["page-1-item-0"]).toBeUndefined();
+  });
+});

--- a/apps/app/tests/unit/data/mixed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/mixed-page-retention.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type {
+  MixedContentCursor,
+  MixedContentReference,
+} from "~/server/mixed-content/projection";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
+import {
+  getMixedScopeKey,
+  mixedContentStore,
+} from "~/lib/data/mixed-content/store";
+
+const SCOPE = { type: "view" as const, viewId: 7 };
+
+function cursor(index: number): Exclude<MixedContentCursor, null> {
+  return {
+    sectionPlacement: null,
+    normalizedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)),
+    entityKind: "feed-item",
+    entityId: `feed-item-${index}`,
+  };
+}
+
+function references(pageIndex: number): MixedContentReference[] {
+  return Array.from({ length: 30 }, (_, itemIndex) => ({
+    entityKind: "feed-item" as const,
+    entityId: `page-${pageIndex}-item-${itemIndex}`,
+    sectionPlacement: null,
+    normalizedAt: new Date(Date.UTC(2026, 0, 1, 0, pageIndex, itemIndex)),
+  }));
+}
+
+function applyPages(count: number) {
+  for (let pageIndex = 0; pageIndex < count; pageIndex++) {
+    mixedContentStore.getState().applyPage({
+      scope: SCOPE,
+      visibility: "unread",
+      page: {
+        references: references(pageIndex),
+        bookmarks: [],
+        feedItems: [],
+        cursor: cursor(pageIndex),
+        hasMore: true,
+      },
+      replacesScope: pageIndex === 0,
+      feedItems: {},
+    });
+  }
+}
+
+afterEach(() => {
+  mixedContentStore.getState().reset();
+  clearRetainedEntityPins("reader:test");
+});
+
+describe("mixed-content page retention", () => {
+  it("plateaus cursor pages and scope references during repeated pagination", () => {
+    applyPages(12);
+
+    const scope =
+      mixedContentStore.getState().scopes[getMixedScopeKey(SCOPE, "unread")];
+
+    expect(scope?.pages).toHaveLength(8);
+    expect(scope?.references).toHaveLength(240);
+    expect(
+      scope?.references.some(({ entityId }) => entityId.startsWith("page-0-")),
+    ).toBe(false);
+    expect(
+      scope?.references.some(({ entityId }) => entityId.startsWith("page-11-")),
+    ).toBe(true);
+  });
+
+  it("keeps an open reader entity while evicting an otherwise distant page", () => {
+    setRetainedEntityPins("reader:test", {
+      feedItemIds: ["page-0-item-0"],
+    });
+
+    applyPages(12);
+
+    const scope =
+      mixedContentStore.getState().scopes[getMixedScopeKey(SCOPE, "unread")];
+    expect(scope?.pages).toHaveLength(8);
+    expect(
+      scope?.references.some(({ entityId }) => entityId === "page-0-item-0"),
+    ).toBe(true);
+    expect(
+      scope?.references.some(({ entityId }) => entityId.startsWith("page-1-")),
+    ).toBe(false);
+  });
+});

--- a/apps/app/tests/unit/data/page-retention.test.ts
+++ b/apps/app/tests/unit/data/page-retention.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { RetainedCursorPage } from "~/lib/data/page-retention";
+import {
+  enforcePageRetention,
+  getBoundedItemWindow,
+  getRetainedPageMetrics,
+  selectPersistedPages,
+} from "~/lib/data/page-retention";
+
+function makePage(index: number, byteSize = 100): RetainedCursorPage<string> {
+  return {
+    key: `cursor-${index}`,
+    requestCursorKey: index === 0 ? "root" : `cursor-${index - 1}`,
+    nextCursorKey: `cursor-${index}`,
+    entityIds: [`item-${index}`],
+    value: `page-${index}`,
+    byteSize,
+    sequence: index,
+  };
+}
+
+describe("client page retention", () => {
+  it("keeps the newest cursor-addressable navigation window within count and byte budgets", () => {
+    const pages = Array.from({ length: 12 }, (_, index) => makePage(index));
+
+    const retained = enforcePageRetention({
+      pages,
+      budget: {
+        maxPages: 8,
+        maxBytes: 1_000,
+        navigationBufferPages: 2,
+      },
+      pinnedEntityIds: new Set(),
+    });
+
+    expect(retained.map((page) => page.key)).toEqual([
+      "cursor-4",
+      "cursor-5",
+      "cursor-6",
+      "cursor-7",
+      "cursor-8",
+      "cursor-9",
+      "cursor-10",
+      "cursor-11",
+    ]);
+    expect(getRetainedPageMetrics(retained)).toEqual({
+      pages: 8,
+      entities: 8,
+      bytes: 800,
+    });
+  });
+
+  it("retains pinned entities and the measured navigation buffer before the newest page", () => {
+    const pages = Array.from({ length: 10 }, (_, index) => makePage(index));
+
+    const retained = enforcePageRetention({
+      pages,
+      budget: {
+        maxPages: 4,
+        maxBytes: 10_000,
+        navigationBufferPages: 2,
+      },
+      pinnedEntityIds: new Set(["item-1"]),
+    });
+
+    expect(retained.map((page) => page.key)).toEqual([
+      "cursor-1",
+      "cursor-7",
+      "cursor-8",
+      "cursor-9",
+    ]);
+  });
+
+  it("lets pins exceed a hard budget instead of evicting an open or optimistic entity", () => {
+    const pages = [makePage(0, 400), makePage(1, 400), makePage(2, 400)];
+
+    const retained = enforcePageRetention({
+      pages,
+      budget: {
+        maxPages: 1,
+        maxBytes: 300,
+        navigationBufferPages: 1,
+      },
+      pinnedEntityIds: new Set(["item-0"]),
+    });
+
+    expect(retained.map((page) => page.key)).toEqual([
+      "cursor-0",
+      "cursor-1",
+      "cursor-2",
+    ]);
+  });
+
+  it("persists only the newest complete pages that fit the IndexedDB budget", () => {
+    const pages = Array.from({ length: 6 }, (_, index) => makePage(index, 100));
+
+    const persisted = selectPersistedPages(pages, {
+      maxPages: 3,
+      maxBytes: 250,
+      navigationBufferPages: 0,
+    });
+
+    expect(persisted.map((page) => page.key)).toEqual(["cursor-4", "cursor-5"]);
+    expect(getRetainedPageMetrics(persisted).bytes).toBe(200);
+  });
+
+  it("keeps mounted list entities inside a fixed window and includes keyboard selection", () => {
+    const itemIds = Array.from({ length: 300 }, (_, index) => `item-${index}`);
+
+    expect(
+      getBoundedItemWindow({
+        itemIds,
+        renderEnd: 240,
+        selectedItemId: null,
+        maxMountedItems: 180,
+      }),
+    ).toEqual({
+      start: 60,
+      end: 240,
+      itemIds: itemIds.slice(60, 240),
+    });
+    expect(
+      getBoundedItemWindow({
+        itemIds,
+        renderEnd: 240,
+        selectedItemId: "item-20",
+        maxMountedItems: 180,
+      }),
+    ).toEqual({
+      start: 20,
+      end: 200,
+      itemIds: itemIds.slice(20, 200),
+    });
+  });
+});

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -38,6 +38,7 @@ describe("client performance audit model", () => {
         authoritativeRefills: 0,
       });
     },
+    30_000,
   );
 
   it("retains bounded list references while identifying whole-cache persistence", () => {
@@ -94,7 +95,7 @@ describe("client performance audit model", () => {
     expect(
       result.operations.normalizedPersistenceMutation.durationMs,
     ).toBeLessThan(50);
-  });
+  }, 30_000);
 
   it("plateaus repeated pagination within memory, IndexedDB, and mounted-item budgets", () => {
     const result = runClientAuditProfile("small");

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -95,4 +95,38 @@ describe("client performance audit model", () => {
       result.operations.normalizedPersistenceMutation.durationMs,
     ).toBeLessThan(50);
   });
+
+  it("plateaus repeated pagination within memory, IndexedDB, and mounted-item budgets", () => {
+    const result = runClientAuditProfile("small");
+
+    expect(result.retention.afterTwentyFourPages.pages).toBe(
+      result.retention.afterTwelvePages.pages,
+    );
+    expect(result.retention.afterTwentyFourPages.entities).toBe(
+      result.retention.afterTwelvePages.entities,
+    );
+    expect(result.retention.afterTwentyFourPages.scopeReferences).toBe(
+      result.retention.afterTwelvePages.scopeReferences,
+    );
+    expect(result.retention.afterTwentyFourPages.pages).toBeLessThanOrEqual(
+      result.retention.budgets.memoryPages,
+    );
+    expect(
+      result.retention.afterTwentyFourPages.retainedBytes,
+    ).toBeLessThanOrEqual(result.retention.budgets.memoryBytes);
+    expect(
+      result.retention.afterTwentyFourPages.retainedHeapBytes,
+    ).toBeLessThanOrEqual(
+      result.retention.afterTwelvePages.retainedHeapBytes + 1_024,
+    );
+    expect(
+      result.retention.afterTwentyFourPages.persistedPages,
+    ).toBeLessThanOrEqual(result.retention.budgets.indexedDbPages);
+    expect(
+      result.retention.afterTwentyFourPages.persistedBytes,
+    ).toBeLessThanOrEqual(result.retention.budgets.indexedDbBytes);
+    expect(
+      result.retention.afterTwentyFourPages.mountedItems,
+    ).toBeLessThanOrEqual(result.retention.budgets.mountedItems);
+  });
 });


### PR DESCRIPTION
## Summary

- add deterministic count and byte budgets for Feed-item and mixed-content cursor pages in memory and normalized IndexedDB persistence
- pin visible, optimistic, and open-reader entities while keeping mounted lists capped at 180 items
- preserve the batched synchronization and change-aware projection seams already on beta

## Evidence

- stress retention plateaus at 8 pages, 240 entities, 240 scope references, and about 145 KB after both 12 and 24 pages
- persisted retention plateaus at 6 pages and about 90 KB
- representative Chromium audit passes cold load, warm hydration, reconnect, pagination, and reader rendering

## Validation

- 40 unit files / 214 tests
- typecheck and formatting
- client-audit coverage freshness and small/representative/stress profiles
- lint with zero errors (30 pre-existing warnings)
- production Vite build and service-worker generation
- React Doctor changed scope: 100/100, no findings
- self-hosted client performance Playwright audit