### PR TITLE
Improve extension page preview observation

### DIFF
--- a/apps/app/tests/unit/bookmarks/extract.test.ts
+++ b/apps/app/tests/unit/bookmarks/extract.test.ts
@@ -33,6 +33,9 @@ describe("Page capture preparation", () => {
       sourceUrl: "https://example.com/submitted",
       candidate: extensionCandidate({
         canonicalUrl: "https://example.com/canonical",
+        title: "Current live title",
+        author: "Current live author",
+        thumbnailUrl: "/current-live-cover.jpg",
       }),
     });
     expect(result.ok).toBe(true);
@@ -43,6 +46,12 @@ describe("Page capture preparation", () => {
         captureSource: "extension-live-dom",
         extractorVersion: "mozilla-readability-0.6",
         sanitizerPolicyVersion: 1,
+      },
+      preview: {
+        title: "Current live title",
+        author: "Current live author",
+        thumbnailUrl: "https://example.com/current-live-cover.jpg",
+        previewSource: "extension-live-dom",
       },
     });
     expect(result.result.observation.capture?.contentHtml).not.toContain(

--- a/apps/extension/lib/bookmark-capture.test.ts
+++ b/apps/extension/lib/bookmark-capture.test.ts
@@ -18,6 +18,219 @@ function readableArticle(content: string) {
 }
 
 describe("extension live DOM Bookmark capture", () => {
+  it("prefers the current YouTube watch title and channel over stale head metadata", () => {
+    const document = new JSDOM(
+      `<!doctype html><html><head>
+        <title>Stale video - YouTube</title>
+        <meta property="og:title" content="Stale video">
+        <meta name="author" content="Stale channel">
+      </head><body>
+        <ytd-watch-metadata>
+          <h1><yt-formatted-string>Current video title</yt-formatted-string></h1>
+          <div id="owner"><div id="channel-name"><a>Current channel</a></div></div>
+        </ytd-watch-metadata>
+      </body></html>`,
+      { url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+    ).window.document;
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.title).toBe("Current video title");
+    expect(result.capture.author).toBe("Current channel");
+  });
+
+  it("prefers the current YouTube Shorts title and structured channel over stale head metadata", () => {
+    const document = new JSDOM(
+      `<!doctype html><html><head>
+        <title>Stale Short - YouTube</title>
+        <meta property="og:title" content="Stale Short">
+        <meta name="author" content="Stale channel">
+      </head><body>
+        <yt-shorts-video-title-view-model>
+          <h1>Current Short title</h1>
+        </yt-shorts-video-title-view-model>
+        <span itemprop="author">
+          <meta itemprop="name" content="Current Shorts channel">
+        </span>
+      </body></html>`,
+      { url: "https://www.youtube.com/shorts/PG_kfqOXqgQ" },
+    ).window.document;
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.title).toBe("Current Short title");
+    expect(result.capture.author).toBe("Current Shorts channel");
+  });
+
+  it("chooses the strongest social-image metadata independently of document order", () => {
+    const document = pageDocument(
+      "<main>Preview only</main>",
+      `
+        <meta name="twitter:image" content="/images/twitter.jpg">
+        <meta property="og:image" content="/images/open-graph.jpg">
+      `,
+    );
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.thumbnailUrl).toBe(
+      "https://example.com/images/open-graph.jpg",
+    );
+  });
+
+  it("uses structured article imagery when social metadata is absent", () => {
+    const document = pageDocument(
+      readableArticle(
+        "<p>This article has structured representative imagery.</p>",
+      ),
+      `
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "Article",
+            "image": {
+              "@type": "ImageObject",
+              "url": "/images/structured-cover.jpg",
+              "width": 1200,
+              "height": 630
+            }
+          }
+        </script>
+      `,
+    );
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.thumbnailUrl).toBe(
+      "https://example.com/images/structured-cover.jpg",
+    );
+  });
+
+  it("quality-ranks relative and lazy-loaded article imagery", () => {
+    const document = pageDocument(`
+      <header>
+        <img src="/images/site-logo.png" width="64" height="64" alt="Site logo">
+      </header>
+      <main>
+        <article>
+          <img src="/images/author-avatar.jpg" width="96" height="96" alt="Author avatar">
+          <img data-src="../images/article-cover.jpg" width="1200" height="630" alt="Article cover">
+          ${readableArticle(
+            "<p>This article has enough text for reader extraction.</p>",
+          )}
+        </article>
+      </main>
+    `);
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.thumbnailUrl).toBe(
+      "https://example.com/images/article-cover.jpg",
+    );
+  });
+
+  it("leaves imagery empty when every candidate is unsafe or unsuitable", () => {
+    const document = pageDocument(
+      `
+        <main>
+          <img src="/images/tracking-pixel.gif" width="1" height="1" alt="Tracking pixel">
+          <img src="/images/hidden-cover.jpg" width="1200" height="630" hidden alt="Hidden cover">
+          <img src="/images/extreme-banner.jpg" width="2400" height="100" alt="Extreme banner">
+        </main>
+      `,
+      `
+        <meta property="og:image" content="javascript:alert('unsafe')">
+        <meta name="twitter:image" content="https://user:secret@example.com/private.jpg">
+        <script type="application/ld+json">
+          { "@type": "Article", "image": "data:image/png;base64,unsafe" }
+        </script>
+      `,
+    );
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.thumbnailUrl).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: "website text",
+      url: "https://example.com/article",
+      head: "",
+      platform: "website",
+      contentType: "text",
+    },
+    {
+      name: "website video",
+      url: "https://example.com/video",
+      head: '<meta property="og:type" content="video.other">',
+      platform: "website",
+      contentType: "video",
+    },
+    {
+      name: "YouTube text",
+      url: "https://www.youtube.com/@serial",
+      head: "",
+      platform: "youtube",
+      contentType: "text",
+    },
+    {
+      name: "YouTube video",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      head: "",
+      platform: "youtube",
+      contentType: "video",
+    },
+    {
+      name: "PeerTube text",
+      url: "https://video.example/about",
+      head: '<meta name="generator" content="PeerTube">',
+      platform: "peertube",
+      contentType: "text",
+    },
+    {
+      name: "PeerTube video",
+      url: "https://video.example/videos/watch/123e4567-e89b-12d3-a456-426614174000",
+      head: "",
+      platform: "peertube",
+      contentType: "video",
+    },
+    {
+      name: "Nebula text",
+      url: "https://nebula.tv/about",
+      head: "",
+      platform: "nebula",
+      contentType: "text",
+    },
+    {
+      name: "Nebula video",
+      url: "https://nebula.tv/videos/example-video",
+      head: "",
+      platform: "nebula",
+      contentType: "video",
+    },
+  ] as const)("fills general preview defaults for $name", (fixture) => {
+    const document = new JSDOM(
+      `<!doctype html><html><head>
+        <title>General preview title</title>
+        <meta property="og:image" content="/general-cover.jpg">
+        ${fixture.head}
+      </head><body><main>Preview only</main></body></html>`,
+      { url: fixture.url },
+    ).window.document;
+
+    const result = extractPageObservation(document);
+
+    expect(result.capture.descriptor).toMatchObject({
+      platform: fixture.platform,
+      contentType: fixture.contentType,
+    });
+    expect(result.capture.title).toBe("General preview title");
+    expect(result.capture.thumbnailUrl).toBe(
+      `${new URL(fixture.url).origin}/general-cover.jpg`,
+    );
+  });
+
   it("extracts a clone, resolves lazy and relative URLs, and discovers Feeds", () => {
     const document = pageDocument(
       readableArticle(`
@@ -130,24 +343,36 @@ describe("extension live DOM Bookmark capture", () => {
   });
 
   it("does not clone an oversized DOM but retains preview and declared Feeds", () => {
+    const structuredData =
+      '{"@type":"Article","image":"https://example.com/large.jpg"}';
     const document = pageDocument(
-      "<main><p>Article preview</p></main>",
+      '<main><p>Article preview</p><img src="/large.jpg"></main>',
       `
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Example Feed">
         <meta property="og:description" content="A lightweight preview">
+        <script type="application/ld+json">${structuredData}</script>
       `,
     );
     const querySelectorAll = document.querySelectorAll.bind(document);
-    vi.spyOn(document, "querySelectorAll").mockImplementation((selector) =>
-      selector === "*"
-        ? ({ length: BOOKMARK_CAPTURE_LIMITS.domElements + 1 } as never)
-        : querySelectorAll(selector),
-    );
+    const query = vi
+      .spyOn(document, "querySelectorAll")
+      .mockImplementation((selector) =>
+        selector === "*"
+          ? ({ length: BOOKMARK_CAPTURE_LIMITS.domElements + 1 } as never)
+          : querySelectorAll(selector),
+      );
     const clone = vi.spyOn(document, "cloneNode");
+    const parse = vi.spyOn(JSON, "parse");
 
     const result = extractPageObservation(document);
 
     expect(clone).not.toHaveBeenCalled();
+    expect(parse.mock.calls.some(([value]) => value === structuredData)).toBe(
+      false,
+    );
+    expect(query.mock.calls.some(([selector]) => selector === "img")).toBe(
+      false,
+    );
     expect(result.capture.description).toBe("A lightweight preview");
     expect(result.capture.contentHtml).toBeUndefined();
     expect(result.captureFailureReason).toBe("too_large");

--- a/packages/bookmark-capture/src/extract.ts
+++ b/packages/bookmark-capture/src/extract.ts
@@ -8,6 +8,8 @@ import type {
   DiscoveredFeed,
   ExtensionCaptureFailureReason,
 } from "./contracts";
+import { boundedText, metaContent, resolvedHttpUrl } from "./metadata";
+import { extractPagePreview } from "./preview";
 import { sanitizeCaptureHtml } from "./sanitize";
 
 export type ExtensionContentDescriptor = {
@@ -50,39 +52,6 @@ const YOUTUBE_HOSTS = new Set([
 const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/;
 const PEERTUBE_VIDEO_ID =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[A-Za-z0-9_-]{22})$/i;
-
-function codePointLength(value: string) {
-  return [...value].length;
-}
-
-function boundedText(value: string | null | undefined, maximum: number) {
-  const normalized = value?.trim();
-  if (!normalized || codePointLength(normalized) > maximum) return undefined;
-  return normalized;
-}
-
-function resolvedHttpUrl(value: string | null | undefined, baseUrl: string) {
-  if (!value) return undefined;
-  try {
-    const url = new URL(value, baseUrl);
-    if (
-      url.username ||
-      url.password ||
-      (url.protocol !== "http:" && url.protocol !== "https:") ||
-      new TextEncoder().encode(url.toString()).byteLength >
-        BOOKMARK_CAPTURE_LIMITS.urlBytes
-    ) {
-      return undefined;
-    }
-    return url.toString();
-  } catch {
-    return undefined;
-  }
-}
-
-function metaContent(document: Document, selector: string) {
-  return document.querySelector<HTMLMetaElement>(selector)?.content ?? null;
-}
 
 function youtubeContentId(url: URL) {
   let candidate: string | null = null;
@@ -278,93 +247,18 @@ export function extractPageObservation(
     : null;
   if (clone) normalizeLazyResources(clone);
   const article = clone ? new Readability(clone).parse() : null;
+  const preview = extractPagePreview({
+    document,
+    effectiveUrl,
+    article,
+    inspectStructuredData: !tooLarge,
+    platform: descriptor.platform,
+    contentType: descriptor.contentType,
+  });
   const capture: ExtensionCaptureCandidate = {
     effectiveUrl,
     ...(canonicalUrl ? { canonicalUrl } : {}),
-    title:
-      boundedText(
-        metaContent(document, 'meta[property="og:title"]') ??
-          article?.title ??
-          document.title,
-        BOOKMARK_CAPTURE_LIMITS.titleCodePoints,
-      ) ?? new URL(effectiveUrl).hostname,
-    ...(boundedText(
-      metaContent(document, 'meta[property="og:description"]') ??
-        metaContent(document, 'meta[name="description"]') ??
-        article?.excerpt,
-      BOOKMARK_CAPTURE_LIMITS.descriptionCodePoints,
-    )
-      ? {
-          description: boundedText(
-            metaContent(document, 'meta[property="og:description"]') ??
-              metaContent(document, 'meta[name="description"]') ??
-              article?.excerpt,
-            BOOKMARK_CAPTURE_LIMITS.descriptionCodePoints,
-          ),
-        }
-      : {}),
-    ...(boundedText(
-      article?.byline ?? metaContent(document, 'meta[name="author"]'),
-      BOOKMARK_CAPTURE_LIMITS.authorCodePoints,
-    )
-      ? {
-          author: boundedText(
-            article?.byline ?? metaContent(document, 'meta[name="author"]'),
-            BOOKMARK_CAPTURE_LIMITS.authorCodePoints,
-          ),
-        }
-      : {}),
-    ...(boundedText(
-      metaContent(document, 'meta[property="og:site_name"]'),
-      BOOKMARK_CAPTURE_LIMITS.siteNameCodePoints,
-    )
-      ? {
-          siteName: boundedText(
-            metaContent(document, 'meta[property="og:site_name"]'),
-            BOOKMARK_CAPTURE_LIMITS.siteNameCodePoints,
-          ),
-        }
-      : {}),
-    ...(boundedText(
-      article?.publishedTime ??
-        metaContent(document, 'meta[property="article:published_time"]'),
-      BOOKMARK_CAPTURE_LIMITS.descriptionCodePoints,
-    )
-      ? {
-          publishedAt:
-            article?.publishedTime ??
-            metaContent(document, 'meta[property="article:published_time"]') ??
-            undefined,
-        }
-      : {}),
-    ...(resolvedHttpUrl(
-      document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.href,
-      effectiveUrl,
-    )
-      ? {
-          iconUrl: resolvedHttpUrl(
-            document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.href,
-            effectiveUrl,
-          ),
-        }
-      : {}),
-    ...(resolvedHttpUrl(
-      metaContent(
-        document,
-        'meta[property="og:image"], meta[name="twitter:image"]',
-      ),
-      effectiveUrl,
-    )
-      ? {
-          thumbnailUrl: resolvedHttpUrl(
-            metaContent(
-              document,
-              'meta[property="og:image"], meta[name="twitter:image"]',
-            ),
-            effectiveUrl,
-          ),
-        }
-      : {}),
+    ...preview,
     descriptor,
   };
 

--- a/packages/bookmark-capture/src/metadata.ts
+++ b/packages/bookmark-capture/src/metadata.ts
@@ -1,0 +1,40 @@
+import { BOOKMARK_CAPTURE_LIMITS } from "./policy";
+
+function codePointLength(value: string) {
+  return [...value].length;
+}
+
+export function boundedText(
+  value: string | null | undefined,
+  maximum: number,
+) {
+  const normalized = value?.trim();
+  if (!normalized || codePointLength(normalized) > maximum) return undefined;
+  return normalized;
+}
+
+export function resolvedHttpUrl(
+  value: string | null | undefined,
+  baseUrl: string,
+) {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value, baseUrl);
+    if (
+      url.username ||
+      url.password ||
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      new TextEncoder().encode(url.toString()).byteLength >
+        BOOKMARK_CAPTURE_LIMITS.urlBytes
+    ) {
+      return undefined;
+    }
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function metaContent(document: Document, selector: string) {
+  return document.querySelector<HTMLMetaElement>(selector)?.content ?? null;
+}

--- a/packages/bookmark-capture/src/preview.ts
+++ b/packages/bookmark-capture/src/preview.ts
@@ -1,0 +1,402 @@
+import type {
+  BookmarkContentPlatform,
+  BookmarkContentType,
+} from "./capabilities";
+import { boundedText, metaContent, resolvedHttpUrl } from "./metadata";
+import { BOOKMARK_CAPTURE_LIMITS } from "./policy";
+
+export type PreviewArticleMetadata = {
+  title?: string | null;
+  excerpt?: string | null;
+  byline?: string | null;
+  publishedTime?: string | null;
+};
+
+export type ExtractedPagePreview = {
+  title: string;
+  description?: string;
+  author?: string;
+  publishedAt?: string;
+  siteName?: string;
+  iconUrl?: string;
+  thumbnailUrl?: string;
+};
+
+type PreviewExtractionInput = {
+  document: Document;
+  effectiveUrl: string;
+  article: PreviewArticleMetadata | null;
+  inspectStructuredData: boolean;
+};
+
+type PreviewStrategy = (
+  input: PreviewExtractionInput,
+  generalPreview: ExtractedPagePreview,
+) => ExtractedPagePreview;
+
+function firstBoundedText(
+  candidates: Array<string | null | undefined>,
+  maximum: number,
+) {
+  for (const candidate of candidates) {
+    const value = boundedText(candidate, maximum);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function firstResolvedHttpUrl(
+  candidates: Array<string | null | undefined>,
+  baseUrl: string,
+) {
+  for (const candidate of candidates) {
+    const value = resolvedHttpUrl(candidate, baseUrl);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function elementTextOrContent(document: Document, selector: string) {
+  const element = document.querySelector<HTMLElement>(selector);
+  return element?.getAttribute("content") ?? element?.textContent ?? null;
+}
+
+type StructuredImageCandidate = {
+  value: string;
+  score: number;
+  order: number;
+};
+
+type DocumentImageCandidate = {
+  url: string;
+  score: number;
+  order: number;
+};
+
+const IMAGE_RANKING = {
+  minimumWidth: 180,
+  minimumHeight: 100,
+  minimumArea: 24_000,
+  minimumAspectRatio: 0.2,
+  maximumAspectRatio: 5,
+  articleScore: 5_000,
+  mainScore: 3_000,
+  figureScore: 1_000,
+  semanticPenalty: 6_000,
+  maximumDimensionScore: 2_500,
+  minimumCandidateScore: 500,
+} as const;
+
+const LOW_QUALITY_IMAGE_MARKER =
+  /(?:^|[-_/.])(avatar|badge|emoji|icon|logo|pixel|sprite|tracker|tracking)(?:[-_/.]|$)/i;
+
+function structuredRecords(value: unknown): Array<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return [];
+  if (Array.isArray(value)) return value.flatMap(structuredRecords);
+  const record = value as Record<string, unknown>;
+  return [record, ...structuredRecords(record["@graph"])];
+}
+
+function structuredImageValues(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!value || typeof value !== "object") return [];
+  if (Array.isArray(value)) return value.flatMap(structuredImageValues);
+  const record = value as Record<string, unknown>;
+  return [
+    ...structuredImageValues(record.contentUrl),
+    ...structuredImageValues(record.url),
+    ...structuredImageValues(record["@id"]),
+  ];
+}
+
+function structuredTypeScore(value: unknown) {
+  const types = (Array.isArray(value) ? value : [value]).filter(
+    (entry): entry is string => typeof entry === "string",
+  );
+  if (
+    types.some((type) =>
+      ["article", "newsarticle", "blogposting", "videoobject"].includes(
+        type.toLowerCase(),
+      ),
+    )
+  ) {
+    return 30;
+  }
+  return types.some((type) => type.toLowerCase() === "webpage") ? 20 : 10;
+}
+
+function structuredImageUrl(document: Document, effectiveUrl: string) {
+  const candidates: StructuredImageCandidate[] = [];
+  let order = 0;
+  for (const script of document.querySelectorAll<HTMLScriptElement>(
+    'script[type="application/ld+json"]',
+  )) {
+    try {
+      for (const record of structuredRecords(
+        JSON.parse(script.textContent || "null"),
+      )) {
+        const typeScore = structuredTypeScore(record["@type"]);
+        const properties = [
+          ["primaryImageOfPage", 3],
+          ["image", 2],
+          ["thumbnailUrl", 1],
+        ] as const;
+        for (const [property, propertyScore] of properties) {
+          for (const value of structuredImageValues(record[property])) {
+            candidates.push({
+              value,
+              score: typeScore + propertyScore,
+              order: order++,
+            });
+          }
+        }
+      }
+    } catch {
+      // Invalid page metadata is ignored locally and is never uploaded.
+    }
+  }
+  candidates.sort(
+    (left, right) => right.score - left.score || left.order - right.order,
+  );
+  return firstResolvedHttpUrl(
+    candidates.map((candidate) => candidate.value),
+    effectiveUrl,
+  );
+}
+
+function numericImageDimension(image: HTMLImageElement, name: "width" | "height") {
+  const natural = name === "width" ? image.naturalWidth : image.naturalHeight;
+  if (natural > 0) return natural;
+  const attribute = Number(image.getAttribute(name));
+  return Number.isFinite(attribute) && attribute > 0 ? attribute : null;
+}
+
+function bestSrcsetUrl(value: string | null) {
+  if (!value) return null;
+  return value
+    .split(",")
+    .map((candidate, order) => {
+      const [url, descriptor] = candidate.trim().split(/\s+/, 2);
+      const score = descriptor?.endsWith("w")
+        ? Number(descriptor.slice(0, -1))
+        : descriptor?.endsWith("x")
+          ? Number(descriptor.slice(0, -1)) * 1_000
+          : 0;
+      return { url, score: Number.isFinite(score) ? score : 0, order };
+    })
+    .filter((candidate) => candidate.url)
+    .sort((left, right) => right.score - left.score || left.order - right.order)[0]
+    ?.url;
+}
+
+function documentImageUrl(document: Document, effectiveUrl: string) {
+  const candidates: DocumentImageCandidate[] = [];
+  let order = 0;
+  for (const image of document.querySelectorAll<HTMLImageElement>("img")) {
+    if (
+      image.closest('[hidden], [aria-hidden="true"]') ||
+      /display\s*:\s*none/i.test(image.getAttribute("style") ?? "")
+    ) {
+      continue;
+    }
+    const url = firstResolvedHttpUrl(
+      [
+        image.currentSrc,
+        image.getAttribute("data-src"),
+        image.getAttribute("data-lazy-src"),
+        image.getAttribute("data-original"),
+        bestSrcsetUrl(image.getAttribute("data-srcset")),
+        bestSrcsetUrl(image.getAttribute("srcset")),
+        image.getAttribute("src"),
+      ],
+      effectiveUrl,
+    );
+    if (!url) continue;
+
+    const width = numericImageDimension(image, "width");
+    const height = numericImageDimension(image, "height");
+    if (width && height) {
+      const area = width * height;
+      const aspectRatio = width / height;
+      if (
+        width < IMAGE_RANKING.minimumWidth ||
+        height < IMAGE_RANKING.minimumHeight ||
+        area < IMAGE_RANKING.minimumArea ||
+        aspectRatio < IMAGE_RANKING.minimumAspectRatio ||
+        aspectRatio > IMAGE_RANKING.maximumAspectRatio
+      ) {
+        continue;
+      }
+    }
+
+    const semanticText = [
+      url,
+      image.alt,
+      image.id,
+      image.className,
+      image.getAttribute("role"),
+    ].join(" ");
+    let score = 0;
+    if (image.closest("article")) score += IMAGE_RANKING.articleScore;
+    if (image.closest("main")) score += IMAGE_RANKING.mainScore;
+    if (image.closest("figure")) score += IMAGE_RANKING.figureScore;
+    if (image.alt.trim()) score += 200;
+    if (image.getAttribute("fetchpriority")?.toLowerCase() === "high") {
+      score += 300;
+    }
+    if (width && height) {
+      score += Math.min(
+        Math.round((width * height) / 1_000),
+        IMAGE_RANKING.maximumDimensionScore,
+      );
+    }
+    if (LOW_QUALITY_IMAGE_MARKER.test(semanticText)) {
+      score -= IMAGE_RANKING.semanticPenalty;
+    }
+    candidates.push({ url, score, order: order++ });
+  }
+  candidates.sort(
+    (left, right) => right.score - left.score || left.order - right.order,
+  );
+  return candidates[0] &&
+    candidates[0].score >= IMAGE_RANKING.minimumCandidateScore
+    ? candidates[0].url
+    : undefined;
+}
+
+function generalPreview(input: PreviewExtractionInput): ExtractedPagePreview {
+  const { article, document, effectiveUrl } = input;
+  const title =
+    firstBoundedText(
+      [
+        metaContent(document, 'meta[property="og:title"]'),
+        article?.title,
+        document.title,
+      ],
+      BOOKMARK_CAPTURE_LIMITS.titleCodePoints,
+    ) ?? new URL(effectiveUrl).hostname;
+  const description = firstBoundedText(
+    [
+      metaContent(document, 'meta[property="og:description"]'),
+      metaContent(document, 'meta[name="description"]'),
+      article?.excerpt,
+    ],
+    BOOKMARK_CAPTURE_LIMITS.descriptionCodePoints,
+  );
+  const author = firstBoundedText(
+    [article?.byline, metaContent(document, 'meta[name="author"]')],
+    BOOKMARK_CAPTURE_LIMITS.authorCodePoints,
+  );
+  const siteName = boundedText(
+    metaContent(document, 'meta[property="og:site_name"]'),
+    BOOKMARK_CAPTURE_LIMITS.siteNameCodePoints,
+  );
+  const publishedAt = firstBoundedText(
+    [
+      article?.publishedTime,
+      metaContent(document, 'meta[property="article:published_time"]'),
+    ],
+    BOOKMARK_CAPTURE_LIMITS.descriptionCodePoints,
+  );
+  const iconUrl = resolvedHttpUrl(
+    document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.href,
+    effectiveUrl,
+  );
+  const thumbnailUrl =
+    firstResolvedHttpUrl(
+      [
+        metaContent(document, 'meta[property="og:image:secure_url"]'),
+        metaContent(document, 'meta[property="og:image"]'),
+        metaContent(document, 'meta[name="twitter:image"]'),
+      ],
+      effectiveUrl,
+    ) ??
+    (input.inspectStructuredData
+      ? structuredImageUrl(document, effectiveUrl) ??
+        documentImageUrl(document, effectiveUrl)
+      : undefined);
+
+  return {
+    title,
+    ...(description ? { description } : {}),
+    ...(author ? { author } : {}),
+    ...(siteName ? { siteName } : {}),
+    ...(publishedAt ? { publishedAt } : {}),
+    ...(iconUrl ? { iconUrl } : {}),
+    ...(thumbnailUrl ? { thumbnailUrl } : {}),
+  };
+}
+
+function useGeneralPreview(
+  _input: PreviewExtractionInput,
+  preview: ExtractedPagePreview,
+) {
+  return preview;
+}
+
+function youtubeVideoPreview(
+  input: PreviewExtractionInput,
+  preview: ExtractedPagePreview,
+) {
+  const { document } = input;
+  const liveTitle = firstBoundedText(
+    [
+      elementTextOrContent(document, "yt-shorts-video-title-view-model h1"),
+      elementTextOrContent(
+        document,
+        "ytd-watch-metadata h1 yt-formatted-string",
+      ),
+      elementTextOrContent(document, "#title h1 yt-formatted-string"),
+    ],
+    BOOKMARK_CAPTURE_LIMITS.titleCodePoints,
+  );
+  const liveAuthor = firstBoundedText(
+    [
+      elementTextOrContent(
+        document,
+        "ytd-watch-metadata ytd-channel-name a",
+      ),
+      elementTextOrContent(document, "#owner #channel-name a"),
+      elementTextOrContent(
+        document,
+        '[itemprop="author"] [itemprop="name"]',
+      ),
+    ],
+    BOOKMARK_CAPTURE_LIMITS.authorCodePoints,
+  );
+  return {
+    ...preview,
+    ...(liveTitle ? { title: liveTitle } : {}),
+    ...(liveAuthor ? { author: liveAuthor } : {}),
+  };
+}
+
+const PREVIEW_STRATEGIES = {
+  website: {
+    text: useGeneralPreview,
+    video: useGeneralPreview,
+  },
+  youtube: {
+    text: useGeneralPreview,
+    video: youtubeVideoPreview,
+  },
+  peertube: {
+    text: useGeneralPreview,
+    video: useGeneralPreview,
+  },
+  nebula: {
+    text: useGeneralPreview,
+    video: useGeneralPreview,
+  },
+} as const satisfies Record<
+  BookmarkContentPlatform,
+  Record<BookmarkContentType, PreviewStrategy>
+>;
+
+export function extractPagePreview(input: PreviewExtractionInput & {
+  platform: BookmarkContentPlatform;
+  contentType: BookmarkContentType;
+}) {
+  const preview = generalPreview(input);
+  return PREVIEW_STRATEGIES[input.platform][input.contentType](input, preview);
+}


### PR DESCRIPTION
## Summary

- add a compile-time exhaustive Platform × Content type preview-strategy matrix with shared defaults and a YouTube video override
- prefer current live YouTube Watch and Shorts titles and channels over stale head metadata
- make representative-image selection deterministic across social metadata, structured data, and quality-ranked article images
- keep all candidates bounded, credential-free, and HTTP(S)-only

## Testing

- pnpm typecheck
- pnpm lint (0 errors; 29 existing warnings)
- pnpm format
- pnpm build:artifact
- extension unit suite: 44 tests passed
- app unit suite: 361 tests passed
- app benchmark:inventory:check
- app benchmark:client:coverage:check
- pnpx react-doctor (80/100; 12 pre-existing findings outside changed implementation files)

## Performance impact

The new generic image fallback makes one bounded DOM image pass only when stronger social and structured candidates are absent. Oversized pages skip both JSON-LD parsing and image scanning; this is fixture-covered. Database inventory and client benchmark coverage remain unchanged and pass.

## Packaged QA

The built MV3 artifact captured current metadata through the real background/content path for a live YouTube Watch page, a live YouTube Short, and a generic Wikipedia article. All three returned current titles/authors and valid representative imagery.