### PR TITLE
Remove generated benchmark artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,8 @@ data/libsql
 playwright-report
 test-results
 .playwright-mcp
+
+# generated benchmark evidence (local-only; durable evidence belongs in ../agents)
+/apps/app/benchmarks/**/*.json
+/apps/app/benchmarks/**/*.md
+!/apps/app/benchmarks/README.md

--- a/apps/app/benchmarks/README.md
+++ b/apps/app/benchmarks/README.md
@@ -7,9 +7,8 @@ latency are at most `1.5 ×` the matching production operation. A bounded page
 must also stay bounded by driver-observed materialized rows. Timing noise is a
 reason to improve the experiment, never to raise the ceiling.
 
-The original benchmark checkpoint recorded the full-library mixed projection
-as a failure. The retained local small, representative, and stress artifacts
-now record the bounded remediation and pass every warm/cold visibility cell.
+The harness keeps the comparison and structural gates executable without
+requiring generated reports in source control. Result files are local-only.
 
 ## Run from a clean checkout
 
@@ -115,17 +114,6 @@ section metadata required by the current production operation. The allowance
 therefore permits one additional bounded Bookmark page, not the user's entire
 Bookmark or Feed-item collection.
 
-## Remediated local evidence
-
-The retained 2026-07-31 artifacts pass every measured cell without averaging
-across workloads:
-
-| Profile        | Median ratio range | p95 ratio range | Candidate max rows | Structural budget |
-| -------------- | -----------------: | --------------: | -----------------: | ----------------: |
-| small          |         1.24–1.38× |      1.21–1.47× |              61–73 |               100 |
-| representative |         1.15–1.31× |      1.19–1.33× |                 75 |               198 |
-| stress         |         1.19–1.32× |      1.17–1.38× |                 75 |               408 |
-
 The structural regression suite separately locks first and cursor View pages,
 Tag pages, point publication lookups, maximum 500-Bookmark bulk updates, and
 the selected Bookmark ordering index. Capture, ownership, organization,
@@ -135,15 +123,15 @@ exists.
 
 ## Which evidence runs where
 
-| Environment or tool                          | Role                                                                                          | Gate status                                                                                     |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| local file libSQL/SQLite                     | Fast iteration, fixture validation, deterministic statement/row guards, query-plan inspection | Structural guards are hard CI candidates; latency is diagnostic                                 |
-| `turso dev`                                  | Exercises the libSQL network protocol and driver transfer on a developer machine              | Required before performance-ticket closure; artifact retained                                   |
-| Dedicated networked Turso benchmark database | Production-like latency, transfer, and tail evidence                                          | Median and p95 1.5× gate; manual or scheduled because shared-network noise must be controlled   |
-| `EXPLAIN QUERY PLAN`                         | Index use, full scans, temp sorting, correlated-subquery evidence                             | Review evidence; plan changes are interpreted, not reduced to a brittle text snapshot           |
-| Driver instrumentation                       | SQL count, DB duration, and materialized rows                                                 | Statement/row limits are deterministic structural gates                                         |
-| Browser profiler                             | Hydration, synchronization, cache mutation, rendering, long tasks, and heap growth            | Production Chromium budgets are hard gates; development measurements remain diagnostic          |
-| CI                                           | Fixture/model tests, inventory freshness, then bounded statement/row guards                   | Hard and deterministic; hosted timing is retained but does not replace scheduled Turso evidence |
+| Environment or tool                          | Role                                                                                          | Gate status                                                                                   |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| local file libSQL/SQLite                     | Fast iteration, fixture validation, deterministic statement/row guards, query-plan inspection | Structural guards are hard CI candidates; latency is diagnostic                               |
+| `turso dev`                                  | Exercises the libSQL network protocol and driver transfer on a developer machine              | Required before performance-ticket closure; output stays local or is attached to the ticket   |
+| Dedicated networked Turso benchmark database | Production-like latency, transfer, and tail evidence                                          | Median and p95 1.5× gate; manual or scheduled because shared-network noise must be controlled |
+| `EXPLAIN QUERY PLAN`                         | Index use, full scans, temp sorting, correlated-subquery evidence                             | Review evidence; plan changes are interpreted, not reduced to a brittle text snapshot         |
+| Driver instrumentation                       | SQL count, DB duration, and materialized rows                                                 | Statement/row limits are deterministic structural gates                                       |
+| Browser profiler                             | Hydration, synchronization, cache mutation, rendering, long tasks, and heap growth            | Production Chromium budgets are hard gates; development measurements remain diagnostic        |
+| CI                                           | Fixture/model tests, current-source inventory checks, then bounded statement/row guards       | Hard and deterministic; hosted timing does not replace scheduled Turso evidence               |
 
 For `turso dev` or a remote target, provision and migrate a dedicated benchmark
 database first. The runner refuses external seeding without the explicit safety
@@ -159,7 +147,7 @@ pnpm benchmark:app --profile representative --cache all \
 For a hosted database, add `--auth-token <token>` and keep credentials outside
 artifacts and version control.
 
-## Production baseline and retained artifacts
+## Production baseline and local outputs
 
 The pre-Bookmark production reference is `090d075f`. The executable baseline is
 the preserved Feed View-page behavior that Bookmark mixed pages extend. Before
@@ -167,7 +155,7 @@ accepting a new baseline, compare the relevant Feed query and filter code with
 that reference and explain any intentional production change in the artifact's
 review note. Never compare the candidate with an older or smaller fixture.
 
-Retain JSON artifacts using this pattern:
+Write local JSON artifacts using this pattern:
 
 ```text
 benchmarks/results/<environment>-<profile>-<git-sha>.json
@@ -175,20 +163,22 @@ benchmarks/results/<environment>-<profile>-<git-sha>.json
 
 An artifact contains its git commit, branch, reference baseline, fixture counts,
 method, raw samples and statement observations, distribution summaries,
-structural counts, ratios, and gate result.
-Attach production-like artifacts to the relevant performance ticket or pull
-request. Do not commit credentials, database URLs, or raw user data.
+structural counts, ratios, and gate result. The result directory and generated
+ledgers are ignored by Git. Attach production-like evidence to the relevant
+performance ticket or pull request when it must be retained. Do not commit
+artifacts, credentials, database URLs, or raw user data to product source.
 
 ## Database-facing inventory and comparison operations
 
-`benchmarks/app-query-inventory.json` is generated from all TypeScript and TSX
-under `src`, `server`, `tests`, and `scripts` (excluding migrations). It records database
+`pnpm benchmark:inventory` generates the ignored local
+`benchmarks/app-query-inventory.json` from all TypeScript and TSX under `src`,
+`server`, `tests`, and `scripts` (excluding migrations). It records database
 client creation and every direct select, insert, update, delete, transaction,
 batch, execute, and relational find call, grouped across request procedures,
 synchronization/projection, background and maintenance tasks, Bookmark capture,
 authentication, administration, database infrastructure, and test-only
-infrastructure. `pnpm benchmark:inventory:check` fails when the checked-in
-inventory is stale.
+infrastructure. `pnpm benchmark:inventory:check` scans current source directly
+and does not require the generated ledger.
 
 The following production comparisons define the audit queue. The page pair is
 implemented by this checkpoint; subsequent audit tickets add or reuse registered
@@ -209,13 +199,9 @@ Capture fetching, RSS parsing, Redis/KV access, browser rendering, and publisher
 delivery remain in the repository-wide inventory even when they are not SQL page
 pairs. Their audit evidence uses the environment/tool division above.
 
-## Client and synchronization audit
+## Client coverage
 
-The retained client audit, executable profiles, per-file coverage ledger, and
-prioritized findings are documented in [CLIENT-AUDIT.md](CLIENT-AUDIT.md).
-
-## Server and database audit
-
-The repository-wide server/database review, prioritized findings, and named
-coverage ledger are retained in
-[`server-database-audit.md`](server-database-audit.md).
+`pnpm benchmark:client:coverage` writes an ignored local coverage ledger.
+`pnpm benchmark:client:coverage:check` scans current client source and validates
+that every configured finding path still belongs to the applicable coverage
+set; it does not require a committed report.

--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -100,7 +100,21 @@ export type ClientAuditResult = {
   };
 };
 
-export function evaluateClientAuditOperationBudgets(result: ClientAuditResult) {
+export type ClientAuditBudgetMeasurements = Pick<
+  ClientAuditResult,
+  "synchronizationBytes" | "persistenceMutationBytes" | "retention"
+> & {
+  operations: {
+    [Operation in keyof ClientAuditResult["operations"]]: Omit<
+      ClientAuditResult["operations"][Operation],
+      "heapDeltaBytes"
+    >;
+  };
+};
+
+export function evaluateClientAuditOperationBudgets(
+  result: ClientAuditBudgetMeasurements,
+) {
   const violations = Object.entries(result.operations).flatMap(
     ([operation, metrics]) =>
       metrics.durationMs > CLIENT_OPERATION_DURATION_BUDGET_MS
@@ -254,7 +268,7 @@ export function evaluateClientAuditOperationBudgets(result: ClientAuditResult) {
     for (const [metricName, budget] of Object.entries(metricBudgets)) {
       checkMaximum(
         `${operationName} ${metricName}`,
-        operation[metricName as keyof ClientAuditOperation],
+        operation[metricName as keyof typeof operation],
         budget,
       );
     }

--- a/apps/app/scripts/performance/inventory-app-queries.ts
+++ b/apps/app/scripts/performance/inventory-app-queries.ts
@@ -167,16 +167,18 @@ function buildInventory() {
   };
 }
 
-const serialized = await format(JSON.stringify(buildInventory()), {
+const inventory = buildInventory();
+const serialized = await format(JSON.stringify(inventory), {
   filepath: OUTPUT_PATH,
 });
 if (process.argv.includes("--check")) {
-  const existing = readFileSync(OUTPUT_PATH, "utf8");
-  if (existing !== serialized) {
-    process.stderr.write(
-      "App query inventory is stale. Run pnpm benchmark:inventory and commit the result.\n",
-    );
+  if (inventory.accessCount === 0) {
+    process.stderr.write("App query inventory found no database accesses.\n");
     process.exitCode = 1;
+  } else {
+    process.stdout.write(
+      `Checked ${inventory.accessCount} direct database accesses from current source.\n`,
+    );
   }
 } else {
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });

--- a/apps/app/scripts/performance/inventory-client-audit.ts
+++ b/apps/app/scripts/performance/inventory-client-audit.ts
@@ -137,12 +137,17 @@ const artifact = {
 const serialized = await format(JSON.stringify(artifact), { parser: "json" });
 
 if (process.argv.includes("--check")) {
-  const current = await readFile(OUTPUT_PATH, "utf8").catch(() => "");
-  if (current !== serialized) {
+  const coveredFiles = new Set(coverage.map((entry) => entry.file));
+  const missingFindingPaths = Object.values(findingPaths)
+    .flat()
+    .filter((file) => !coveredFiles.has(file));
+  if (missingFindingPaths.length > 0) {
     console.error(
-      "Client audit coverage is stale. Run benchmark:client:coverage.",
+      `Client audit finding paths are missing from current source coverage: ${missingFindingPaths.join(", ")}`,
     );
     process.exitCode = 1;
+  } else {
+    console.log(`Checked ${coverage.length} applicable client files.`);
   }
 } else {
   await writeFile(OUTPUT_PATH, serialized, "utf8");

--- a/apps/app/tests/fixtures/performance/budget-baselines.json
+++ b/apps/app/tests/fixtures/performance/budget-baselines.json
@@ -1,0 +1,269 @@
+{
+  "client": {
+    "synchronizationBytes": {
+      "request": 2743,
+      "maximumResponsePage": 36049,
+      "requestBudget": 16384,
+      "responseBudget": 262144
+    },
+    "persistenceMutationBytes": {
+      "measured": 10881,
+      "budget": 524288
+    },
+    "retention": {
+      "budgets": {
+        "memoryPages": 8,
+        "memoryBytes": 8388608,
+        "indexedDbPages": 6,
+        "indexedDbBytes": 4194304,
+        "mountedItems": 180
+      },
+      "afterTwelvePages": {
+        "pages": 8,
+        "entities": 240,
+        "scopeReferences": 240,
+        "retainedBytes": 144790,
+        "retainedHeapBytes": 130203,
+        "persistedPages": 6,
+        "persistedBytes": 90038,
+        "mountedItems": 180
+      },
+      "afterTwentyFourPages": {
+        "pages": 8,
+        "entities": 240,
+        "scopeReferences": 240,
+        "retainedBytes": 144773,
+        "retainedHeapBytes": 130248,
+        "persistedPages": 6,
+        "persistedBytes": 90070,
+        "mountedItems": 180
+      }
+    },
+    "operations": {
+      "bookmarkSave": {
+        "durationMs": 1.3838750000001028,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 1,
+        "authoritativeRefills": 1
+      },
+      "bookmarkProgressEvent": {
+        "durationMs": 0.1187080000000833,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "bookmarkCaptureEvent": {
+        "durationMs": 0.08708300000012059,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "bookmarkOrganizationChange": {
+        "durationMs": 0.8510830000000169,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 1,
+        "authoritativeRefills": 2
+      },
+      "bookmarkDelete": {
+        "durationMs": 0.7825000000000273,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 1,
+        "authoritativeRefills": 1
+      },
+      "feedProgressEvent": {
+        "durationMs": 23.595542000000023,
+        "bookmarkStoreNotifications": 0,
+        "feedItemStoreNotifications": 1,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "feedProgressBurst": {
+        "durationMs": 22.907416999999896,
+        "bookmarkStoreNotifications": 0,
+        "feedItemStoreNotifications": 1,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "bookmarkBurstSingleFrame": {
+        "durationMs": 0.14754199999993034,
+        "bookmarkStoreNotifications": 100,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "bookmarkBurstSeparateFrames": {
+        "durationMs": 0.19908299999997325,
+        "bookmarkStoreNotifications": 100,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "coldSynchronization": {
+        "durationMs": 0.6547499999996944,
+        "bookmarkStoreNotifications": 1,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "warmSynchronization": {
+        "durationMs": 17.816749999999956,
+        "bookmarkStoreNotifications": 0,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      },
+      "normalizedPersistenceMutation": {
+        "durationMs": 9.014208000000053,
+        "bookmarkStoreNotifications": 0,
+        "feedItemStoreNotifications": 0,
+        "feedItemProjectionNotifications": 0,
+        "feedItemScopeNotifications": 0,
+        "mixedStoreNotifications": 0,
+        "authoritativeRefills": 0
+      }
+    }
+  },
+  "browser": {
+    "coldLoad": {
+      "usableContentMs": 1107.5,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 6.700000002980232
+        }
+      ],
+      "indexedDb": {
+        "reads": 11,
+        "writes": 1348
+      },
+      "requests": 97,
+      "transferBytes": 2140051,
+      "rpcRequests": 7,
+      "rpcTransferBytes": 1538154,
+      "heapBytes": 47400000,
+      "storageBytes": 4714609
+    },
+    "warmHydration": {
+      "usableContentMs": 196.70000000298023,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 10.100000008940697
+        }
+      ],
+      "indexedDb": {
+        "reads": 1350,
+        "writes": 345
+      },
+      "requests": 97,
+      "transferBytes": 263029,
+      "rpcRequests": 7,
+      "rpcTransferBytes": 260765,
+      "heapBytes": 47400000,
+      "storageBytes": 4875664
+    },
+    "reconnect": {
+      "usableContentMs": null,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 5.999999970197678
+        }
+      ],
+      "indexedDb": {
+        "reads": 0,
+        "writes": 345
+      },
+      "requests": 7,
+      "transferBytes": 327416,
+      "rpcRequests": 6,
+      "rpcTransferBytes": 326649,
+      "heapBytes": 47400000,
+      "storageBytes": 4854746
+    },
+    "pagination": {
+      "usableContentMs": null,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 6.0999999940395355
+        }
+      ],
+      "indexedDb": {
+        "reads": 0,
+        "writes": 0
+      },
+      "requests": 3,
+      "transferBytes": 1506,
+      "rpcRequests": 1,
+      "rpcTransferBytes": 9,
+      "heapBytes": 47400000,
+      "storageBytes": 4854746
+    },
+    "reader": {
+      "usableContentMs": 57.099999994039536,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 7.899999991059303
+        }
+      ],
+      "indexedDb": {
+        "reads": 0,
+        "writes": 32
+      },
+      "requests": 1,
+      "transferBytes": 0,
+      "rpcRequests": 1,
+      "rpcTransferBytes": 0,
+      "heapBytes": 47400000,
+      "storageBytes": 4826301
+    },
+    "pageCaptureReader": {
+      "usableContentMs": 67.59999999403954,
+      "longTasks": [],
+      "commits": [
+        {
+          "actualDuration": 6
+        }
+      ],
+      "indexedDb": {
+        "reads": 0,
+        "writes": 0
+      },
+      "requests": 4,
+      "transferBytes": 0,
+      "rpcRequests": 1,
+      "rpcTransferBytes": 0,
+      "heapBytes": 47400000,
+      "storageBytes": 4852635
+    }
+  }
+}

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -4,7 +4,7 @@ import {
   evaluateClientAuditOperationBudgets,
   runClientAuditProfile,
 } from "../../../scripts/performance/client-audit-model";
-import type { ClientAuditResult } from "../../../scripts/performance/client-audit-model";
+import type { ClientAuditBudgetMeasurements } from "../../../scripts/performance/client-audit-model";
 
 describe("client performance audit model", () => {
   it.each([
@@ -100,17 +100,17 @@ describe("client performance audit model", () => {
   }, 30_000);
 
   it("keeps the retained stress profile within explicit operation budgets", async () => {
-    const result = JSON.parse(
+    const baselines = JSON.parse(
       await readFile(
         new URL(
-          "../../../benchmarks/results/client-stress.json",
+          "../../fixtures/performance/budget-baselines.json",
           import.meta.url,
         ),
         "utf8",
       ),
-    ) as ClientAuditResult;
+    ) as { client: ClientAuditBudgetMeasurements };
 
-    expect(evaluateClientAuditOperationBudgets(result)).toEqual([]);
+    expect(evaluateClientAuditOperationBudgets(baselines.client)).toEqual([]);
   });
 
   it("rejects deliberately reintroduced fan-out, payload, and retention regressions", () => {

--- a/apps/app/tests/unit/performance/client-browser-budgets.test.ts
+++ b/apps/app/tests/unit/performance/client-browser-budgets.test.ts
@@ -7,19 +7,24 @@ import {
 
 describe("client browser performance budgets", () => {
   it("keeps the retained representative production-browser profile in budget", async () => {
-    const artifact = JSON.parse(
+    const baselines = JSON.parse(
       await readFile(
         new URL(
-          "../../../benchmarks/results/browser-client-representative.json",
+          "../../fixtures/performance/budget-baselines.json",
           import.meta.url,
         ),
         "utf8",
       ),
-    ) as Record<string, Parameters<typeof evaluateClientBrowserScenario>[1]>;
+    ) as {
+      browser: Record<
+        string,
+        Parameters<typeof evaluateClientBrowserScenario>[1]
+      >;
+    };
     const violations = Object.keys(CLIENT_BROWSER_BUDGETS).flatMap((scenario) =>
       evaluateClientBrowserScenario(
         scenario as keyof typeof CLIENT_BROWSER_BUDGETS,
-        artifact[scenario]!,
+        baselines.browser[scenario]!,
       ).map((violation) => `${scenario}: ${violation}`),
     );
 


### PR DESCRIPTION
## Summary

- remove 21 generated benchmark JSON and audit/report Markdown artifacts from product source control and clean CI checkouts
- keep the benchmark harness and source-derived inventory/coverage checks executable
- replace four checked-in JSON dependencies with one 7.5 KB deterministic budget fixture containing evaluator inputs only
- ignore local benchmark JSON and all benchmark Markdown except the harness README
- preserve the removed artifacts byte-identically at their ignored local paths

## CI file requirements after this change

- `apps/app/tests/fixtures/performance/budget-baselines.json` is the only retained result-comparison file
- `benchmark:inventory:check` and `benchmark:client:coverage:check` inspect current source directly and require no generated report files
- no audit/report Markdown is present in a clean checkout

## Verification

- `pnpm benchmark:inventory:check` (476 direct database accesses)
- `pnpm benchmark:client:coverage:check` (317 applicable client files)
- focused performance unit tests (10 passed)
- all package unit tests (252 passed total)
- seeded self-hosted E2E (33 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm format`
- `pnpm build`
- React Doctor changed scope (no issues)
- client benchmark gate for small, representative, and stress profiles
- app benchmark smoke harness executed; warm/read and warm/later passed, warm/unread produced a timing-only p95 diagnostic in non-gating smoke mode
- retained fixture verdict parity checked against original client and browser result files
- all 21 locally restored artifacts match their pre-cleanup SHA-256 hashes
- runtime source and migration trees are identical to `beta-backup`

`beta-backup` remains at `f2e77e72` locally and remotely until this PR is explicitly approved, merged, and post-merge verification passes.