### PR TITLE
Fit Edit Bookmark to the extension popup

### DIFF
--- a/apps/app/src/components/bookmarks/BookmarkOrganizationEditor.tsx
+++ b/apps/app/src/components/bookmarks/BookmarkOrganizationEditor.tsx
@@ -178,10 +178,15 @@ export function EditBookmarkDialog({
           Organize this Bookmark into Views and Tags.
         </DialogDescription>
         {bookmarkId && (
-          <BookmarkOrganizationEditor
-            bookmarkId={bookmarkId}
-            onClose={onClose}
-          />
+          <div
+            data-slot="bookmark-editor-dialog-viewport"
+            className="max-h-[min(100dvh,44rem)] min-w-0 overflow-x-hidden overflow-y-auto"
+          >
+            <BookmarkOrganizationEditor
+              bookmarkId={bookmarkId}
+              onClose={onClose}
+            />
+          </div>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/app/tests/unit/components/bookmark-editor.test.ts
+++ b/apps/app/tests/unit/components/bookmark-editor.test.ts
@@ -83,8 +83,42 @@ describe("shouldShowBookmarkEditorFeedback", () => {
     expect(markup).toContain("lucide-refresh-cw");
     expect(markup).toContain(`aria-label="${message}"`);
     expect(markup).not.toContain('role="status"');
-    expect(markup.match(/overflow-y-auto/g)).toHaveLength(1);
+    expect(markup).toContain('data-slot="bookmark-editor"');
+    expect(markup).toContain("min-w-0");
+    expect(markup).not.toContain("overflow-y-auto");
+    expect(markup).not.toContain("max-h-");
     expect(markup.match(/px-6/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps long organization labels within the editor container", () => {
+    const longLabel = "A View name that is much wider than its parent surface";
+    const markup = renderToStaticMarkup(
+      createElement(BookmarkEditor, {
+        bookmark: {
+          title:
+            "A Bookmark title that is also much wider than its parent surface",
+          author: "An equally long Bookmark author name",
+          sourceUrl: "https://example.com/article",
+          platform: "website",
+          contentType: "text",
+        },
+        viewOptions: [{ id: 1, label: longLabel }],
+        selectedViewIds: [],
+        onToggleView: () => undefined,
+        onCreateView: () => undefined,
+        tagOptions: [{ id: 2, label: longLabel }],
+        selectedTagIds: [],
+        onToggleTag: () => undefined,
+        onCreateTag: () => undefined,
+        isDeleting: false,
+        onDelete: () => undefined,
+        onDone: () => undefined,
+      }),
+    );
+
+    expect(markup.match(/max-w-full/g)).toHaveLength(2);
+    expect(markup.match(/class="truncate"/g)).toHaveLength(2);
+    expect(markup.match(/min-w-0/g)?.length).toBeGreaterThanOrEqual(6);
   });
 
   it("hides routine first-save outcomes", () => {

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
@@ -2,7 +2,10 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { FeedDiscovery } from "./BookmarkWorkspaceView";
+import {
+  BookmarkEditorPopupLayout,
+  FeedDiscovery,
+} from "./BookmarkWorkspaceView";
 import type { BookmarkWorkspace } from "../../lib/bookmarks";
 
 const FEED_URL = "https://example.com/feed.xml";
@@ -40,5 +43,36 @@ describe("extension Feed discovery actions", () => {
     expect(markup).toContain('aria-label="Feed added"');
     expect(markup).toContain("lucide-check");
     expect(markup).not.toContain("animate-spin");
+  });
+
+  it("keeps long Feed rows within the popup container", () => {
+    const markup = renderFeedDiscovery({});
+
+    expect(markup.match(/min-w-0/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(markup).toContain("max-w-full");
+  });
+});
+
+describe("extension Bookmark editor sizing", () => {
+  it("owns popup viewport constraints outside the shared editor content", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        BookmarkEditorPopupLayout,
+        null,
+        createElement("div", {
+          "data-slot": "bookmark-editor",
+          className: "flex min-h-0 min-w-0 flex-col",
+        }),
+      ),
+    );
+
+    expect(markup).toContain('data-slot="extension-bookmark-editor-viewport"');
+    expect(markup).toContain(
+      "h-full min-w-0 overflow-x-hidden overflow-y-auto",
+    );
+    expect(markup).toContain(
+      "[&amp;&gt;[data-slot=bookmark-editor]]:min-h-full",
+    );
+    expect(markup).not.toContain("max-w-");
   });
 });

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   Alert,
   AlertDescription,
@@ -16,6 +17,21 @@ import { ExtensionHeader } from "./ExtensionHeader";
 import { PopupLayout } from "./PopupLayout";
 import { useBookmarkWorkspace } from "./useBookmarkWorkspace";
 
+export function BookmarkEditorPopupLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <main
+      data-slot="extension-bookmark-editor-viewport"
+      className="h-full min-w-0 overflow-x-hidden overflow-y-auto [&>[data-slot=bookmark-editor]]:min-h-full"
+    >
+      {children}
+    </main>
+  );
+}
+
 export function FeedDiscovery({
   workspace,
   pendingFeedUrls,
@@ -31,7 +47,7 @@ export function FeedDiscovery({
   const pendingFeedUrlSet = new Set(pendingFeedUrls);
   const addedFeedUrlSet = new Set(addedFeedUrls);
   return (
-    <div className="grid gap-2 border-t pt-5">
+    <div className="grid min-w-0 gap-2 border-t pt-5">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold">Feeds on this page</h2>
         <Rss className="text-muted-foreground size-4" />
@@ -44,10 +60,12 @@ export function FeedDiscovery({
             key={feed.url}
             size="xs"
             variant="outline"
-            className="flex-nowrap"
+            className="min-w-0 flex-nowrap"
           >
             <ItemContent className="min-w-0">
-              <ItemTitle>{feed.title || new URL(feed.url).hostname}</ItemTitle>
+              <ItemTitle className="max-w-full">
+                {feed.title || new URL(feed.url).hostname}
+              </ItemTitle>
               <ItemDescription className="truncate">{feed.url}</ItemDescription>
             </ItemContent>
             <Button
@@ -125,47 +143,48 @@ export function BookmarkWorkspaceView({
     }
     const error = externalError || controller.error;
     return (
-      <BookmarkEditor
-        className="h-full"
-        bookmark={workspace.bookmark}
-        feedback={workspace}
-        viewOptions={workspace.views.map((view) => ({
-          id: view.id,
-          label: view.name,
-        }))}
-        selectedViewIds={workspace.bookmark.viewIds}
-        onToggleView={(id) => void controller.toggleOrganization("view", id)}
-        onCreateView={(name) => controller.createOrganization("view", name)}
-        tagOptions={workspace.tags.map((tag) => ({
-          id: tag.id,
-          label: tag.name,
-        }))}
-        selectedTagIds={workspace.bookmark.tagIds}
-        prioritizedTagIds={prioritizedTagIds}
-        onToggleTag={(id) => void controller.toggleOrganization("tag", id)}
-        onCreateTag={(name) => controller.createOrganization("tag", name)}
-        afterOrganization={
-          <>
-            {error && (
-              <Alert variant="destructive">
-                <Info />
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-            <FeedDiscovery
-              workspace={workspace}
-              pendingFeedUrls={controller.pendingFeedUrls}
-              addedFeedUrls={controller.addedFeedUrls}
-              onAddFeed={(url) => void controller.addFeed(url)}
-            />
-          </>
-        }
-        isDeleting={controller.isDeleting}
-        onDelete={async () => {
-          if (await controller.removeBookmark()) window.close();
-        }}
-        onDone={() => window.close()}
-      />
+      <BookmarkEditorPopupLayout>
+        <BookmarkEditor
+          bookmark={workspace.bookmark}
+          feedback={workspace}
+          viewOptions={workspace.views.map((view) => ({
+            id: view.id,
+            label: view.name,
+          }))}
+          selectedViewIds={workspace.bookmark.viewIds}
+          onToggleView={(id) => void controller.toggleOrganization("view", id)}
+          onCreateView={(name) => controller.createOrganization("view", name)}
+          tagOptions={workspace.tags.map((tag) => ({
+            id: tag.id,
+            label: tag.name,
+          }))}
+          selectedTagIds={workspace.bookmark.tagIds}
+          prioritizedTagIds={prioritizedTagIds}
+          onToggleTag={(id) => void controller.toggleOrganization("tag", id)}
+          onCreateTag={(name) => controller.createOrganization("tag", name)}
+          afterOrganization={
+            <>
+              {error && (
+                <Alert variant="destructive">
+                  <Info />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+              <FeedDiscovery
+                workspace={workspace}
+                pendingFeedUrls={controller.pendingFeedUrls}
+                addedFeedUrls={controller.addedFeedUrls}
+                onAddFeed={(url) => void controller.addFeed(url)}
+              />
+            </>
+          }
+          isDeleting={controller.isDeleting}
+          onDelete={async () => {
+            if (await controller.removeBookmark()) window.close();
+          }}
+          onDone={() => window.close()}
+        />
+      </BookmarkEditorPopupLayout>
     );
   }
 

--- a/packages/ui/src/bookmark-editor.tsx
+++ b/packages/ui/src/bookmark-editor.tsx
@@ -84,8 +84,9 @@ export function BookmarkEditor({
 
   return (
     <div
+      data-slot="bookmark-editor"
       className={cn(
-        "flex max-h-[min(100dvh,44rem)] min-h-0 flex-col overflow-y-auto",
+        "flex min-h-0 min-w-0 flex-col",
         className,
       )}
     >
@@ -125,7 +126,7 @@ export function BookmarkEditor({
         </div>
       </div>
 
-      <div className="grid flex-1 content-start gap-6 px-6 py-5">
+      <div className="grid min-w-0 flex-1 content-start gap-6 px-6 py-5">
         <SelectableChipList
           label="Views"
           options={viewOptions}

--- a/packages/ui/src/selectable-chip-list.tsx
+++ b/packages/ui/src/selectable-chip-list.tsx
@@ -193,7 +193,7 @@ export function SelectableChipList({
 
   return (
     <div
-      className="grid gap-2"
+      className="grid min-w-0 gap-2"
       data-slot="selectable-chip-list"
       data-label={label}
     >
@@ -292,7 +292,7 @@ export function SelectableChipList({
       {totalCount > 0 ? (
         <div
           ref={chipContainerRef}
-          className="relative flex flex-wrap content-start gap-1 overflow-hidden"
+          className="relative flex min-w-0 flex-wrap content-start gap-1 overflow-hidden"
         >
           {renderOptions.map((option) => {
             const isSelected = selectedSet.has(option.id);
@@ -307,7 +307,7 @@ export function SelectableChipList({
                   badgeVariants({
                     variant: isSelected ? "default" : "outline",
                   }),
-                  "cursor-pointer",
+                  "max-w-full min-w-0 shrink cursor-pointer [&>svg]:shrink-0",
                   isPrioritized && !isSelected && "border-primary/50",
                   !isPrioritized && !isSelected && "border-dashed",
                 )}
@@ -320,7 +320,7 @@ export function SelectableChipList({
                     className="text-muted-foreground"
                   />
                 )}
-                {option.label}
+                <span className="truncate">{option.label}</span>
               </button>
             );
           })}


### PR DESCRIPTION
## Summary

- make the shared Bookmark editor container-agnostic by moving height and scrolling policy into the app dialog and extension popup wrappers
- keep long Bookmark, View, Tag, and Feed content within the owning surface through explicit shrink and truncation boundaries
- add sizing ownership and long-content regression coverage

## Validation

- pnpm test:unit in apps/extension — 32 tests passed
- pnpm test:unit in apps/app — 362 tests passed
- pnpm test:e2e:self-hosted tests/e2e/self-hosted/bookmark-app-flow.spec.ts --reporter=line — 2 tests passed
- pnpm typecheck in apps/extension, apps/app, and packages/ui — passed
- pnpm lint in apps/extension — passed
- pnpm lint in apps/app — passed with 29 existing warnings and no errors
- pnpm format in apps/extension and apps/app — passed
- pnpm build and pnpm build:firefox in apps/extension — passed
- pnpx react-doctor — 12 existing warnings; no findings in changed files; packages/ui scored 100
- pnpm benchmark:inventory:check — checked 590 direct database accesses
- pnpm benchmark:client:coverage:check — checked 339 applicable client files
- pnpm benchmark:client:smoke — passed small profile
- headless Chromium production-CSS probe at 380px and 320px — document, popup, and editor scroll widths matched their container widths with no overflowing descendants; sticky header/footer and scrolled Feed/create content remained contained

## Performance impact

Presentation-only. The change adds one wrapper element and CSS sizing constraints; it does not add data work, subscriptions, network calls, or rendering loops. The client smoke profile and inventory/coverage checks passed.

## Follow-up

Packaged Chrome staging validation remains required after merge, as specified by the QA ticket. This PR does not authorize or perform that merge.