### PR TITLE
Strip image links in both readers

### DIFF
--- a/apps/app/src/components/bookmarks/BookmarkArticleContent.tsx
+++ b/apps/app/src/components/bookmarks/BookmarkArticleContent.tsx
@@ -5,6 +5,7 @@ import parse, { Element } from "html-react-parser";
 import { useEffect, useState } from "react";
 import type { HTMLReactParserOptions } from "html-react-parser";
 import { CustomVideoPlayer } from "~/components/CustomVideoPlayer";
+import { flattenReaderImages } from "~/components/content-reader/flattenReaderImages";
 import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
 import { useFlagState } from "~/lib/hooks/useFlagState";
 import {
@@ -93,5 +94,8 @@ export function BookmarkArticleContent({ content }: { content: string }) {
     },
   };
 
-  return <>{parse(sanitizedContent, options)}</>;
+  const parsed = parse(sanitizedContent, options);
+  const nodes = Array.isArray(parsed) ? parsed : [parsed];
+
+  return <>{flattenReaderImages(nodes)}</>;
 }

--- a/apps/app/src/components/content-reader/flattenReaderImages.tsx
+++ b/apps/app/src/components/content-reader/flattenReaderImages.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
+
+function isImageLightbox(node: React.ReactNode): boolean {
+  return React.isValidElement(node) && node.type === ArticleImageLightbox;
+}
+
+function hasLinkedContent(node: React.ReactNode): boolean {
+  if (typeof node === "string") return node.trim().length > 0;
+  if (typeof node === "number") return true;
+  if (!React.isValidElement<{ children?: React.ReactNode }>(node)) return false;
+
+  return React.Children.toArray(node.props.children).some(hasLinkedContent);
+}
+
+function extractImages(node: React.ReactNode): {
+  images: React.ReactNode[];
+  rest: React.ReactNode | null;
+} {
+  if (!React.isValidElement(node)) return { images: [], rest: node };
+
+  if (isImageLightbox(node)) return { images: [node], rest: null };
+
+  const element = node as React.ReactElement<{ children?: React.ReactNode }>;
+  const children = React.Children.toArray(element.props.children);
+  if (children.length === 0) return { images: [], rest: node };
+
+  const collectedImages: React.ReactNode[] = [];
+  const remainingChildren: React.ReactNode[] = [];
+
+  for (const child of children) {
+    const { images, rest } = extractImages(child);
+    collectedImages.push(...images);
+    if (rest !== null) remainingChildren.push(rest);
+  }
+
+  if (collectedImages.length === 0) return { images: [], rest: node };
+
+  const anchorHasLinkedContent = remainingChildren.some(hasLinkedContent);
+  const keepWrapper =
+    remainingChildren.length > 0 &&
+    (element.type !== "a" || anchorHasLinkedContent);
+  const rest = keepWrapper
+    ? React.cloneElement(element, undefined, ...remainingChildren)
+    : null;
+
+  return { images: collectedImages, rest };
+}
+
+export function flattenReaderImages(
+  nodes: React.ReactNode[],
+): React.ReactNode[] {
+  const result: React.ReactNode[] = [];
+  for (const node of nodes) {
+    const { images, rest } = extractImages(node);
+    result.push(...images);
+    if (rest !== null) result.push(rest);
+  }
+  return result;
+}

--- a/apps/app/src/components/feed/read/ArticleContent.tsx
+++ b/apps/app/src/components/feed/read/ArticleContent.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React from "react";
 import parse, { Element } from "html-react-parser";
 import type { HTMLReactParserOptions } from "html-react-parser";
 import { CustomVideoPlayer } from "~/components/CustomVideoPlayer";
+import { flattenReaderImages } from "~/components/content-reader/flattenReaderImages";
 import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
 import { useFlagState } from "~/lib/hooks/useFlagState";
 import classes from "~/components/feed/read/article.module.css";
@@ -112,50 +112,5 @@ export function ArticleContent({ content }: { content: string }) {
   const parsed = parse(content, options);
   const nodes = Array.isArray(parsed) ? parsed : [parsed];
 
-  return <>{flattenImages(nodes)}</>;
-}
-
-function isImageLightbox(node: React.ReactNode): boolean {
-  return React.isValidElement(node) && node.type === ArticleImageLightbox;
-}
-
-function extractImages(node: React.ReactNode): {
-  images: React.ReactNode[];
-  rest: React.ReactNode | null;
-} {
-  if (!React.isValidElement(node)) return { images: [], rest: node };
-
-  if (isImageLightbox(node)) return { images: [node], rest: null };
-
-  const element = node as React.ReactElement<{ children?: React.ReactNode }>;
-  const children = React.Children.toArray(element.props.children);
-  if (children.length === 0) return { images: [], rest: node };
-
-  const collectedImages: React.ReactNode[] = [];
-  const remainingChildren: React.ReactNode[] = [];
-
-  for (const child of children) {
-    const { images, rest } = extractImages(child);
-    collectedImages.push(...images);
-    if (rest !== null) remainingChildren.push(rest);
-  }
-
-  if (collectedImages.length === 0) return { images: [], rest: node };
-
-  const rest =
-    remainingChildren.length > 0
-      ? React.cloneElement(element, undefined, ...remainingChildren)
-      : null;
-
-  return { images: collectedImages, rest };
-}
-
-function flattenImages(nodes: React.ReactNode[]): React.ReactNode[] {
-  const result: React.ReactNode[] = [];
-  for (const node of nodes) {
-    const { images, rest } = extractImages(node);
-    result.push(...images);
-    if (rest !== null) result.push(rest);
-  }
-  return result;
+  return <>{flattenReaderImages(nodes)}</>;
 }

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -232,7 +232,9 @@ export async function seedBookmarkProjectionData(
     bookmarkId,
     contentHtml: `<p>Captured Bookmark body</p>
       <p><a href="https://example.com/next">External reader link</a></p>
-      <img src="https://images.example.com/reader.jpg" alt="Reader image" onerror="steal()">
+      <a href="https://example.com/image-target">
+        <img src="https://images.example.com/reader.jpg" alt="Reader image" onerror="steal()">
+      </a>
       <div data-serial-embed="youtube" data-video-id="dQw4w9WgXcQ" data-start="42"></div>
       ${ARTICLE_HTML}
       <script data-testid="unsafe-capture-script">steal()</script>`,

--- a/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
@@ -236,7 +236,8 @@ test.describe("article progress tracking", () => {
     await setFeedItemContent(
       SELF_HOSTED_TURSO_PORT,
       feedItemId,
-      '<img src="/icon-192x192.png" alt="Keyboard preview">',
+      `<a href="https://example.com/image-target"><img src="/icon-192x192.png" alt="Keyboard preview"></a>
+       <a href="https://example.com/article">Ordinary reader link</a>`,
     );
 
     await signIn({ page, email, password });
@@ -247,6 +248,12 @@ test.describe("article progress tracking", () => {
         name: "Open image preview: Keyboard preview",
       }),
     ).toBeVisible();
+    await expect(
+      page.locator('a[href="https://example.com/image-target"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: "Ordinary reader link" }),
+    ).toHaveAttribute("target", "_blank");
 
     await page.keyboard.press("ArrowDown");
     await expect(page.locator("[data-lightbox]")).toHaveAttribute(

--- a/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
@@ -70,6 +70,16 @@ test.describe("Bookmark Serial-app flow", () => {
     const remoteImage = page.getByAltText("Reader image");
     await expect(remoteImage).toHaveAttribute("referrerpolicy", "no-referrer");
     await expect(remoteImage).toHaveAttribute("loading", "lazy");
+    const remoteImageTrigger = page.getByRole("button", {
+      name: "Open image preview: Reader image",
+    });
+    await expect(
+      page.locator('a[href="https://example.com/image-target"]'),
+    ).toHaveCount(0);
+    await remoteImageTrigger.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
     await expect(page.locator("[data-article-video-embed]")).toBeVisible();
     await expect(page.getByTitle("YouTube video player")).toHaveAttribute(
       "src",

--- a/apps/app/tests/unit/components/reader-content-images.test.ts
+++ b/apps/app/tests/unit/components/reader-content-images.test.ts
@@ -1,0 +1,73 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ReactNode } from "react";
+import { flattenReaderImages } from "~/components/content-reader/flattenReaderImages";
+import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
+
+function renderReaderNodes(...nodes: ReactNode[]) {
+  return renderToStaticMarkup(
+    createElement("main", null, ...flattenReaderImages(nodes)),
+  );
+}
+
+describe("reader content images", () => {
+  it("removes navigation wrapped around an image", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "a",
+        { href: "https://example.com/image-target" },
+        "\n  ",
+        createElement(
+          "span",
+          null,
+          "\n",
+          createElement(ArticleImageLightbox, {
+            src: "https://example.com/image.jpg",
+            alt: "Linked preview",
+          }),
+          "  ",
+        ),
+        "\n",
+      ),
+    );
+
+    expect(markup).toContain('aria-label="Open image preview: Linked preview"');
+    expect(markup).not.toContain("image-target");
+  });
+
+  it("preserves linked text next to a non-navigating image", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "a",
+        { href: "https://example.com/article" },
+        createElement(ArticleImageLightbox, {
+          src: "https://example.com/image.jpg",
+          alt: "Mixed preview",
+        }),
+        "Read the article",
+      ),
+    );
+
+    expect(markup.indexOf("Open image preview: Mixed preview")).toBeLessThan(
+      markup.indexOf("Read the article"),
+    );
+    expect(markup).toContain(
+      '<a href="https://example.com/article">Read the article</a>',
+    );
+  });
+
+  it("leaves ordinary links unchanged", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "a",
+        { href: "https://example.com/article" },
+        "Read the article",
+      ),
+    );
+
+    expect(markup).toContain(
+      '<a href="https://example.com/article">Read the article</a>',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- share the Feed reader image-flattening transform with Bookmark Page captures
- remove whitespace-only image anchor remnants while preserving linked text and ordinary navigation
- cover Feed-item and Bookmark reader behavior with focused unit and headless end-to-end tests

## Validation

- `pnpm test:unit` — 61 files, 382 tests passed
- `pnpm typecheck`
- `pnpm format`
- `pnpm lint` — zero errors; 29 existing warnings
- `pnpm benchmark:inventory:check` — 592 accesses checked
- `pnpm benchmark:client:coverage:check` — 340 client files checked
- `pnpm test:e2e:self-hosted tests/e2e/self-hosted/article-progress.spec.ts tests/e2e/self-hosted/bookmark-app-flow.spec.ts --grep ... --reporter=line --workers=1` — both affected production-build reader cases passed
- `pnpx react-doctor --verbose --scope changed` — 100/100, no findings

## Performance impact

The change adds one recursive render-time traversal to Bookmark Page-capture content and reuses the existing Feed-item traversal. The declared small client benchmark completed within all structural budgets. The retained representative browser audit was also attempted with `SERIAL_RUN_CLIENT_PERFORMANCE=1` through the declared self-hosted E2E script, but its Node process exhausted the 4 GB heap before producing a budget artifact; no heap-option workaround was used. Production-build Feed-item and Page-capture reader E2E coverage passed after rebasing onto current `beta`.