### PR TITLE
Preserve cached View filter state in the app

### DIFF
--- a/apps/app/src/components/feed/ViewFilterChips.tsx
+++ b/apps/app/src/components/feed/ViewFilterChips.tsx
@@ -13,19 +13,25 @@ import {
   MAX_VIEW_SHORTCUTS,
   VIEW_SHORTCUT_KEYS,
 } from "~/lib/constants/shortcuts";
-import {
-  getNavigationAvailability,
-  useNavigationSnapshot,
-  useNavigationSnapshotStatus,
-} from "~/lib/data/navigation/store";
+import { getNavigationAvailability } from "~/lib/data/navigation/store";
 import { Skeleton } from "~/components/ui/skeleton";
 
+const VIEW_FILTER_SKELETON_WIDTHS = ["w-16", "w-22", "w-18", "w-26"];
+
+function ViewFilterChipSkeletons() {
+  return (
+    <div className="flex max-w-[calc(100vw-3rem)] flex-wrap gap-1 md:max-w-lg">
+      {VIEW_FILTER_SKELETON_WIDTHS.map((width) => (
+        <Skeleton className={clsx("h-8", width)} key={width} />
+      ))}
+    </div>
+  );
+}
+
 export function ViewFilterChips() {
-  const { views } = useViews();
+  const { views, viewAvailability, hasFetchedViews } = useViews();
   const [viewFilter] = useAtom(viewFilterIdAtom);
   const visibilityFilter = useAtomValue(visibilityFilterAtom);
-  const navigationSnapshot = useNavigationSnapshot();
-  const navigationSnapshotStatus = useNavigationSnapshotStatus();
 
   const updateViewFilter = useUpdateViewFilter();
 
@@ -45,14 +51,8 @@ export function ViewFilterChips() {
     );
   }
 
-  if (navigationSnapshotStatus !== "success") {
-    return (
-      <div className="flex max-w-[calc(100vw-3rem)] flex-wrap gap-1 md:max-w-lg">
-        {views.map((view) => (
-          <Skeleton className="h-8 w-20" key={view.id} />
-        ))}
-      </div>
-    );
+  if (!hasFetchedViews) {
+    return <ViewFilterChipSkeletons />;
   }
 
   return (
@@ -72,7 +72,7 @@ export function ViewFilterChips() {
           <ToggleGroupItem
             className={clsx("relative", {
               "opacity-50": !getNavigationAvailability(
-                navigationSnapshot.views,
+                viewAvailability,
                 view.id,
               )[visibilityFilter],
             })}

--- a/apps/app/src/lib/data/navigation/store.ts
+++ b/apps/app/src/lib/data/navigation/store.ts
@@ -1,5 +1,6 @@
 import { createStore } from "zustand";
 import { createSelectorHooks } from "../createSelectorHooks";
+import { viewsStore } from "../views/store";
 import type {
   NavigationAvailability,
   NavigationSnapshot,
@@ -26,7 +27,7 @@ let refetchRequested = false;
 let requestGeneration = 0;
 
 const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
-  (set) => ({
+  (set, get) => ({
     snapshot: EMPTY_SNAPSHOT,
     fetchStatus: "idle",
     reset: () => {
@@ -34,7 +35,10 @@ const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
       refetchRequested = false;
       set({ snapshot: EMPTY_SNAPSHOT, fetchStatus: "idle" });
     },
-    set: (snapshot) => set({ snapshot, fetchStatus: "success" }),
+    set: (snapshot) => {
+      viewsStore.getState().setViewAvailability(snapshot.views);
+      set({ snapshot, fetchStatus: "success" });
+    },
     fetch: async () => {
       if (activeFetch) {
         refetchRequested = true;
@@ -49,7 +53,7 @@ const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
             const snapshot =
               await orpcRouterClient.initial.getNavigationSnapshot();
             if (fetchGeneration === requestGeneration) {
-              set({ snapshot, fetchStatus: "success" });
+              get().set(snapshot);
             }
           } catch (error) {
             if (fetchGeneration === requestGeneration) {

--- a/apps/app/src/lib/data/views/index.ts
+++ b/apps/app/src/lib/data/views/index.ts
@@ -9,7 +9,7 @@ import {
   viewsAtom,
 } from "../atoms";
 import { INBOX_VIEW_ID, INBOX_VIEW_PLACEMENT } from "./constants";
-import { useViewsFetchStatus } from "./store";
+import { useViewAvailability, useViewsFetchStatus } from "./store";
 import type { ApplicationView } from "~/server/db/schema";
 
 export { INBOX_VIEW_ID, INBOX_VIEW_PLACEMENT };
@@ -50,9 +50,11 @@ export function useUpdateViewFilter() {
 export function useViews() {
   const views = useAtomValue(viewsAtom);
   const fetchStatus = useViewsFetchStatus();
+  const viewAvailability = useViewAvailability();
 
   return {
     views,
+    viewAvailability,
     hasFetchedViews: fetchStatus === "success",
   };
 }

--- a/apps/app/src/lib/data/views/store.ts
+++ b/apps/app/src/lib/data/views/store.ts
@@ -4,12 +4,14 @@ import { createSelectorHooks } from "../createSelectorHooks";
 import { createIDBStorage } from "../idb-storage";
 import { sortViewsByPlacement } from "./utils";
 import type { ApplicationView } from "~/server/db/schema";
+import type { NavigationAvailability } from "~/server/navigation/snapshot";
 import { orpcRouterClient } from "~/lib/orpc";
 
 export type ViewsStore = {
   reset: () => void;
   views: ApplicationView[];
   viewsDict: Record<number, ApplicationView>;
+  viewAvailability: Record<number, NavigationAvailability>;
   fetchStatus: "idle" | "fetching" | "success";
   fetch: () => Promise<void>;
   set: (views: ApplicationView[]) => void;
@@ -17,7 +19,15 @@ export type ViewsStore = {
   update: (id: number, view: Partial<ApplicationView>) => void;
   remove: (id: number) => void;
   removeFeedReferences: (feedIds: number[]) => void;
+  setViewAvailability: (
+    availability: Record<number, NavigationAvailability>,
+  ) => void;
 };
+
+export type PersistedViewsState = Pick<
+  ViewsStore,
+  "views" | "viewsDict" | "viewAvailability"
+>;
 
 export function removeFeedReferencesFromViews(
   views: ApplicationView[],
@@ -32,17 +42,19 @@ export function removeFeedReferencesFromViews(
   }));
 }
 
-const vanillaViewsStore = createStore<ViewsStore>()(
-  persist(
+export const viewsStoreApi = createStore<ViewsStore>()(
+  persist<ViewsStore, [], [], PersistedViewsState>(
     (set, get) => ({
       reset: () =>
         set({
           views: [],
           viewsDict: {},
+          viewAvailability: {},
           fetchStatus: "idle",
         }),
       views: [],
       viewsDict: {},
+      viewAvailability: {},
       fetchStatus: "idle",
 
       fetch: async () => {
@@ -133,14 +145,18 @@ const vanillaViewsStore = createStore<ViewsStore>()(
 
         set({ views: updatedViews, viewsDict });
       },
+      setViewAvailability: (viewAvailability) => {
+        set({ viewAvailability });
+      },
     }),
     {
       name: "serial-views-store",
-      storage: createIDBStorage(),
+      storage: createIDBStorage<PersistedViewsState>(),
       version: 1,
       partialize: (state) => ({
         views: state.views,
         viewsDict: state.viewsDict,
+        viewAvailability: state.viewAvailability,
       }),
       merge: (persistedState, currentState) => {
         const merged = {
@@ -156,12 +172,13 @@ const vanillaViewsStore = createStore<ViewsStore>()(
   ),
 );
 
-export const viewsStore = createSelectorHooks(vanillaViewsStore);
+export const viewsStore = createSelectorHooks(viewsStoreApi);
 
 export const {
   useViews,
   useFetchStatus: useViewsFetchStatus,
   useFetch: useFetchViews,
   useSet: useSetViews,
+  useViewAvailability,
   useRemoveFeedReferences,
 } = viewsStore;

--- a/apps/app/tests/unit/components/view-filter-chips.test.ts
+++ b/apps/app/tests/unit/components/view-filter-chips.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { createStore, Provider } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApplicationView } from "~/server/db/schema";
+import { ViewFilterChips } from "~/components/feed/ViewFilterChips";
+import {
+  viewFilterIdAtom,
+  viewsAtom,
+  visibilityFilterAtom,
+} from "~/lib/data/atoms";
+import { navigationSnapshotStore } from "~/lib/data/navigation/store";
+import { viewsStore } from "~/lib/data/views/store";
+
+vi.mock("~/components/ButtonWithShortcut", () => ({
+  KeyboardShortcutDisplay: () => null,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const NOW = new Date("2026-08-02T12:00:00.000Z");
+
+function view(id: number, name: string): ApplicationView {
+  return {
+    id,
+    userId: "view-filter-user",
+    name,
+    daysWindow: 0,
+    readStatus: 0,
+    contentFilter: 3,
+    layout: "list",
+    placement: id,
+    createdAt: NOW,
+    updatedAt: NOW,
+    categoryIds: [],
+    feedIds: [],
+    isDefault: false,
+    viewSections: [],
+  };
+}
+
+function renderViewFilterChips(
+  input: {
+    cachedViews?: ApplicationView[];
+    hasFetchedViews?: boolean;
+  } = {},
+) {
+  const cachedViews = input.cachedViews ?? [
+    view(1, "Reading"),
+    view(2, "Research"),
+  ];
+  viewsStore.setState({
+    views: cachedViews,
+    fetchStatus: input.hasFetchedViews === false ? "idle" : "success",
+  });
+  const jotaiStore = createStore();
+  jotaiStore.set(viewsAtom, cachedViews);
+  jotaiStore.set(viewFilterIdAtom, 1);
+  jotaiStore.set(visibilityFilterAtom, "unread");
+
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(
+        Provider,
+        { store: jotaiStore },
+        createElement(ViewFilterChips),
+      ),
+    );
+  });
+  const markup = container.innerHTML;
+  act(() => root.unmount());
+  return markup;
+}
+
+function chipFromMarkup(markup: string, label: string) {
+  const container = document.createElement("div");
+  container.innerHTML = markup;
+  const chip = Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent === label,
+  );
+  if (!chip) throw new Error(`Missing ${label} View chip`);
+  return chip;
+}
+
+afterEach(() => {
+  navigationSnapshotStore.getState().reset();
+  viewsStore.getState().reset();
+});
+
+describe("View filter loading", () => {
+  it("keeps cached View chips and their previous dimming while revalidating", () => {
+    navigationSnapshotStore.getState().set({
+      views: {
+        1: { unread: true, read: false, later: false },
+        2: { unread: false, read: false, later: false },
+      },
+      tags: {},
+      feeds: {},
+      viewFeeds: {},
+    });
+    navigationSnapshotStore.getState().reset();
+    navigationSnapshotStore.setState({
+      fetchStatus: "fetching",
+    });
+
+    const markup = renderViewFilterChips();
+
+    expect(markup).toContain("Reading");
+    expect(markup).toContain("Research");
+    expect(markup).not.toContain('data-slot="skeleton"');
+    expect(chipFromMarkup(markup, "Reading").classList).not.toContain(
+      "opacity-50",
+    );
+    expect(chipFromMarkup(markup, "Research").classList).toContain(
+      "opacity-50",
+    );
+  });
+
+  it("previews four content-shaped View chips on a true first load", () => {
+    const markup = renderViewFilterChips({
+      cachedViews: [],
+      hasFetchedViews: false,
+    });
+
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(4);
+    for (const width of ["w-16", "w-22", "w-18", "w-26"]) {
+      expect(markup).toContain(`h-8 ${width}`);
+    }
+
+    const renderedMarkup = renderViewFilterChips();
+    expect(chipFromMarkup(renderedMarkup, "Reading").classList).toContain(
+      "h-8",
+    );
+  });
+
+  it("applies fresh View dimming after successful revalidation", () => {
+    navigationSnapshotStore.getState().set({
+      views: {
+        1: { unread: true, read: false, later: false },
+        2: { unread: false, read: false, later: false },
+      },
+      tags: {},
+      feeds: {},
+      viewFeeds: {},
+    });
+    navigationSnapshotStore.getState().set({
+      views: {
+        1: { unread: false, read: false, later: false },
+        2: { unread: true, read: false, later: false },
+      },
+      tags: {},
+      feeds: {},
+      viewFeeds: {},
+    });
+
+    const markup = renderViewFilterChips();
+
+    expect(chipFromMarkup(markup, "Reading").classList).toContain("opacity-50");
+    expect(chipFromMarkup(markup, "Research").classList).not.toContain(
+      "opacity-50",
+    );
+  });
+
+  it("retains previous View dimming after failed revalidation", () => {
+    navigationSnapshotStore.getState().set({
+      views: {
+        1: { unread: true, read: false, later: false },
+        2: { unread: false, read: false, later: false },
+      },
+      tags: {},
+      feeds: {},
+      viewFeeds: {},
+    });
+    navigationSnapshotStore.getState().reset();
+
+    const markup = renderViewFilterChips();
+
+    expect(chipFromMarkup(markup, "Reading").classList).not.toContain(
+      "opacity-50",
+    );
+    expect(chipFromMarkup(markup, "Research").classList).toContain(
+      "opacity-50",
+    );
+  });
+});

--- a/apps/app/tests/unit/views/view-availability-cache.test.ts
+++ b/apps/app/tests/unit/views/view-availability-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+
+import type { PersistedViewsState } from "~/lib/data/views/store";
+import { viewsStoreApi } from "~/lib/data/views/store";
+
+function createMemoryStorage() {
+  const values = new Map<string, StorageValue<PersistedViewsState>>();
+  const storage: PersistStorage<PersistedViewsState> = {
+    getItem: (name) => values.get(name) ?? null,
+    setItem: (name, value) => {
+      values.set(name, value);
+    },
+    removeItem: (name) => {
+      values.delete(name);
+    },
+  };
+  return {
+    storage,
+    values,
+  };
+}
+
+describe("View availability cache", () => {
+  it("restores the last successful View availability with no other navigation data", async () => {
+    const { storage, values } = createMemoryStorage();
+    const originalStorage = viewsStoreApi.persist.getOptions().storage;
+    viewsStoreApi.persist.setOptions({ storage });
+    try {
+      viewsStoreApi.getState().reset();
+      viewsStoreApi.getState().setViewAvailability({
+        1: { unread: true, read: false, later: false },
+        2: { unread: false, read: true, later: true },
+      });
+      const persisted = values.get("serial-views-store");
+      if (!persisted) throw new Error("View availability was not persisted");
+
+      viewsStoreApi.getState().reset();
+      values.set("serial-views-store", persisted);
+      await viewsStoreApi.persist.rehydrate();
+
+      expect(viewsStoreApi.getState().viewAvailability).toEqual({
+        1: { unread: true, read: false, later: false },
+        2: { unread: false, read: true, later: true },
+      });
+      expect(Object.keys(persisted.state)).not.toEqual(
+        expect.arrayContaining(["tags", "feeds", "viewFeeds"]),
+      );
+    } finally {
+      viewsStoreApi.persist.setOptions({ storage: originalStorage });
+      viewsStoreApi.getState().reset();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- keep hydrated app View chips interactive while navigation availability revalidates
- persist only the last successful per-View availability and use it for initial chip dimming
- retain previous dimming after refresh failures and replace it only after a successful snapshot
- show four content-shaped 32px skeleton chips only on a true first load

## Validation

- `pnpm test:unit` (59 files, 366 tests)
- `pnpm test:e2e:self-hosted tests/e2e/self-hosted/view-mixed-content-matrix.spec.ts --reporter=line --workers=1` (38 tests)
- `pnpm typecheck`
- `pnpm format`
- `pnpm lint` (0 errors; 29 existing warnings)
- `pnpm build:atomic`
- full client performance gate (small, representative, stress)
- React Doctor changed scope (100/100)
- manual desktop and 390px mobile app QA, including reload persistence

## Performance

Adds one persisted availability record per View and one throttled IndexedDB update after each successful navigation snapshot. The stress client benchmark remained within budget; `localViewProjection` measured about 7.61 ms against a 50 ms gate.
