### PR TITLE
Prefer detected YouTube thumbnails for Bookmarks

### DIFF
--- a/apps/app/src/lib/content/classification.ts
+++ b/apps/app/src/lib/content/classification.ts
@@ -339,9 +339,3 @@ export function mergePreview(
   if (candidateWins && usedCandidate) next.previewSource = candidate.source;
   return next;
 }
-
-export function youtubeThumbnailUrl(contentId: string | null) {
-  return contentId && YOUTUBE_VIDEO_ID.test(contentId)
-    ? `https://i.ytimg.com/vi/${contentId}/hqdefault.jpg`
-    : null;
-}

--- a/apps/app/src/server/bookmarks/extract.ts
+++ b/apps/app/src/server/bookmarks/extract.ts
@@ -1,4 +1,5 @@
 import { Readability } from "@mozilla/readability";
+import { selectBookmarkPreviewThumbnail } from "@serial/bookmark-capture";
 import { JSDOM } from "jsdom";
 import {
   BOOKMARK_CAPTURE_LIMITS,
@@ -29,7 +30,6 @@ import {
   createFallbackPreview,
   isValidNativeContentIdForUrl,
   mergePreview,
-  youtubeThumbnailUrl,
 } from "~/lib/content/classification";
 import {
   CONTENT_PLATFORM,
@@ -115,12 +115,13 @@ export function buildUrlFallbackObservation(
   const normalized = normalizeBookmarkUrl(sourceUrl);
   const classification = classifyUrl(normalized);
   let preview = createFallbackPreview(normalized);
-  if (classification.platform === CONTENT_PLATFORM.YOUTUBE) {
-    preview = mergePreview(preview, {
-      source: OBSERVATION_SOURCE.URL,
-      thumbnailUrl: youtubeThumbnailUrl(classification.contentId),
-    });
-  }
+  preview = mergePreview(preview, {
+    source: OBSERVATION_SOURCE.URL,
+    thumbnailUrl: selectBookmarkPreviewThumbnail({
+      ...classification,
+      observedThumbnailUrl: preview.thumbnailUrl,
+    }),
+  });
   return buildObservation({
     sourceUrl: normalized,
     effectiveUrl: normalized,
@@ -205,14 +206,13 @@ function extensionPreview(input: {
       BOOKMARK_CAPTURE_LIMITS.siteNameCodePoints,
     ),
     publishedAt: optionalPublishedAt(input.candidate.publishedAt),
-    thumbnailUrl:
-      resolveOptionalHttpUrl(
+    thumbnailUrl: selectBookmarkPreviewThumbnail({
+      ...input.classification,
+      observedThumbnailUrl: resolveOptionalHttpUrl(
         input.candidate.thumbnailUrl,
         input.effectiveUrl,
-      ) ??
-      (input.classification.platform === CONTENT_PLATFORM.YOUTUBE
-        ? youtubeThumbnailUrl(input.classification.contentId)
-        : null),
+      ),
+    }),
     iconUrl: resolveOptionalHttpUrl(
       input.candidate.iconUrl,
       input.effectiveUrl,
@@ -359,17 +359,16 @@ function staticPreviewCandidate(input: {
       article?.publishedTime ??
         metaContent(document, 'meta[property="article:published_time"]'),
     ),
-    thumbnailUrl:
-      resolveOptionalHttpUrl(
+    thumbnailUrl: selectBookmarkPreviewThumbnail({
+      ...classification,
+      observedThumbnailUrl: resolveOptionalHttpUrl(
         metaContent(
           document,
           'meta[property="og:image"], meta[name="twitter:image"]',
         ),
         effectiveUrl,
-      ) ??
-      (classification.platform === CONTENT_PLATFORM.YOUTUBE
-        ? youtubeThumbnailUrl(classification.contentId)
-        : null),
+      ),
+    }),
     iconUrl: resolveOptionalHttpUrl(
       document.querySelector('link[rel~="icon"]')?.getAttribute("href"),
       effectiveUrl,

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { createClient } from "@libsql/client";
 import { eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/libsql";
@@ -45,6 +45,28 @@ export async function cleanupUser(tursoPort: number, email: string) {
   const { db, client } = getDb(tursoPort);
   await db.delete(schema.user).where(eq(schema.user.email, email));
   client.close();
+}
+
+export async function seedExtensionSession(tursoPort: number, email: string) {
+  const { db, client } = getDb(tursoPort);
+  const testUser = await db
+    .select({ id: schema.user.id })
+    .from(schema.user)
+    .where(eq(schema.user.email, email))
+    .get();
+  if (!testUser) {
+    client.close();
+    throw new Error("Extension session seed user was not found");
+  }
+  const token = `serial_ext_${randomBytes(32).toString("base64url")}`;
+  const tokenHash = createHash("sha256").update(token).digest("base64url");
+  await db.insert(schema.extensionSession).values({
+    tokenHash,
+    userId: testUser.id,
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  client.close();
+  return token;
 }
 
 export async function seedClientPerformanceData(

--- a/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
@@ -8,6 +8,7 @@ import {
   getBookmarkState,
   seedArticleData,
   seedBookmarkProjectionData,
+  seedExtensionSession,
 } from "../fixtures/seed-db";
 import { signIn } from "../fixtures/auth";
 
@@ -172,6 +173,58 @@ test.describe("Bookmark Serial-app flow", () => {
         };
       })
       .toEqual({ isSaved: false, isRead: true, hasProgress: true });
+  });
+
+  test("renders the detected YouTube thumbnail instead of page metadata", async ({
+    page,
+    request,
+  }) => {
+    const { email, password } = await seedArticleData(
+      SELF_HOSTED_TURSO_PORT,
+      SELF_HOSTED_APP_PORT,
+    );
+    testEmail = email;
+    const token = await seedExtensionSession(SELF_HOSTED_TURSO_PORT, email);
+    const videoId = "dQw4w9WgXcQ";
+    const sourceUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    const saveResponse = await request.post("/api/extension/bookmarks", {
+      headers: { Authorization: `Bearer ${token}` },
+      data: {
+        contractVersion: 2,
+        sourceUrl,
+        capture: {
+          effectiveUrl: sourceUrl,
+          title: "Detected YouTube Bookmark",
+          thumbnailUrl: "https://metadata.example/standard-youtube.jpg",
+          descriptor: {
+            platform: "youtube",
+            contentType: "video",
+            orientation: null,
+            contentId: videoId,
+            classifierVersion: 1,
+          },
+        },
+        feeds: [],
+      },
+    });
+    expect(saveResponse.status()).toBe(201);
+    const saved = (await saveResponse.json()) as { bookmark: { id: string } };
+
+    await page.route("https://i.ytimg.com/**", (route) => route.abort());
+    await signIn({ page, email, password });
+    await page
+      .getByRole("radio", { name: "Uncategorized", exact: true })
+      .click();
+    await page.getByRole("tab", { name: /Saved/ }).click();
+    const bookmarkCard = page.locator(
+      `article[data-item-id="${saved.bookmark.id}"][data-entity-kind="bookmark"]`,
+    );
+    await expect(bookmarkCard).toContainText("Detected YouTube Bookmark", {
+      timeout: 30_000,
+    });
+    await expect(
+      bookmarkCard.getByRole("img", { name: "Detected YouTube Bookmark" }),
+    ).toHaveAttribute("src", `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`);
   });
 
   test("refreshes a duplicate without losing organization when capture fails", async ({

--- a/apps/app/tests/unit/bookmarks/extract.test.ts
+++ b/apps/app/tests/unit/bookmarks/extract.test.ts
@@ -6,6 +6,9 @@ import {
   prepareExtensionCapture,
 } from "~/server/bookmarks/extract";
 
+const YOUTUBE_ID = "dQw4w9WgXcQ";
+const YOUTUBE_THUMBNAIL_URL = `https://i.ytimg.com/vi/${YOUTUBE_ID}/hqdefault.jpg`;
+
 function extensionCandidate(
   overrides: Partial<ExtensionCaptureCandidate> = {},
 ): ExtensionCaptureCandidate {
@@ -77,6 +80,38 @@ describe("Page capture preparation", () => {
     ).toEqual({ ok: false, reason: "unsupported_capture_version" });
   });
 
+  it.each([
+    ["Watch", `https://www.youtube.com/watch?v=${YOUTUBE_ID}`, null],
+    ["Shorts", `https://www.youtube.com/shorts/${YOUTUBE_ID}`, "vertical"],
+  ] as const)(
+    "trusts the detected YouTube thumbnail ahead of %s page metadata",
+    (_pageType, sourceUrl, orientation) => {
+      const result = prepareExtensionCapture({
+        sourceUrl,
+        candidate: extensionCandidate({
+          effectiveUrl: sourceUrl,
+          thumbnailUrl: "https://metadata.example/standard-youtube.jpg",
+          descriptor: {
+            platform: "youtube",
+            contentType: "video",
+            orientation,
+            contentId: YOUTUBE_ID,
+            classifierVersion: 1,
+          },
+          contentHtml: undefined,
+          extractorVersion: undefined,
+          sanitizerPolicyVersion: undefined,
+        }),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.result.observation.preview.thumbnailUrl).toBe(
+        YOUTUBE_THUMBNAIL_URL,
+      );
+    },
+  );
+
   it("extracts static reader content without trusting a cross-origin canonical", () => {
     const result = extractStaticCapture({
       sourceUrl: "https://example.com/submitted",
@@ -106,6 +141,20 @@ describe("Page capture preparation", () => {
       'href="https://example.com/next"',
     );
     expect(result.observation.capture?.contentHtml).not.toContain("script");
+  });
+
+  it("prefers the detected YouTube thumbnail during static extraction", () => {
+    const sourceUrl = `https://www.youtube.com/watch?v=${YOUTUBE_ID}`;
+    const result = extractStaticCapture({
+      sourceUrl,
+      effectiveUrl: sourceUrl,
+      html: `<!doctype html><html><head>
+        <title>YouTube video</title>
+        <meta property="og:image" content="https://metadata.example/standard-youtube.jpg">
+      </head><body></body></html>`,
+    });
+
+    expect(result.observation.preview.thumbnailUrl).toBe(YOUTUBE_THUMBNAIL_URL);
   });
 
   it("rejects an oversized DOM before parsing structured data or cloning", () => {

--- a/apps/app/tests/unit/content/classification.test.ts
+++ b/apps/app/tests/unit/content/classification.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  selectBookmarkPreviewThumbnail,
+  youtubeThumbnailUrl,
+} from "@serial/bookmark-capture";
 import type { BookmarkClassification } from "~/lib/content/classification";
 import {
   classifyDocument,
@@ -7,7 +11,6 @@ import {
   isValidNativeContentIdForUrl,
   mergeClassification,
   mergePreview,
-  youtubeThumbnailUrl,
 } from "~/lib/content/classification";
 
 const YOUTUBE_ID = "dQw4w9WgXcQ";
@@ -159,4 +162,29 @@ describe("content classification", () => {
     expect(youtubeThumbnailUrl(YOUTUBE_ID)).toContain(YOUTUBE_ID);
     expect(youtubeThumbnailUrl("invalid")).toBeNull();
   });
+
+  it.each([
+    ["youtube", "video", YOUTUBE_ID, true],
+    ["youtube", "text", null, false],
+    ["website", "video", null, false],
+    ["peertube", "video", PEERTUBE_ID, false],
+    ["nebula", "video", "episode", false],
+  ] as const)(
+    "applies detected thumbnail precedence only to %s %s content",
+    (platform, contentType, contentId, expectsDetectedThumbnail) => {
+      const observedThumbnailUrl = "https://example.com/observed.jpg";
+      expect(
+        selectBookmarkPreviewThumbnail({
+          platform,
+          contentType,
+          contentId,
+          observedThumbnailUrl,
+        }),
+      ).toBe(
+        expectsDetectedThumbnail
+          ? youtubeThumbnailUrl(YOUTUBE_ID)
+          : observedThumbnailUrl,
+      );
+    },
+  );
 });

--- a/apps/extension/lib/bookmark-capture.test.ts
+++ b/apps/extension/lib/bookmark-capture.test.ts
@@ -6,6 +6,9 @@ import {
 } from "@serial/bookmark-capture";
 import { serializeBookmarkRequest } from "./bookmarks";
 
+const YOUTUBE_THUMBNAIL_URL =
+  "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg";
+
 function pageDocument(body: string, head = "") {
   return new JSDOM(
     `<!doctype html><html><head><title>Fixture article</title>${head}</head><body>${body}</body></html>`,
@@ -61,6 +64,26 @@ describe("extension live DOM Bookmark capture", () => {
     expect(result.capture.title).toBe("Current Short title");
     expect(result.capture.author).toBe("Current Shorts channel");
   });
+
+  it.each([
+    ["Watch", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+    ["Shorts", "https://www.youtube.com/shorts/dQw4w9WgXcQ"],
+  ])(
+    "prefers the detected YouTube thumbnail for %s pages",
+    (_pageType, url) => {
+      const document = new JSDOM(
+        `<!doctype html><html><head>
+          <title>YouTube video</title>
+          <meta property="og:image" content="https://metadata.example/standard-youtube.jpg">
+        </head><body></body></html>`,
+        { url },
+      ).window.document;
+
+      const result = extractPageObservation(document);
+
+      expect(result.capture.thumbnailUrl).toBe(YOUTUBE_THUMBNAIL_URL);
+    },
+  );
 
   it("chooses the strongest social-image metadata independently of document order", () => {
     const document = pageDocument(
@@ -226,9 +249,11 @@ describe("extension live DOM Bookmark capture", () => {
       contentType: fixture.contentType,
     });
     expect(result.capture.title).toBe("General preview title");
-    expect(result.capture.thumbnailUrl).toBe(
-      `${new URL(fixture.url).origin}/general-cover.jpg`,
-    );
+    const expectedThumbnailUrl =
+      fixture.platform === "youtube" && fixture.contentType === "video"
+        ? YOUTUBE_THUMBNAIL_URL
+        : `${new URL(fixture.url).origin}/general-cover.jpg`;
+    expect(result.capture.thumbnailUrl).toBe(expectedThumbnailUrl);
   });
 
   it("extracts a clone, resolves lazy and relative URLs, and discovers Feeds", () => {

--- a/packages/bookmark-capture/src/extract.ts
+++ b/packages/bookmark-capture/src/extract.ts
@@ -254,6 +254,7 @@ export function extractPageObservation(
     inspectStructuredData: !tooLarge,
     platform: descriptor.platform,
     contentType: descriptor.contentType,
+    contentId: descriptor.contentId,
   });
   const capture: ExtensionCaptureCandidate = {
     effectiveUrl,

--- a/packages/bookmark-capture/src/index.ts
+++ b/packages/bookmark-capture/src/index.ts
@@ -3,3 +3,4 @@ export * from "./contracts";
 export * from "./extract";
 export * from "./mutations";
 export * from "./policy";
+export * from "./thumbnail";

--- a/packages/bookmark-capture/src/preview.ts
+++ b/packages/bookmark-capture/src/preview.ts
@@ -4,6 +4,7 @@ import type {
 } from "./capabilities";
 import { boundedText, metaContent, resolvedHttpUrl } from "./metadata";
 import { BOOKMARK_CAPTURE_LIMITS } from "./policy";
+import { selectBookmarkPreviewThumbnail } from "./thumbnail";
 
 export type PreviewArticleMetadata = {
   title?: string | null;
@@ -27,6 +28,7 @@ type PreviewExtractionInput = {
   effectiveUrl: string;
   article: PreviewArticleMetadata | null;
   inspectStructuredData: boolean;
+  contentId: string | null;
 };
 
 type PreviewStrategy = (
@@ -364,10 +366,17 @@ function youtubeVideoPreview(
     ],
     BOOKMARK_CAPTURE_LIMITS.authorCodePoints,
   );
+  const thumbnailUrl = selectBookmarkPreviewThumbnail({
+    platform: "youtube",
+    contentType: "video",
+    contentId: input.contentId,
+    observedThumbnailUrl: preview.thumbnailUrl,
+  });
   return {
     ...preview,
     ...(liveTitle ? { title: liveTitle } : {}),
     ...(liveAuthor ? { author: liveAuthor } : {}),
+    ...(thumbnailUrl ? { thumbnailUrl } : {}),
   };
 }
 

--- a/packages/bookmark-capture/src/thumbnail.ts
+++ b/packages/bookmark-capture/src/thumbnail.ts
@@ -1,0 +1,24 @@
+import type {
+  BookmarkContentPlatform,
+  BookmarkContentType,
+} from "./capabilities";
+
+const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/;
+
+export function youtubeThumbnailUrl(contentId: string | null) {
+  return contentId && YOUTUBE_VIDEO_ID.test(contentId)
+    ? `https://i.ytimg.com/vi/${contentId}/hqdefault.jpg`
+    : null;
+}
+
+export function selectBookmarkPreviewThumbnail(input: {
+  platform: BookmarkContentPlatform;
+  contentType: BookmarkContentType;
+  contentId: string | null;
+  observedThumbnailUrl?: string | null;
+}) {
+  if (input.platform !== "youtube" || input.contentType !== "video") {
+    return input.observedThumbnailUrl;
+  }
+  return youtubeThumbnailUrl(input.contentId) ?? input.observedThumbnailUrl;
+}


### PR DESCRIPTION
## Summary

- centralize YouTube-only Bookmark thumbnail precedence in the shared capture package
- prefer derived Watch and Shorts thumbnails over page metadata in live-extension and trusted server ingestion
- preserve existing image selection for YouTube text pages and all non-YouTube platforms
- add focused unit coverage and a self-hosted browser flow through the extension API and Bookmark card

## Validation

- pnpm typecheck
- pnpm format
- pnpm lint (passes with 29 existing warnings)
- pnpm test:unit (app: 379 passed; extension: 56 passed; edge script: 8 passed)
- pnpm test:e2e:self-hosted tests/e2e/self-hosted/bookmark-app-flow.spec.ts --reporter=line (3 passed)
- pnpm build
- pnpm benchmark:inventory:check (592 direct database accesses checked)
- pnpm benchmark:client:coverage:check (339 applicable client files checked)
- pnpm benchmark:app:smoke (all warm small-profile visibility cells passed; median ratios 0.57-0.59x, p95 ratios 0.56-0.78x)
- pnpx react-doctor (no branch-introduced findings; 16 existing warnings)

## Performance impact

The runtime change is one constant-time platform/content check plus a bounded 11-character video-ID regex during Bookmark capture. It does not add database queries, synchronization work, retained state, or render-path work. Inventory and client-coverage checks are unchanged, and the declared app smoke benchmark passes all cells.