### PR TITLE
Decouple bookmark save from feed discovery

### DIFF
--- a/apps/app/src/app/api.extension.bookmark-feed-discovery.ts
+++ b/apps/app/src/app/api.extension.bookmark-feed-discovery.ts
@@ -1,0 +1,96 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import {
+  BOOKMARK_CAPTURE_LIMITS,
+  extensionDiscoveredFeedsSchema,
+} from "~/server/bookmarks/contracts";
+import { authenticatedExtensionUser } from "~/server/auth/extensionRequest";
+import { discoverFeeds as discoverFeedsForUrl } from "~/server/feeds/discovery";
+import { captureException } from "~/server/logger";
+import {
+  extensionPreflightResponse,
+  extensionJsonResponse as jsonResponse,
+  prepareExtensionJsonRequest,
+} from "~/server/http/extensionApi";
+
+const EXTENSION_FEED_DISCOVERY_REQUEST_BYTES = 16 * 1024;
+
+const extensionFeedDiscoveryRequestSchema = z.strictObject({
+  sourceUrl: z
+    .string()
+    .max(BOOKMARK_CAPTURE_LIMITS.urlBytes)
+    .refine((value) => {
+      try {
+        const url = new URL(value);
+        return (
+          (url.protocol === "http:" || url.protocol === "https:") &&
+          !url.username &&
+          !url.password
+        );
+      } catch {
+        return false;
+      }
+    }),
+});
+
+type ExtensionFeedDiscoveryDependencies = {
+  authenticate: typeof authenticatedExtensionUser;
+  discover: typeof discoverFeedsForUrl;
+};
+
+const DEFAULT_DEPENDENCIES: ExtensionFeedDiscoveryDependencies = {
+  authenticate: authenticatedExtensionUser,
+  discover: discoverFeedsForUrl,
+};
+
+export async function discoverExtensionBookmarkFeeds(
+  request: Request,
+  dependencies: ExtensionFeedDiscoveryDependencies = DEFAULT_DEPENDENCIES,
+) {
+  const prepared = await prepareExtensionJsonRequest({
+    request,
+    maxBytes: EXTENSION_FEED_DISCOVERY_REQUEST_BYTES,
+    requestLabel: "Feed discovery",
+    authenticate: dependencies.authenticate,
+  });
+  if (!prepared.ok) return prepared.response;
+
+  const parsedRequest = extensionFeedDiscoveryRequestSchema.safeParse(
+    prepared.body,
+  );
+  if (!parsedRequest.success) {
+    return jsonResponse(
+      { error: "The Feed discovery request is invalid" },
+      400,
+    );
+  }
+
+  try {
+    const discoveredFeeds = await dependencies.discover(
+      prepared.user.id,
+      parsedRequest.data.sourceUrl,
+    );
+    const feeds = extensionDiscoveredFeedsSchema.parse(
+      discoveredFeeds.map((feed) => ({
+        url: feed.url,
+        ...(feed.title ? { title: feed.title } : {}),
+      })),
+    );
+    return jsonResponse({ feeds });
+  } catch (error) {
+    captureException(error, {
+      context: "extension-bookmark-feed-discovery",
+    });
+    return jsonResponse({ error: "Unable to discover Feeds" }, 500);
+  }
+}
+
+export const Route = createFileRoute("/api/extension/bookmark-feed-discovery")({
+  server: {
+    handlers: {
+      POST: ({ request }) => discoverExtensionBookmarkFeeds(request),
+      OPTIONS: () => extensionPreflightResponse(["POST"]),
+    },
+  },
+});

--- a/apps/app/src/app/api.extension.bookmarks.ts
+++ b/apps/app/src/app/api.extension.bookmarks.ts
@@ -26,8 +26,6 @@ import {
   publishBookmarkDeletion,
   publishBookmarkUpsert,
 } from "~/server/mixed-content/sync";
-import { discoverFeeds as discoverFeedsForUrl } from "~/server/feeds/discovery";
-import { captureException } from "~/server/logger";
 import {
   extensionPreflightResponse,
   extensionJsonResponse as jsonResponse,
@@ -46,7 +44,6 @@ type ExtensionBookmarkRouteDependencies = {
     result: Awaited<ReturnType<typeof saveBookmarkFromExtension>>,
   ) => ReturnType<typeof publishBookmarkUpsert>;
   workspace?: typeof loadExtensionBookmarkWorkspace;
-  discover?: typeof discoverFeedsForUrl;
 };
 
 const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
@@ -72,7 +69,6 @@ const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
     });
   },
   workspace: loadExtensionBookmarkWorkspace,
-  discover: discoverFeedsForUrl,
 };
 
 const extensionBookmarkRequestSchema = z.strictObject({
@@ -113,19 +109,6 @@ export async function saveExtensionBookmark(
       capture: bookmarkRequest.capture,
       captureFailureReason: bookmarkRequest.captureFailureReason,
     });
-    const discoveredFeeds =
-      bookmarkRequest.feeds.length > 0
-        ? bookmarkRequest.feeds
-        : await (dependencies.discover ?? discoverFeedsForUrl)(
-            authenticatedUser.id,
-            bookmarkRequest.sourceUrl,
-          ).catch((error) => {
-            captureException(error, {
-              context: "extension-bookmark-feed-discovery",
-              url: bookmarkRequest.sourceUrl,
-            });
-            return [];
-          });
     const publishedBookmark = await dependencies.notify?.(
       authenticatedUser.id,
       result,
@@ -140,14 +123,14 @@ export async function saveExtensionBookmark(
       workspace
         ? {
             ...result,
-            feeds: discoveredFeeds,
+            feeds: bookmarkRequest.feeds,
             bookmark: workspace.bookmark,
             workspace: {
               views: workspace.views,
               tags: workspace.tags,
             },
           }
-        : { ...result, feeds: discoveredFeeds },
+        : { ...result, feeds: bookmarkRequest.feeds },
       result.disposition === "created" ? 201 : 200,
     );
   } catch (error) {

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AppAdminIndexRouteImport } from './app/_app.admin.index'
 import { Route as ApiRpcSplatRouteImport } from './app/api/rpc.$'
 import { Route as ApiExtensionFeedsRouteImport } from './app/api.extension.feeds'
 import { Route as ApiExtensionBookmarksRouteImport } from './app/api.extension.bookmarks'
+import { Route as ApiExtensionBookmarkFeedDiscoveryRouteImport } from './app/api.extension.bookmark-feed-discovery'
 import { Route as ApiExtensionAuthSplatRouteImport } from './app/api/extension-auth.$'
 import { Route as ApiDemoProvisionRouteImport } from './app/api.demo.provision'
 import { Route as ApiAuthSplatRouteImport } from './app/api/auth.$'
@@ -140,6 +141,12 @@ const ApiExtensionBookmarksRoute = ApiExtensionBookmarksRouteImport.update({
   path: '/api/extension/bookmarks',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiExtensionBookmarkFeedDiscoveryRoute =
+  ApiExtensionBookmarkFeedDiscoveryRouteImport.update({
+    id: '/api/extension/bookmark-feed-discovery',
+    path: '/api/extension/bookmark-feed-discovery',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiExtensionAuthSplatRoute = ApiExtensionAuthSplatRouteImport.update({
   id: '/api/extension-auth/$',
   path: '/api/extension-auth/$',
@@ -222,6 +229,7 @@ export interface FileRoutesByFullPath {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/demo/provision': typeof ApiDemoProvisionRoute
   '/api/extension-auth/$': typeof ApiExtensionAuthSplatRoute
+  '/api/extension/bookmark-feed-discovery': typeof ApiExtensionBookmarkFeedDiscoveryRoute
   '/api/extension/bookmarks': typeof ApiExtensionBookmarksRoute
   '/api/extension/feeds': typeof ApiExtensionFeedsRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
@@ -254,6 +262,7 @@ export interface FileRoutesByTo {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/demo/provision': typeof ApiDemoProvisionRoute
   '/api/extension-auth/$': typeof ApiExtensionAuthSplatRoute
+  '/api/extension/bookmark-feed-discovery': typeof ApiExtensionBookmarkFeedDiscoveryRoute
   '/api/extension/bookmarks': typeof ApiExtensionBookmarksRoute
   '/api/extension/feeds': typeof ApiExtensionFeedsRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
@@ -288,6 +297,7 @@ export interface FileRoutesById {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/demo/provision': typeof ApiDemoProvisionRoute
   '/api/extension-auth/$': typeof ApiExtensionAuthSplatRoute
+  '/api/extension/bookmark-feed-discovery': typeof ApiExtensionBookmarkFeedDiscoveryRoute
   '/api/extension/bookmarks': typeof ApiExtensionBookmarksRoute
   '/api/extension/feeds': typeof ApiExtensionFeedsRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
@@ -322,6 +332,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/demo/provision'
     | '/api/extension-auth/$'
+    | '/api/extension/bookmark-feed-discovery'
     | '/api/extension/bookmarks'
     | '/api/extension/feeds'
     | '/api/rpc/$'
@@ -354,6 +365,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/demo/provision'
     | '/api/extension-auth/$'
+    | '/api/extension/bookmark-feed-discovery'
     | '/api/extension/bookmarks'
     | '/api/extension/feeds'
     | '/api/rpc/$'
@@ -387,6 +399,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/demo/provision'
     | '/api/extension-auth/$'
+    | '/api/extension/bookmark-feed-discovery'
     | '/api/extension/bookmarks'
     | '/api/extension/feeds'
     | '/api/rpc/$'
@@ -403,6 +416,7 @@ export interface RootRouteChildren {
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiDemoProvisionRoute: typeof ApiDemoProvisionRoute
   ApiExtensionAuthSplatRoute: typeof ApiExtensionAuthSplatRoute
+  ApiExtensionBookmarkFeedDiscoveryRoute: typeof ApiExtensionBookmarkFeedDiscoveryRoute
   ApiExtensionBookmarksRoute: typeof ApiExtensionBookmarksRoute
   ApiExtensionFeedsRoute: typeof ApiExtensionFeedsRoute
   ApiRpcSplatRoute: typeof ApiRpcSplatRoute
@@ -550,6 +564,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiExtensionBookmarksRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/extension/bookmark-feed-discovery': {
+      id: '/api/extension/bookmark-feed-discovery'
+      path: '/api/extension/bookmark-feed-discovery'
+      fullPath: '/api/extension/bookmark-feed-discovery'
+      preLoaderRoute: typeof ApiExtensionBookmarkFeedDiscoveryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/extension-auth/$': {
       id: '/api/extension-auth/$'
       path: '/api/extension-auth/$'
@@ -695,6 +716,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiDemoProvisionRoute: ApiDemoProvisionRoute,
   ApiExtensionAuthSplatRoute: ApiExtensionAuthSplatRoute,
+  ApiExtensionBookmarkFeedDiscoveryRoute:
+    ApiExtensionBookmarkFeedDiscoveryRoute,
   ApiExtensionBookmarksRoute: ApiExtensionBookmarksRoute,
   ApiExtensionFeedsRoute: ApiExtensionFeedsRoute,
   ApiRpcSplatRoute: ApiRpcSplatRoute,

--- a/apps/app/tests/unit/bookmarks/extension-feed-discovery-route.test.ts
+++ b/apps/app/tests/unit/bookmarks/extension-feed-discovery-route.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { discoverExtensionBookmarkFeeds } from "~/app/api.extension.bookmark-feed-discovery";
+
+vi.mock("~/server/db", () => ({
+  db: { query: { user: { findFirst: vi.fn() } } },
+}));
+vi.mock("~/server/auth/extension", () => ({ findExtensionSession: vi.fn() }));
+
+const TOKEN = `serial_ext_${"a".repeat(43)}`;
+
+function discoveryRequest(sourceUrl = "https://example.com/article") {
+  return new Request(
+    "https://serial.example/api/extension/bookmark-feed-discovery",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sourceUrl }),
+    },
+  );
+}
+
+function dependencies() {
+  return {
+    authenticate: vi.fn(() => Promise.resolve({ id: "user-one" }) as never),
+    discover: vi.fn(() =>
+      Promise.resolve(
+        [] as Array<{ url: string; title?: string; format?: string }>,
+      ),
+    ),
+  };
+}
+
+describe("extension Bookmark Feed-discovery HTTP contract", () => {
+  it("authenticates and returns bounded discovered Feeds", async () => {
+    const deps = dependencies();
+    deps.discover.mockResolvedValue([
+      {
+        url: "https://example.com/feed.xml",
+        title: "Example Feed",
+        format: "rss",
+      },
+    ]);
+
+    const response = await discoverExtensionBookmarkFeeds(
+      discoveryRequest(),
+      deps,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.discover).toHaveBeenCalledWith(
+      "user-one",
+      "https://example.com/article",
+    );
+    await expect(response.json()).resolves.toEqual({
+      feeds: [{ url: "https://example.com/feed.xml", title: "Example Feed" }],
+    });
+  });
+
+  it("keeps an empty discovery result distinct from request failure", async () => {
+    const response = await discoverExtensionBookmarkFeeds(
+      discoveryRequest(),
+      dependencies(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ feeds: [] });
+  });
+
+  it("reports discovery failure without changing the saved Bookmark contract", async () => {
+    const deps = dependencies();
+    deps.discover.mockRejectedValue(new Error("upstream unavailable"));
+
+    const response = await discoverExtensionBookmarkFeeds(
+      discoveryRequest(),
+      deps,
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unable to discover Feeds",
+    });
+  });
+
+  it("rejects non-HTTP(S) and credential-bearing targets", async () => {
+    for (const sourceUrl of [
+      "file:///tmp/article",
+      "https://user:secret@example.com/article",
+    ]) {
+      const deps = dependencies();
+      const response = await discoverExtensionBookmarkFeeds(
+        discoveryRequest(sourceUrl),
+        deps,
+      );
+
+      expect(response.status).toBe(400);
+      expect(deps.discover).not.toHaveBeenCalled();
+    }
+  });
+
+  it("requires extension authentication", async () => {
+    const deps = dependencies();
+    deps.authenticate.mockResolvedValue(null as never);
+
+    const response = await discoverExtensionBookmarkFeeds(
+      discoveryRequest(),
+      deps,
+    );
+
+    expect(response.status).toBe(401);
+    expect(deps.discover).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/bookmarks/extension-route.test.ts
+++ b/apps/app/tests/unit/bookmarks/extension-route.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { discoverFeeds as discoverFeedsFromUrl } from "feedscout";
 
 import type { saveBookmarkFromExtension } from "~/server/bookmarks/service";
 import {
@@ -19,7 +18,6 @@ vi.mock("~/server/bookmarks/service", () => ({
   setBookmarkTag: vi.fn(),
   setBookmarkView: vi.fn(),
 }));
-vi.mock("feedscout", () => ({ discoverFeeds: vi.fn() }));
 
 const TOKEN = `serial_ext_${"a".repeat(43)}`;
 
@@ -191,68 +189,17 @@ describe("extension Bookmark HTTP contract", () => {
     });
   });
 
-  it("uses Serial Feed discovery when the page declares no Feeds", async () => {
-    vi.mocked(discoverFeedsFromUrl).mockResolvedValue([
-      {
-        url: "https://example.com/discovered.xml",
-        title: "Discovered Feed",
-        isValid: true,
-      },
-    ] as never);
-
+  it("returns the saved Bookmark immediately when the page declares no Feeds", async () => {
     const response = await saveExtensionBookmark(
       bookmarkRequest(supportedRequest({ feeds: [] })),
       dependencies(),
     );
 
-    expect(discoverFeedsFromUrl).toHaveBeenCalledWith(
-      "https://example.com/article",
-      expect.objectContaining({
-        methods: ["platform", "html", "headers", "guess"],
-        concurrency: 2,
-        maxUris: 8,
-        fetchFn: expect.any(Function),
-      }),
-    );
-    await expect(response.json()).resolves.toMatchObject({
-      feeds: [
-        {
-          url: "https://example.com/discovered.xml",
-          title: "Discovered Feed",
-        },
-      ],
-    });
-  });
-
-  it("does not start fallback discovery until the Bookmark save is accepted", async () => {
-    let acceptSave: (() => void) | undefined;
-    const saveAccepted = new Promise<void>((resolve) => {
-      acceptSave = resolve;
-    });
-    const discover = vi.fn(() => Promise.resolve([]));
-    const deps = dependencies();
-    deps.save.mockImplementation(async () => {
-      await saveAccepted;
-      return successfulResult("created");
-    });
-
-    const responsePromise = saveExtensionBookmark(
-      bookmarkRequest(supportedRequest({ feeds: [] })),
-      { ...deps, discover },
-    );
-    await Promise.resolve();
-    expect(discover).not.toHaveBeenCalled();
-
-    acceptSave?.();
-    await responsePromise;
-    expect(discover).toHaveBeenCalledWith(
-      "user-one",
-      "https://example.com/article",
-    );
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({ feeds: [] });
   });
 
   it("prefers page-declared Feeds without running server discovery", async () => {
-    vi.mocked(discoverFeedsFromUrl).mockClear();
     const declaredFeeds = [
       {
         url: "https://example.com/declared.xml",
@@ -266,7 +213,6 @@ describe("extension Bookmark HTTP contract", () => {
     );
 
     expect(response.status).toBe(201);
-    expect(discoverFeedsFromUrl).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({
       feeds: declaredFeeds,
     });

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
@@ -16,18 +16,41 @@ const workspace = {
 function renderFeedDiscovery(input: {
   pendingFeedUrls?: string[];
   addedFeedUrls?: string[];
+  status?: "idle" | "loading" | "loaded" | "error";
+  workspace?: BookmarkWorkspace;
 }) {
   return renderToStaticMarkup(
     createElement(FeedDiscovery, {
-      workspace,
+      workspace: input.workspace ?? workspace,
       pendingFeedUrls: input.pendingFeedUrls ?? [],
       addedFeedUrls: input.addedFeedUrls ?? [],
+      status: input.status ?? "loaded",
       onAddFeed: vi.fn(),
     }),
   );
 }
 
 describe("extension Feed discovery actions", () => {
+  it("shows one item skeleton only while remote discovery is loading", () => {
+    const loadingMarkup = renderFeedDiscovery({
+      status: "loading",
+      workspace: { ...workspace, feeds: [] },
+    });
+    const loadedMarkup = renderFeedDiscovery({
+      status: "loaded",
+      workspace: { ...workspace, feeds: [] },
+    });
+    const failedMarkup = renderFeedDiscovery({
+      status: "error",
+      workspace: { ...workspace, feeds: [] },
+    });
+
+    expect(loadingMarkup).toContain('aria-label="Finding Feeds on this page"');
+    expect(loadingMarkup).toContain("animate-pulse");
+    expect(loadedMarkup).not.toContain("animate-pulse");
+    expect(failedMarkup).not.toContain("animate-pulse");
+  });
+
   it("replaces the Add icon with a spinner throughout initial ingestion", () => {
     const markup = renderFeedDiscovery({ pendingFeedUrls: [FEED_URL] });
 

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
@@ -16,6 +16,7 @@ import type { BookmarkWorkspace } from "../../lib/bookmarks";
 import { ExtensionHeader } from "./ExtensionHeader";
 import { PopupLayout } from "./PopupLayout";
 import { useBookmarkWorkspace } from "./useBookmarkWorkspace";
+import type { FeedDiscoveryStatus } from "./useBookmarkWorkspace";
 
 export function BookmarkEditorPopupLayout({
   children,
@@ -36,13 +37,36 @@ export function FeedDiscovery({
   workspace,
   pendingFeedUrls,
   addedFeedUrls,
+  status,
   onAddFeed,
 }: {
   workspace: BookmarkWorkspace;
   pendingFeedUrls: string[];
   addedFeedUrls: string[];
+  status: FeedDiscoveryStatus;
   onAddFeed: (url: string) => void;
 }) {
+  if (status === "loading") {
+    return (
+      <div
+        className="grid gap-2 border-t pt-5"
+        role="status"
+        aria-label="Finding Feeds on this page"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold">Feeds on this page</h2>
+          <Rss className="text-muted-foreground size-4" />
+        </div>
+        <Item size="xs" variant="outline" className="flex-nowrap">
+          <ItemContent className="min-w-0 gap-2">
+            <div className="bg-muted h-3.5 w-2/3 animate-pulse rounded" />
+            <div className="bg-muted h-3 w-4/5 animate-pulse rounded" />
+          </ItemContent>
+          <div className="bg-muted size-8 shrink-0 animate-pulse rounded-md" />
+        </Item>
+      </div>
+    );
+  }
   if (workspace.feeds.length === 0) return null;
   const pendingFeedUrlSet = new Set(pendingFeedUrls);
   const addedFeedUrlSet = new Set(addedFeedUrls);
@@ -174,6 +198,7 @@ export function BookmarkWorkspaceView({
                 workspace={workspace}
                 pendingFeedUrls={controller.pendingFeedUrls}
                 addedFeedUrls={controller.addedFeedUrls}
+                status={controller.feedDiscoveryStatus}
                 onAddFeed={(url) => void controller.addFeed(url)}
               />
             </>

--- a/apps/extension/entrypoints/popup/useBookmarkWorkspace.test.tsx
+++ b/apps/extension/entrypoints/popup/useBookmarkWorkspace.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExtensionAuthSession } from "../../lib/auth";
+import type {
+  BookmarkMessageResponse,
+  BookmarkWorkspace,
+} from "../../lib/bookmarks";
+import { useBookmarkWorkspace } from "./useBookmarkWorkspace";
+
+const session: ExtensionAuthSession = {
+  version: 2,
+  instance: "https://serial.example",
+  token: "serial_ext_test",
+  expiresAt: Date.now() + 60_000,
+  user: { id: "user-one", name: "User" },
+};
+
+const workspace: BookmarkWorkspace = {
+  bookmark: {
+    id: "bookmark-one",
+    sourceUrl: "https://example.com/article",
+    platform: "website",
+    contentType: "text",
+    title: "Article",
+    author: null,
+    siteName: "Example",
+    thumbnailUrl: null,
+    iconUrl: null,
+    captureHash: null,
+    viewIds: [],
+    tagIds: [],
+  },
+  views: [],
+  tags: [],
+  feeds: [],
+  disposition: "created",
+  capture: { status: "captured" },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("extension Bookmark workspace lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let controller: ReturnType<typeof useBookmarkWorkspace>;
+  const onAuthExpired = vi.fn();
+
+  function Harness() {
+    controller = useBookmarkWorkspace({ session, onAuthExpired });
+    return null;
+  }
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    onAuthExpired.mockClear();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("makes the editor ready before delayed Feed discovery completes", async () => {
+    const capture = deferred<BookmarkMessageResponse>();
+    const discovery = deferred<BookmarkMessageResponse>();
+    const sendMessage = vi.fn((message: { type: string }) =>
+      message.type === "bookmark.capture-active"
+        ? capture.promise
+        : discovery.promise,
+    );
+    vi.stubGlobal("browser", { runtime: { sendMessage } });
+
+    await act(async () => root.render(createElement(Harness)));
+    expect(controller.status).toBe("loading");
+
+    await act(async () => {
+      capture.resolve({ ok: true, status: "saved", workspace });
+      await capture.promise;
+    });
+
+    expect(controller.status).toBe("saved");
+    expect(controller.workspace?.bookmark.id).toBe("bookmark-one");
+    expect(controller.feedDiscoveryStatus).toBe("loading");
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      type: "bookmark.discover-feeds",
+      sourceUrl: "https://example.com/article",
+    });
+
+    await act(async () => {
+      discovery.resolve({
+        ok: true,
+        status: "feeds-discovered",
+        feeds: [{ url: "https://example.com/feed.xml", title: "Example Feed" }],
+      });
+      await discovery.promise;
+    });
+
+    expect(controller.status).toBe("saved");
+    expect(controller.feedDiscoveryStatus).toBe("loaded");
+    expect(controller.workspace?.feeds).toEqual([
+      { url: "https://example.com/feed.xml", title: "Example Feed" },
+    ]);
+  });
+
+  it("uses page-declared Feeds without starting remote discovery", async () => {
+    const declaredWorkspace = {
+      ...workspace,
+      feeds: [{ url: "https://example.com/declared.xml" }],
+    };
+    const sendMessage = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: "saved",
+        workspace: declaredWorkspace,
+      } satisfies BookmarkMessageResponse),
+    );
+    vi.stubGlobal("browser", { runtime: { sendMessage } });
+
+    await act(async () => root.render(createElement(Harness)));
+
+    expect(controller.status).toBe("saved");
+    expect(controller.feedDiscoveryStatus).toBe("loaded");
+    expect(controller.workspace?.feeds).toEqual(declaredWorkspace.feeds);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "empty result",
+      settle: (request: ReturnType<typeof deferred<BookmarkMessageResponse>>) =>
+        request.resolve({ ok: true, status: "feeds-discovered", feeds: [] }),
+      expectedStatus: "loaded" as const,
+    },
+    {
+      name: "failure response",
+      settle: (request: ReturnType<typeof deferred<BookmarkMessageResponse>>) =>
+        request.resolve({
+          ok: false,
+          authExpired: false,
+          error: "Unable to discover Feeds",
+        }),
+      expectedStatus: "error" as const,
+    },
+    {
+      name: "timeout rejection",
+      settle: (request: ReturnType<typeof deferred<BookmarkMessageResponse>>) =>
+        request.reject(new Error("request timed out")),
+      expectedStatus: "error" as const,
+    },
+  ])(
+    "keeps Bookmark success through $name",
+    async ({ settle, expectedStatus }) => {
+      const discovery = deferred<BookmarkMessageResponse>();
+      const sendMessage = vi.fn((message: { type: string }) =>
+        message.type === "bookmark.capture-active"
+          ? Promise.resolve({
+              ok: true,
+              status: "saved",
+              workspace,
+            } satisfies BookmarkMessageResponse)
+          : discovery.promise,
+      );
+      vi.stubGlobal("browser", { runtime: { sendMessage } });
+
+      await act(async () => root.render(createElement(Harness)));
+      expect(controller.status).toBe("saved");
+      expect(controller.feedDiscoveryStatus).toBe("loading");
+
+      await act(async () => {
+        settle(discovery);
+        await discovery.promise.catch(() => undefined);
+      });
+
+      expect(controller.status).toBe("saved");
+      expect(controller.feedDiscoveryStatus).toBe(expectedStatus);
+      expect(controller.workspace?.bookmark.id).toBe("bookmark-one");
+    },
+  );
+});

--- a/apps/extension/entrypoints/popup/useBookmarkWorkspace.ts
+++ b/apps/extension/entrypoints/popup/useBookmarkWorkspace.ts
@@ -14,6 +14,8 @@ import type {
 type WorkspaceStatus =
   "loading" | "base" | "ineligible" | "saved" | "removed" | "error";
 
+export type FeedDiscoveryStatus = "idle" | "loading" | "loaded" | "error";
+
 async function sendBookmarkMessage(message: BookmarkMessage) {
   const response = (await browser.runtime.sendMessage(
     message,
@@ -30,12 +32,15 @@ export function useBookmarkWorkspace(input: {
 }) {
   const [status, setStatus] = useState<WorkspaceStatus>("loading");
   const [workspace, setWorkspace] = useState<BookmarkWorkspace | null>(null);
+  const [feedDiscoveryStatus, setFeedDiscoveryStatus] =
+    useState<FeedDiscoveryStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [pendingOrganization, setPendingOrganization] = useState<string[]>([]);
   const [pendingFeedUrls, setPendingFeedUrls] = useState<string[]>([]);
   const [addedFeedUrls, setAddedFeedUrls] = useState<string[]>([]);
   const [isDeleting, setIsDeleting] = useState(false);
   const attemptedToken = useRef<string | null>(null);
+  const feedDiscoveryGeneration = useRef(0);
   const workspaceRef = useRef<BookmarkWorkspace | null>(null);
   const pendingOrganizationRef = useRef<Set<string> | null>(null);
   if (pendingOrganizationRef.current === null) {
@@ -77,8 +82,42 @@ export function useBookmarkWorkspace(input: {
     [onAuthExpired],
   );
 
+  const discoverFeeds = useCallback(
+    async (savedWorkspace: BookmarkWorkspace, generation: number) => {
+      setFeedDiscoveryStatus("loading");
+      try {
+        const response = await sendBookmarkMessage({
+          type: "bookmark.discover-feeds",
+          sourceUrl: savedWorkspace.bookmark.sourceUrl,
+        });
+        if (feedDiscoveryGeneration.current !== generation) return;
+        if (!response.ok) {
+          if (response.authExpired) onAuthExpired();
+          setFeedDiscoveryStatus("error");
+          return;
+        }
+        if (response.status !== "feeds-discovered") {
+          throw new Error("Serial returned an unexpected Feed-discovery state");
+        }
+        const currentWorkspace = workspaceRef.current;
+        if (currentWorkspace?.bookmark.id === savedWorkspace.bookmark.id) {
+          replaceWorkspace({ ...currentWorkspace, feeds: response.feeds });
+        }
+        setFeedDiscoveryStatus("loaded");
+      } catch {
+        if (feedDiscoveryGeneration.current === generation) {
+          setFeedDiscoveryStatus("error");
+        }
+      }
+    },
+    [onAuthExpired, replaceWorkspace],
+  );
+
   const captureActive = useCallback(async () => {
+    const generation = feedDiscoveryGeneration.current + 1;
+    feedDiscoveryGeneration.current = generation;
     setStatus("loading");
+    setFeedDiscoveryStatus("idle");
     setError(null);
     try {
       const response = await sendBookmarkMessage({
@@ -95,6 +134,11 @@ export function useBookmarkWorkspace(input: {
       }
       replaceWorkspace(response.workspace);
       setStatus("saved");
+      if (response.workspace.feeds.length > 0) {
+        setFeedDiscoveryStatus("loaded");
+      } else {
+        void discoverFeeds(response.workspace, generation);
+      }
     } catch (captureError) {
       setError(
         captureError instanceof Error
@@ -103,7 +147,7 @@ export function useBookmarkWorkspace(input: {
       );
       setStatus("error");
     }
-  }, [handleFailure, replaceWorkspace]);
+  }, [discoverFeeds, handleFailure, replaceWorkspace]);
 
   useEffect(() => {
     if (attemptedToken.current === session.token) return;
@@ -215,6 +259,7 @@ export function useBookmarkWorkspace(input: {
         return false;
       }
       if (response.status === "removed") {
+        feedDiscoveryGeneration.current += 1;
         setStatus("removed");
         return true;
       }
@@ -324,6 +369,7 @@ export function useBookmarkWorkspace(input: {
   return {
     status,
     workspace,
+    feedDiscoveryStatus,
     error,
     pendingOrganization,
     pendingFeedUrls,

--- a/apps/extension/lib/background-bookmarks.test.ts
+++ b/apps/extension/lib/background-bookmarks.test.ts
@@ -25,6 +25,28 @@ function workspacePayload(feeds?: unknown) {
   };
 }
 
+function authenticatedDependencies(
+  fetchFromInstance: (
+    input: string | URL | Request,
+    init?: RequestInit,
+    options?: { timeoutMs?: number },
+  ) => Promise<Response>,
+) {
+  return {
+    readStoredSession: vi.fn(() =>
+      Promise.resolve({
+        version: 1,
+        instance: "https://serial.example",
+        token: "serial_ext_test",
+        expiresAt: Date.now() + 60_000,
+        user: { id: "user-one", name: "User", email: "u@example.com" },
+      } as never),
+    ),
+    clearSession: vi.fn(),
+    fetchFromInstance,
+  };
+}
+
 describe("extension Bookmark page eligibility", () => {
   it("treats every path on the connected Serial origin as the base extension", () => {
     expect(
@@ -70,19 +92,7 @@ describe("extension Bookmark Feed discovery", () => {
 
     await handleBookmarkMessage(
       { type: "bookmark.add-feed", url: "https://example.com/feed.xml" },
-      {
-        readStoredSession: vi.fn(() =>
-          Promise.resolve({
-            version: 1,
-            instance: "https://serial.example",
-            token: "serial_ext_test",
-            expiresAt: Date.now() + 60_000,
-            user: { id: "user-one", name: "User", email: "u@example.com" },
-          } as never),
-        ),
-        clearSession: vi.fn(),
-        fetchFromInstance,
-      },
+      authenticatedDependencies(fetchFromInstance),
     );
 
     expect(fetchFromInstance).toHaveBeenCalledWith(
@@ -112,5 +122,97 @@ describe("extension Bookmark Feed discovery", () => {
         [],
       ),
     ).toBeNull();
+  });
+
+  it("runs remote discovery as a separate authenticated message", async () => {
+    const fetchFromInstance = vi.fn(() =>
+      Promise.resolve(
+        Response.json({
+          feeds: [
+            {
+              url: "https://example.com/discovered.xml",
+              title: "Discovered Feed",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const response = await handleBookmarkMessage(
+      {
+        type: "bookmark.discover-feeds",
+        sourceUrl: "https://example.com/article",
+      },
+      authenticatedDependencies(fetchFromInstance),
+    );
+
+    expect(fetchFromInstance).toHaveBeenCalledWith(
+      "https://serial.example/api/extension/bookmark-feed-discovery",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ sourceUrl: "https://example.com/article" }),
+      }),
+      undefined,
+    );
+    expect(response).toEqual({
+      ok: true,
+      status: "feeds-discovered",
+      feeds: [
+        {
+          url: "https://example.com/discovered.xml",
+          title: "Discovered Feed",
+        },
+      ],
+    });
+  });
+
+  it("reports empty, failed, and timed-out discovery independently", async () => {
+    const empty = await handleBookmarkMessage(
+      {
+        type: "bookmark.discover-feeds",
+        sourceUrl: "https://example.com/article",
+      },
+      authenticatedDependencies(
+        vi.fn(() => Promise.resolve(Response.json({ feeds: [] }))),
+      ),
+    );
+    expect(empty).toEqual({ ok: true, status: "feeds-discovered", feeds: [] });
+
+    const failed = await handleBookmarkMessage(
+      {
+        type: "bookmark.discover-feeds",
+        sourceUrl: "https://example.com/article",
+      },
+      authenticatedDependencies(
+        vi.fn(() =>
+          Promise.resolve(
+            Response.json(
+              { error: "Unable to discover Feeds" },
+              { status: 500 },
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(failed).toEqual({
+      ok: false,
+      authExpired: false,
+      error: "Unable to discover Feeds",
+    });
+
+    const timedOut = await handleBookmarkMessage(
+      {
+        type: "bookmark.discover-feeds",
+        sourceUrl: "https://example.com/article",
+      },
+      authenticatedDependencies(
+        vi.fn(() => Promise.reject(new Error("request timed out"))),
+      ),
+    );
+    expect(timedOut).toEqual({
+      ok: false,
+      authExpired: false,
+      error: "Unable to reach the Serial instance",
+    });
   });
 });

--- a/apps/extension/lib/background-bookmarks.ts
+++ b/apps/extension/lib/background-bookmarks.ts
@@ -1,6 +1,7 @@
 import {
   EXTENSION_FEED_ADD_REQUEST_TIMEOUT_MS,
   parseExtensionBookmark,
+  parseExtensionDiscoveredFeeds,
   parseExtensionBookmarkWorkspace,
   type ExtensionCaptureCandidate,
   type ExtensionPageObservation,
@@ -194,6 +195,42 @@ async function captureActiveBookmark(
   return { ok: true, status: "saved", workspace };
 }
 
+async function discoverBookmarkFeeds(
+  session: ExtensionAuthSession,
+  sourceUrl: string,
+  dependencies: BookmarkBackgroundDependencies,
+): Promise<BookmarkMessageResponse> {
+  const request = await authenticatedApiRequest(
+    session,
+    "/api/extension/bookmark-feed-discovery",
+    {
+      method: "POST",
+      body: JSON.stringify({ sourceUrl }),
+    },
+    dependencies,
+  );
+  if (request.authExpired) {
+    return { ok: false, authExpired: true, error: "Reconnect to Serial" };
+  }
+  if (!request.response.ok) {
+    return {
+      ok: false,
+      authExpired: false,
+      error: apiError(request.payload, "Serial could not discover Feeds"),
+    };
+  }
+  const feeds = isRecord(request.payload)
+    ? parseExtensionDiscoveredFeeds(request.payload.feeds)
+    : null;
+  return feeds
+    ? { ok: true, status: "feeds-discovered", feeds }
+    : {
+        ok: false,
+        authExpired: false,
+        error: "This Serial instance returned incompatible Feed results",
+      };
+}
+
 export async function handleBookmarkMessage(
   message: BookmarkMessage,
   dependencies: BookmarkBackgroundDependencies,
@@ -206,6 +243,13 @@ export async function handleBookmarkMessage(
   try {
     if (message.type === "bookmark.capture-active") {
       return captureActiveBookmark(session, dependencies);
+    }
+    if (message.type === "bookmark.discover-feeds") {
+      return await discoverBookmarkFeeds(
+        session,
+        message.sourceUrl,
+        dependencies,
+      );
     }
     const request =
       message.type === "bookmark.add-feed"

--- a/apps/extension/lib/bookmarks.ts
+++ b/apps/extension/lib/bookmarks.ts
@@ -4,6 +4,7 @@ import {
 } from "@serial/bookmark-capture";
 import type {
   BookmarkWorkspace,
+  DiscoveredFeed,
   ExtensionBookmark,
   ExtensionCaptureCandidate,
   ExtensionPageObservation,
@@ -14,6 +15,7 @@ import type {
 export type {
   BookmarkCaptureOutcome,
   BookmarkWorkspace,
+  DiscoveredFeed,
   ExtensionBookmark,
   OrganizationOption,
   ViewOrganizationOption,
@@ -21,6 +23,7 @@ export type {
 
 export type BookmarkMessage =
   | { type: "bookmark.capture-active" }
+  | { type: "bookmark.discover-feeds"; sourceUrl: string }
   | {
       type: "bookmark.set-view";
       bookmarkId: string;
@@ -42,6 +45,7 @@ export type BookmarkMessageResponse =
   | { ok: true; status: "base" | "ineligible" }
   | { ok: true; status: "removed" | "feed-added" }
   | { ok: true; status: "saved"; workspace: BookmarkWorkspace }
+  | { ok: true; status: "feeds-discovered"; feeds: DiscoveredFeed[] }
   | { ok: true; status: "updated"; bookmark: ExtensionBookmark }
   | {
       ok: true;

--- a/packages/bookmark-capture/src/contracts.ts
+++ b/packages/bookmark-capture/src/contracts.ts
@@ -1,4 +1,5 @@
 import { CONTENT_CAPABILITIES } from "./capabilities";
+import { BOOKMARK_CAPTURE_LIMITS } from "./policy";
 import type {
   BookmarkContentPlatform,
   BookmarkContentType,
@@ -64,6 +65,42 @@ export type DiscoveredFeed = {
   url: string;
   title?: string;
 };
+
+export function parseExtensionDiscoveredFeeds(
+  value: unknown,
+): DiscoveredFeed[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length > BOOKMARK_CAPTURE_LIMITS.discoveredFeeds
+  ) {
+    return null;
+  }
+
+  const feeds: DiscoveredFeed[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry) || typeof entry.url !== "string") return null;
+    try {
+      const url = new URL(entry.url);
+      if (
+        (url.protocol !== "http:" && url.protocol !== "https:") ||
+        url.username ||
+        url.password
+      ) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    if (entry.title !== undefined && typeof entry.title !== "string") {
+      return null;
+    }
+    feeds.push({
+      url: entry.url,
+      ...(typeof entry.title === "string" ? { title: entry.title } : {}),
+    });
+  }
+  return feeds;
+}
 
 export type ExtensionBookmark = {
   id: string;


### PR DESCRIPTION
## Summary

- return a usable bookmark workspace as soon as persistence and workspace data are ready
- move server feed discovery to a separate authenticated endpoint and extension background message
- keep feed discovery loading, empty, failure, and timeout states independent from bookmark save success
- show an item-shaped skeleton only while independent discovery is loading

## Validation

- `pnpm lint` — passed (29 pre-existing warnings, 0 errors)
- `pnpm typecheck` — passed across all 7 packages
- `pnpm test:unit` — passed after rebasing onto current `beta` (app: 366 tests; extension: 40 tests; www edge: 8 tests)
- focused bookmark route tests — 20 passed
- focused extension workspace/background/view tests — 16 passed
- `pnpm format` — passed
- `git diff --check` — passed
- app `pnpm build:atomic` — passed
- extension `pnpm build` — passed for Chrome MV3
- extension `pnpm build:firefox` — passed for Firefox MV2

## Performance

- `pnpm benchmark:inventory:check` — passed; 590 direct accesses checked
- `pnpm benchmark:client:coverage:check` — passed; 339 applicable files checked
- `pnpm benchmark:app:smoke` — passed for warm Unread, Read, and Later profiles
  - Unread: median 0.59x, p95 0.58x, rows 1/100
  - Read: median 0.54x, p95 0.56x, rows 1/100
  - Later: median 0.60x, p95 0.44x, rows 1/100

## React Doctor

`pnpx react-doctor` reported 16 existing/generated findings and no findings in files changed by this branch. The findings are limited to an existing auth reset warning, generated build-output crypto warnings, extension entrypoint false-positive unused-file warnings, untouched app unused exports, and one existing unused dev dependency.

## Outstanding packaged QA

The Chrome MV3 package builds successfully, but local browser automation could not validate the popup: Chrome did not register the unpacked extension even when launched with explicit load and extension-enable flags. The ticket-required packaged Chrome popup check against staging therefore remains pending after merge/deployment. This PR does not claim that browser check passed.

## Rebase note

Rebased onto `beta` after #277. Its popup viewport constraints and this branch's independent Feed-discovery status were both preserved. The unrelated extension auth-flow test hit its five-second timeout once during the first full rerun, then passed in isolation and in the subsequent complete suite.
