### PR TITLE
Deploy Chrome and Firefox extensions from main

### DIFF
--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -29,13 +29,15 @@ setting below exist.
 
 2. In the Chrome Web Store Developer Dashboard, add a new item and upload
    `apps/extension/.output/*-chrome.zip`. Save it as a draft; do not submit it
-   for review yet.
+   for review yet. The store ZIP intentionally omits the development-only
+   manifest `key`; the dashboard assigns the listing identity.
 3. Record the item ID. On the Package tab, choose **View public key** and copy
    the base64 text between the PEM markers as one line.
 4. Replace `CHROME_EXTENSION_MANIFEST_KEY` and its derived
    `CHROME_EXTENSION_ID` in `packages/extension-identity/src/index.ts`. Run the
-   identity tests and rebuild the Chrome package. Its unpacked extension ID must
-   match the dashboard item ID.
+   identity tests and a local Chrome build. Its unpacked extension ID must match
+   the dashboard item ID. Rebuild the store packages separately; they continue
+   to omit the manifest `key`.
 5. Upload the rebuilt package to the same draft. Complete the Store listing,
    Privacy, Distribution, and Test instructions tabs. The privacy declarations
    must match `apps/extension/README.md` and the actual permission/data flow.

--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -53,7 +53,7 @@ API setup is documented at
 ### Firefox Add-ons
 
 1. Upload `apps/extension/.output/*-firefox.zip` to AMO as a listed add-on with
-   ID `extension@serial.tube`. Include
+   ID `serial@megaflora.net`. Include
    `apps/extension/.output/*-sources.zip` when AMO requests source code.
 2. Complete the listing, privacy/data-collection declarations, reviewer notes,
    and initial review. Publish the first listed version.
@@ -95,7 +95,7 @@ Create these Actions repository variables:
 | `CHROME_PUBLISHER_ID`               | Publisher ID from Chrome dashboard Settings                          |
 | `CHROME_SERVICE_ACCOUNT`            | Google service-account email added to Chrome Web Store               |
 | `CHROME_WORKLOAD_IDENTITY_PROVIDER` | Full `projects/.../providers/...` provider resource name             |
-| `FIREFOX_EXTENSION_ID`              | `extension@serial.tube`                                              |
+| `FIREFOX_EXTENSION_ID`              | `serial@megaflora.net`                                               |
 
 Create these Actions repository secrets:
 

--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -25,6 +25,7 @@ setting below exist.
 
    ```sh
    pnpm --filter @serial/extension zip:stores
+   pnpm --filter @serial/extension lint:firefox
    ```
 
 2. In the Chrome Web Store Developer Dashboard, add a new item and upload
@@ -59,6 +60,18 @@ API setup is documented at
    and initial review. Publish the first listed version.
 3. Create AMO API credentials from the developer credentials page. Store the
    issuer and secret only in GitHub Actions secrets.
+
+The package passes AMO lint with five reviewed `innerHTML` warnings from
+unmodified third-party libraries. Include these source links and versions in
+**Notes for Reviewers**:
+
+- Mozilla Readability 0.6.0: <https://github.com/mozilla/readability>
+- DOMPurify 3.4.12: <https://github.com/cure53/DOMPurify>
+- React DOM 19.2.7: <https://github.com/facebook/react>
+
+Readability and DOMPurify are used only by the content-script capture pipeline;
+React DOM renders the extension popup. The Firefox source ZIP includes the
+lockfile, unminified Serial source, and deterministic rebuild instructions.
 
 Mozilla's API credential instructions are at
 <https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/#obtain-an-api-key>.

--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -1,0 +1,124 @@
+# Browser extension deployment
+
+`deploy-extension.yml` builds and submits Chrome and Firefox updates after an
+affected push reaches `main`. Store reviews remain asynchronous; accepted
+updates publish automatically. A manual workflow dispatch forces a release.
+
+The workflow uses a UTC calendar manifest version with four Chrome-compatible
+integer components:
+
+```text
+year.day-of-year.hour.second-within-hour
+```
+
+For example, `2026.215.14.1832` represents 2026 day 215 at 14:30:32 UTC. Local
+builds continue to use the version in `apps/extension/package.json`.
+
+## One-time listing bootstrap
+
+Do not merge this workflow to `main` until both listings and every repository
+setting below exist.
+
+### Chrome Web Store
+
+1. Build the manual packages from the approved `beta` commit:
+
+   ```sh
+   pnpm --filter @serial/extension zip:stores
+   ```
+
+2. In the Chrome Web Store Developer Dashboard, add a new item and upload
+   `apps/extension/.output/*-chrome.zip`. Save it as a draft; do not submit it
+   for review yet.
+3. Record the item ID. On the Package tab, choose **View public key** and copy
+   the base64 text between the PEM markers as one line.
+4. Replace `CHROME_EXTENSION_MANIFEST_KEY` and its derived
+   `CHROME_EXTENSION_ID` in `packages/extension-identity/src/index.ts`. Run the
+   identity tests and rebuild the Chrome package. Its unpacked extension ID must
+   match the dashboard item ID.
+5. Upload the rebuilt package to the same draft. Complete the Store listing,
+   Privacy, Distribution, and Test instructions tabs. The privacy declarations
+   must match `apps/extension/README.md` and the actual permission/data flow.
+6. Manually submit and publish the initial public version. Chrome API v2 keeps
+   the existing visibility, so the public visibility must be established once
+   in the dashboard before CI can publish updates.
+
+Chrome's official identity instructions are at
+<https://developer.chrome.com/docs/extensions/reference/manifest/key>. Chrome's
+API setup is documented at
+<https://developer.chrome.com/docs/webstore/service-accounts>.
+
+### Firefox Add-ons
+
+1. Upload `apps/extension/.output/*-firefox.zip` to AMO as a listed add-on with
+   ID `extension@serial.tube`. Include
+   `apps/extension/.output/*-sources.zip` when AMO requests source code.
+2. Complete the listing, privacy/data-collection declarations, reviewer notes,
+   and initial review. Publish the first listed version.
+3. Create AMO API credentials from the developer credentials page. Store the
+   issuer and secret only in GitHub Actions secrets.
+
+Mozilla's API credential instructions are at
+<https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/#obtain-an-api-key>.
+
+## Keyless Chrome authentication
+
+Create a Google Cloud project, enable the Chrome Web Store API, and create a
+service account. Add that service-account email under the Chrome Web Store
+Developer Dashboard's Account section. Chrome currently permits one service
+account per publisher.
+
+Create a GitHub OIDC Workload Identity pool/provider with these restrictions:
+
+- issuer: `https://token.actions.githubusercontent.com`
+- repository: `megaflorasoftware/serial`
+- ref: `refs/heads/main`
+- mapped repository attribute used in the service-account IAM binding
+
+Grant the repository principal
+`roles/iam.workloadIdentityUser` on the service account. Do not create or export
+a service-account JSON key. The workflow requests only the
+`https://www.googleapis.com/auth/chromewebstore` OAuth scope.
+
+The maintained GitHub authentication action documents the exact Workload
+Identity commands at <https://github.com/google-github-actions/auth>.
+
+## GitHub repository configuration
+
+Create these Actions repository variables:
+
+| Variable                            | Value                                                                |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `CHROME_EXTENSION_ID`               | Chrome dashboard item ID; must match `CHROME_EXTENSION_ID` in source |
+| `CHROME_PUBLISHER_ID`               | Publisher ID from Chrome dashboard Settings                          |
+| `CHROME_SERVICE_ACCOUNT`            | Google service-account email added to Chrome Web Store               |
+| `CHROME_WORKLOAD_IDENTITY_PROVIDER` | Full `projects/.../providers/...` provider resource name             |
+| `FIREFOX_EXTENSION_ID`              | `extension@serial.tube`                                              |
+
+Create these Actions repository secrets:
+
+| Secret               | Value                  |
+| -------------------- | ---------------------- |
+| `FIREFOX_JWT_ISSUER` | AMO JWT issuer/API key |
+| `FIREFOX_JWT_SECRET` | AMO JWT secret         |
+
+## Release behavior
+
+The affected check follows Turbo's dependency graph. Changes to the extension,
+its transitive workspace packages, repository build inputs, lockfile, or this
+deployment workflow/scripts trigger a release. Unrelated app and website changes
+do not.
+
+Chrome and Firefox share one release version and one readiness gate. If either
+store has a revision under review—or Chrome has one staged for publication—the
+workflow stops before building or uploading either package. It never cancels an
+active review. After both stores are ready, rerun the failed workflow. Store
+warnings block Chrome submission so a maintainer can resolve them in the
+Developer Dashboard instead of silently publishing through a changed review
+condition.
+
+The two store submissions are independent API calls after the shared gate. If
+exactly one deployment job fails, rerun only that failed job from the same
+workflow run. It reuses the retained package and shared version without
+replacing the successful store's active review. Do not dispatch a new release
+to recover a partial submission.

--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -61,9 +61,17 @@ API setup is documented at
 3. Create AMO API credentials from the developer credentials page. Store the
    issuer and secret only in GitHub Actions secrets.
 
-The package passes AMO lint with five reviewed `innerHTML` warnings from
-unmodified third-party libraries. Include these source links and versions in
-**Notes for Reviewers**:
+The package passes AMO lint with five reviewed `UNSAFE_VAR_ASSIGNMENT` warnings
+from unmodified third-party libraries. Use this scoped explanation in **Notes
+for Reviewers**:
+
+> The five UNSAFE_VAR_ASSIGNMENT warnings originate from unmodified third-party
+> code: Mozilla Readability 0.6.0 (2), DOMPurify 3.4.12 (1), and React DOM 19.2.7
+> (2). No Serial-authored code in the submitted extension directly assigns
+> dynamic values to innerHTML. The source archive includes the lockfile, source
+> code, and deterministic rebuild instructions.
+
+Include these source links and versions alongside that explanation:
 
 - Mozilla Readability 0.6.0: <https://github.com/mozilla/readability>
 - DOMPurify 3.4.12: <https://github.com/cure53/DOMPurify>

--- a/.github/EXTENSION_DEPLOYMENT.md
+++ b/.github/EXTENSION_DEPLOYMENT.md
@@ -143,5 +143,8 @@ condition.
 The two store submissions are independent API calls after the shared gate. If
 exactly one deployment job fails, rerun only that failed job from the same
 workflow run. It reuses the retained package and shared version without
-replacing the successful store's active review. Do not dispatch a new release
+replacing the successful store's active review. On a Chrome retry, a staged
+revision is published without another upload only when its reported manifest
+version matches the retained package; an unrelated or unidentified staged
+revision remains blocked for manual resolution. Do not dispatch a new release
 to recover a partial submission.

--- a/.github/scripts/check-deployable-affected.sh
+++ b/.github/scripts/check-deployable-affected.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-deployable="${1:?usage: check-deployable-affected.sh <app|www>}"
+deployable="${1:?usage: check-deployable-affected.sh <app|extension|www>}"
 before_sha="${BEFORE_SHA:-}"
 head_sha="${GITHUB_SHA:-HEAD}"
 event_name="${GITHUB_EVENT_NAME:-}"
@@ -11,6 +11,9 @@ output_file="${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
 case "$deployable" in
   app)
     task_id="@serial/app#build:artifact"
+    ;;
+  extension)
+    task_id="@serial/extension#build:artifact"
     ;;
   www)
     task_id="@serial/www#build:artifact"
@@ -48,6 +51,14 @@ while IFS= read -r changed_file; do
       app:Dockerfile | \
       app:.github/workflows/deploy-app.yml | \
       app:.github/scripts/check-deployable-affected.sh | \
+      extension:package.json | \
+      extension:pnpm-lock.yaml | \
+      extension:pnpm-workspace.yaml | \
+      extension:turbo.json | \
+      extension:.node-version | \
+      extension:.github/workflows/deploy-extension.yml | \
+      extension:.github/scripts/check-deployable-affected.sh | \
+      extension:.github/scripts/extensions/* | \
       www:package.json | \
       www:pnpm-lock.yaml | \
       www:pnpm-workspace.yaml | \

--- a/.github/scripts/extensions/check-store-readiness.sh
+++ b/.github/scripts/extensions/check-store-readiness.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CHROME_ACCESS_TOKEN:?CHROME_ACCESS_TOKEN must be set}"
+: "${CHROME_PUBLISHER_ID:?CHROME_PUBLISHER_ID must be set}"
+: "${CHROME_EXTENSION_ID:?CHROME_EXTENSION_ID must be set}"
+: "${FIREFOX_EXTENSION_ID:?FIREFOX_EXTENSION_ID must be set}"
+: "${FIREFOX_JWT_ISSUER:?FIREFOX_JWT_ISSUER must be set}"
+: "${FIREFOX_JWT_SECRET:?FIREFOX_JWT_SECRET must be set}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+curl_bin="${CURL_BIN:-curl}"
+chrome_api_origin="${CHROME_WEB_STORE_API_ORIGIN:-https://chromewebstore.googleapis.com}"
+firefox_api_origin="${FIREFOX_ADDONS_API_ORIGIN:-https://addons.mozilla.org/api/v5}"
+chrome_status_url="$chrome_api_origin/v2/publishers/$CHROME_PUBLISHER_ID/items/$CHROME_EXTENSION_ID:fetchStatus"
+firefox_versions_url="$firefox_api_origin/addons/addon/$FIREFOX_EXTENSION_ID/versions/?filter=all_without_unlisted&page_size=50"
+response_dir="$(mktemp -d)"
+trap 'rm -rf "$response_dir"' EXIT
+
+request() {
+  local response_file="$1"
+  local authorization="$2"
+  local url="$3"
+
+  if ! "$curl_bin" \
+    --fail-with-body \
+    --show-error \
+    --silent \
+    --retry 4 \
+    --retry-all-errors \
+    --connect-timeout 15 \
+    --max-time 120 \
+    --header "Authorization: $authorization" \
+    --output "$response_file" \
+    --request GET \
+    "$url"; then
+    echo "Extension store readiness request failed:" >&2
+    jq . "$response_file" >&2 2>/dev/null || sed -n '1,120p' "$response_file" >&2
+    return 1
+  fi
+}
+
+blocked=false
+chrome_response="$response_dir/chrome.json"
+request "$chrome_response" "Bearer $CHROME_ACCESS_TOKEN" "$chrome_status_url"
+chrome_state="$(
+  jq -r '.submittedItemRevisionStatus.state // empty' "$chrome_response"
+)"
+chrome_version="$(
+  jq -r \
+    '.submittedItemRevisionStatus.distributionChannels[0].crxVersion // empty' \
+    "$chrome_response"
+)"
+case "$chrome_state" in
+  PENDING_REVIEW | STAGED)
+    echo \
+      "Chrome revision ${chrome_version:-unknown} is $chrome_state." \
+      >&2
+    blocked=true
+    ;;
+esac
+
+firefox_token="$(node "$script_dir/generate-amo-jwt.mjs")"
+firefox_response="$response_dir/firefox.json"
+request "$firefox_response" "JWT $firefox_token" "$firefox_versions_url"
+if ! jq -e '.results | type == "array"' "$firefox_response" > /dev/null; then
+  echo "Firefox returned an unexpected versions response." >&2
+  jq . "$firefox_response" >&2
+  exit 1
+fi
+firefox_pending_versions="$(
+  jq -r \
+    '[.results[]? | select(.file.status == "unreviewed") | .version] | join(", ")' \
+    "$firefox_response"
+)"
+if [[ -n "$firefox_pending_versions" ]]; then
+  echo \
+    "Firefox revision(s) $firefox_pending_versions are awaiting review." \
+    >&2
+  blocked=true
+fi
+
+if [[ "$blocked" == "true" ]]; then
+  echo \
+    "The synchronized browser-extension release is blocked. Preserve the active review and rerun the workflow after both stores are ready." \
+    >&2
+  exit 2
+fi
+
+echo "Chrome and Firefox are ready for a synchronized extension release."

--- a/.github/scripts/extensions/check-store-readiness.sh
+++ b/.github/scripts/extensions/check-store-readiness.sh
@@ -69,16 +69,16 @@ if ! jq -e '.results | type == "array"' "$firefox_response" > /dev/null; then
   jq . "$firefox_response" >&2
   exit 1
 fi
-firefox_pending_versions="$(
+firefox_nonterminal_versions="$(
   jq -r \
     '[.results[]? | select(
-      .file.status == "unreviewed" or .file.status == "awaiting_review"
-    ) | .version] | join(", ")' \
+      .file.status != "public" and .file.status != "disabled"
+    ) | "\(.version) (\(.file.status // "missing status"))"] | join(", ")' \
     "$firefox_response"
 )"
-if [[ -n "$firefox_pending_versions" ]]; then
+if [[ -n "$firefox_nonterminal_versions" ]]; then
   echo \
-    "Firefox revision(s) $firefox_pending_versions are awaiting review." \
+    "Firefox revision(s) $firefox_nonterminal_versions are not in a terminal store state." \
     >&2
   blocked=true
 fi

--- a/.github/scripts/extensions/check-store-readiness.sh
+++ b/.github/scripts/extensions/check-store-readiness.sh
@@ -71,7 +71,9 @@ if ! jq -e '.results | type == "array"' "$firefox_response" > /dev/null; then
 fi
 firefox_pending_versions="$(
   jq -r \
-    '[.results[]? | select(.file.status == "unreviewed") | .version] | join(", ")' \
+    '[.results[]? | select(
+      .file.status == "unreviewed" or .file.status == "awaiting_review"
+    ) | .version] | join(", ")' \
     "$firefox_response"
 )"
 if [[ -n "$firefox_pending_versions" ]]; then

--- a/.github/scripts/extensions/collect-store-packages.sh
+++ b/.github/scripts/extensions/collect-store-packages.sh
@@ -45,6 +45,24 @@ for browser in chrome firefox; do
     echo "$browser store package contains the development-only manifest key" >&2
     exit 1
   fi
+
+  if jq -e \
+    '[.host_permissions[]?, .permissions[]?] | any(test("^https?://"))' \
+    <<< "$manifest" >/dev/null; then
+    echo "$browser store package contains required host access" >&2
+    exit 1
+  fi
+
+  optional_origins="$(
+    jq -c '.optional_host_permissions // .optional_permissions // []' \
+      <<< "$manifest"
+  )"
+  if [[ "$optional_origins" != '["https://*/*"]' ]]; then
+    echo \
+      "$browser store package must request only optional HTTPS host access" \
+      >&2
+    exit 1
+  fi
 done
 
 required_source_paths=(

--- a/.github/scripts/extensions/collect-store-packages.sh
+++ b/.github/scripts/extensions/collect-store-packages.sh
@@ -32,13 +32,17 @@ cp "${firefox_candidates[0]}" "$destination_dir/firefox.zip"
 cp "${source_candidates[0]}" "$destination_dir/firefox-sources.zip"
 
 for browser in chrome firefox; do
-  manifest_version="$(
-    unzip -p "$destination_dir/$browser.zip" manifest.json | jq -r '.version'
-  )"
+  manifest="$(unzip -p "$destination_dir/$browser.zip" manifest.json)"
+  manifest_version="$(jq -r '.version' <<< "$manifest")"
   if [[ "$manifest_version" != "$release_version" ]]; then
     echo \
       "$browser package version $manifest_version does not match $release_version" \
       >&2
+    exit 1
+  fi
+
+  if jq -e 'has("key")' <<< "$manifest" >/dev/null; then
+    echo "$browser store package contains the development-only manifest key" >&2
     exit 1
   fi
 done

--- a/.github/scripts/extensions/collect-store-packages.sh
+++ b/.github/scripts/extensions/collect-store-packages.sh
@@ -54,6 +54,7 @@ required_source_paths=(
   pnpm-lock.yaml
   pnpm-workspace.yaml
   apps/extension/package.json
+  apps/extension/scripts/check-firefox-lint.mjs
   apps/extension/wxt.config.ts
   apps/extension/entrypoints/background.ts
   packages/bookmark-capture/package.json

--- a/.github/scripts/extensions/collect-store-packages.sh
+++ b/.github/scripts/extensions/collect-store-packages.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output_dir="${1:?usage: collect-store-packages.sh <output-dir> <destination-dir> <release-version>}"
+destination_dir="${2:?usage: collect-store-packages.sh <output-dir> <destination-dir> <release-version>}"
+release_version="${3:?usage: collect-store-packages.sh <output-dir> <destination-dir> <release-version>}"
+
+shopt -s nullglob
+chrome_candidates=("$output_dir"/*-"$release_version"-chrome.zip)
+firefox_candidates=("$output_dir"/*-"$release_version"-firefox.zip)
+source_candidates=("$output_dir"/*-"$release_version"-sources.zip)
+shopt -u nullglob
+
+require_single_package() {
+  local label="$1"
+  shift
+
+  if (( $# != 1 )); then
+    echo "Expected one $label package for version $release_version, found $#" >&2
+    exit 1
+  fi
+}
+
+require_single_package Chrome "${chrome_candidates[@]}"
+require_single_package Firefox "${firefox_candidates[@]}"
+require_single_package "Firefox source" "${source_candidates[@]}"
+
+mkdir -p "$destination_dir"
+cp "${chrome_candidates[0]}" "$destination_dir/chrome.zip"
+cp "${firefox_candidates[0]}" "$destination_dir/firefox.zip"
+cp "${source_candidates[0]}" "$destination_dir/firefox-sources.zip"
+
+for browser in chrome firefox; do
+  manifest_version="$(
+    unzip -p "$destination_dir/$browser.zip" manifest.json | jq -r '.version'
+  )"
+  if [[ "$manifest_version" != "$release_version" ]]; then
+    echo \
+      "$browser package version $manifest_version does not match $release_version" \
+      >&2
+    exit 1
+  fi
+done
+
+required_source_paths=(
+  .gitignore
+  .node-version
+  package.json
+  pnpm-lock.yaml
+  pnpm-workspace.yaml
+  apps/extension/package.json
+  apps/extension/wxt.config.ts
+  apps/extension/entrypoints/background.ts
+  packages/bookmark-capture/package.json
+  packages/extension-identity/package.json
+  packages/ui/package.json
+)
+source_listing="$(unzip -Z1 "$destination_dir/firefox-sources.zip")"
+for path in "${required_source_paths[@]}"; do
+  if ! grep -Fxq "$path" <<< "$source_listing"; then
+    echo "Firefox source package is missing $path" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '(^|/)(node_modules|\.output|\.wxt|\.turbo)/' \
+  <<< "$source_listing"; then
+  echo "Firefox source package contains generated files" >&2
+  exit 1
+fi
+
+sha256sum "$destination_dir"/*.zip

--- a/.github/scripts/extensions/generate-amo-jwt.mjs
+++ b/.github/scripts/extensions/generate-amo-jwt.mjs
@@ -1,0 +1,25 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+const jwtIssuer = process.env.FIREFOX_JWT_ISSUER;
+const jwtSecret = process.env.FIREFOX_JWT_SECRET;
+
+if (!jwtIssuer || !jwtSecret) {
+  throw new Error("FIREFOX_JWT_ISSUER and FIREFOX_JWT_SECRET must be set");
+}
+
+const issuedAt = Math.floor(Date.now() / 1000);
+const header = { alg: "HS256", typ: "JWT" };
+const payload = {
+  iss: jwtIssuer,
+  jti: randomUUID(),
+  iat: issuedAt,
+  exp: issuedAt + 60,
+};
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsignedToken = `${encode(header)}.${encode(payload)}`;
+const signature = createHmac("sha256", jwtSecret)
+  .update(unsignedToken)
+  .digest("base64url");
+
+process.stdout.write(`${unsignedToken}.${signature}`);

--- a/.github/scripts/extensions/generate-version.mjs
+++ b/.github/scripts/extensions/generate-version.mjs
@@ -1,0 +1,32 @@
+import { appendFileSync } from "node:fs";
+
+const releaseTimestamp = process.env.RELEASE_TIMESTAMP;
+const releaseDate = releaseTimestamp ? new Date(releaseTimestamp) : new Date();
+
+if (Number.isNaN(releaseDate.getTime())) {
+  throw new Error(`Invalid RELEASE_TIMESTAMP: ${releaseTimestamp}`);
+}
+
+const releaseYear = releaseDate.getUTCFullYear();
+const yearStart = Date.UTC(releaseYear, 0, 1);
+const releaseDayStart = Date.UTC(
+  releaseYear,
+  releaseDate.getUTCMonth(),
+  releaseDate.getUTCDate(),
+);
+const releaseDay = Math.floor((releaseDayStart - yearStart) / 86_400_000) + 1;
+const releaseHour = releaseDate.getUTCHours();
+const releaseSecondWithinHour =
+  releaseDate.getUTCMinutes() * 60 + releaseDate.getUTCSeconds();
+const releaseVersion = [
+  releaseYear,
+  releaseDay,
+  releaseHour,
+  releaseSecondWithinHour,
+].join(".");
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `version=${releaseVersion}\n`);
+}
+
+process.stdout.write(`${releaseVersion}\n`);

--- a/.github/scripts/extensions/publish-chrome.sh
+++ b/.github/scripts/extensions/publish-chrome.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+chrome_zip="${1:?usage: publish-chrome.sh <chrome-zip>}"
+: "${CHROME_ACCESS_TOKEN:?CHROME_ACCESS_TOKEN must be set}"
+: "${CHROME_PUBLISHER_ID:?CHROME_PUBLISHER_ID must be set}"
+: "${CHROME_EXTENSION_ID:?CHROME_EXTENSION_ID must be set}"
+
+if [[ ! -f "$chrome_zip" ]]; then
+  echo "Chrome extension package not found: $chrome_zip" >&2
+  exit 1
+fi
+
+curl_bin="${CURL_BIN:-curl}"
+sleep_bin="${SLEEP_BIN:-sleep}"
+api_origin="${CHROME_WEB_STORE_API_ORIGIN:-https://chromewebstore.googleapis.com}"
+item_name="publishers/$CHROME_PUBLISHER_ID/items/$CHROME_EXTENSION_ID"
+status_url="$api_origin/v2/$item_name:fetchStatus"
+upload_url="$api_origin/upload/v2/$item_name:upload"
+publish_url="$api_origin/v2/$item_name:publish"
+response_dir="$(mktemp -d)"
+trap 'rm -rf "$response_dir"' EXIT
+
+request() {
+  local response_file="$1"
+  shift
+
+  if ! "$curl_bin" \
+    --fail-with-body \
+    --show-error \
+    --silent \
+    --connect-timeout 15 \
+    --max-time 120 \
+    --header "Authorization: Bearer $CHROME_ACCESS_TOKEN" \
+    --output "$response_file" \
+    "$@"; then
+    echo "Chrome Web Store API request failed:" >&2
+    jq . "$response_file" >&2 2>/dev/null || sed -n '1,120p' "$response_file" >&2
+    return 1
+  fi
+}
+
+fetch_status() {
+  local response_file="$1"
+  request \
+    "$response_file" \
+    --retry 4 \
+    --retry-all-errors \
+    --request GET \
+    "$status_url"
+}
+
+status_response="$response_dir/status.json"
+fetch_status "$status_response"
+
+submitted_state="$(
+  jq -r '.submittedItemRevisionStatus.state // empty' "$status_response"
+)"
+submitted_version="$(
+  jq -r \
+    '.submittedItemRevisionStatus.distributionChannels[0].crxVersion // empty' \
+    "$status_response"
+)"
+
+case "$submitted_state" in
+  PENDING_REVIEW | STAGED)
+    echo \
+      "Chrome revision ${submitted_version:-unknown} is $submitted_state; preserve it and rerun this job after the store finishes processing it." \
+      >&2
+    exit 2
+    ;;
+esac
+
+upload_response="$response_dir/upload.json"
+request \
+  "$upload_response" \
+  --request POST \
+  --header "Content-Type: application/zip" \
+  --upload-file "$chrome_zip" \
+  "$upload_url"
+
+upload_state="$(jq -r '.uploadState // empty' "$upload_response")"
+uploaded_version="$(jq -r '.crxVersion // empty' "$upload_response")"
+
+if [[ "$upload_state" == "IN_PROGRESS" ]]; then
+  for _ in {1..12}; do
+    "$sleep_bin" 5
+    fetch_status "$status_response"
+    upload_state="$(jq -r '.lastAsyncUploadState // empty' "$status_response")"
+    if [[ "$upload_state" != "IN_PROGRESS" ]]; then
+      break
+    fi
+  done
+fi
+
+if [[ "$upload_state" != "SUCCEEDED" ]]; then
+  echo "Chrome package upload did not succeed (state: ${upload_state:-missing})." >&2
+  jq . "$upload_response" >&2
+  exit 1
+fi
+
+publish_response="$response_dir/publish.json"
+request \
+  "$publish_response" \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --data '{"publishType":"DEFAULT_PUBLISH","deployInfos":[{"deployPercentage":100}],"skipReview":false,"blockOnWarnings":true}' \
+  "$publish_url"
+
+publish_state="$(jq -r '.state // empty' "$publish_response")"
+case "$publish_state" in
+  PENDING_REVIEW | PUBLISHED)
+    ;;
+  *)
+    echo \
+      "Chrome submission returned an unexpected state: ${publish_state:-missing}." \
+      >&2
+    jq . "$publish_response" >&2
+    exit 1
+    ;;
+esac
+
+echo \
+  "Chrome extension ${uploaded_version:-unknown} submitted successfully ($publish_state)."

--- a/.github/scripts/extensions/publish-chrome.sh
+++ b/.github/scripts/extensions/publish-chrome.sh
@@ -11,6 +11,13 @@ if [[ ! -f "$chrome_zip" ]]; then
   echo "Chrome extension package not found: $chrome_zip" >&2
   exit 1
 fi
+if ! package_version="$(
+  unzip -p "$chrome_zip" manifest.json | \
+    jq -er '.version | strings | select(length > 0)'
+)"; then
+  echo "Chrome extension package has no valid manifest version: $chrome_zip" >&2
+  exit 1
+fi
 
 curl_bin="${CURL_BIN:-curl}"
 sleep_bin="${SLEEP_BIN:-sleep}"
@@ -63,41 +70,56 @@ submitted_version="$(
     "$status_response"
 )"
 
+resume_staged=false
 case "$submitted_state" in
-  PENDING_REVIEW | STAGED)
+  PENDING_REVIEW)
     echo \
       "Chrome revision ${submitted_version:-unknown} is $submitted_state; preserve it and rerun this job after the store finishes processing it." \
       >&2
     exit 2
     ;;
+  STAGED)
+    if [[ -z "$submitted_version" || "$submitted_version" != "$package_version" ]]; then
+      echo \
+        "Chrome revision ${submitted_version:-unknown} is STAGED and does not match retained package $package_version; preserve it and resolve the staged revision before retrying." \
+        >&2
+      exit 2
+    fi
+    echo \
+      "Chrome revision $submitted_version is STAGED and matches the retained package; resuming publication."
+    resume_staged=true
+    ;;
 esac
 
-upload_response="$response_dir/upload.json"
-request \
-  "$upload_response" \
-  --request POST \
-  --header "Content-Type: application/zip" \
-  --upload-file "$chrome_zip" \
-  "$upload_url"
+uploaded_version="$submitted_version"
+if [[ "$resume_staged" != "true" ]]; then
+  upload_response="$response_dir/upload.json"
+  request \
+    "$upload_response" \
+    --request POST \
+    --header "Content-Type: application/zip" \
+    --upload-file "$chrome_zip" \
+    "$upload_url"
 
-upload_state="$(jq -r '.uploadState // empty' "$upload_response")"
-uploaded_version="$(jq -r '.crxVersion // empty' "$upload_response")"
+  upload_state="$(jq -r '.uploadState // empty' "$upload_response")"
+  uploaded_version="$(jq -r '.crxVersion // empty' "$upload_response")"
 
-if [[ "$upload_state" == "IN_PROGRESS" ]]; then
-  for _ in {1..12}; do
-    "$sleep_bin" 5
-    fetch_status "$status_response"
-    upload_state="$(jq -r '.lastAsyncUploadState // empty' "$status_response")"
-    if [[ "$upload_state" != "IN_PROGRESS" ]]; then
-      break
-    fi
-  done
-fi
+  if [[ "$upload_state" == "IN_PROGRESS" ]]; then
+    for _ in {1..12}; do
+      "$sleep_bin" 5
+      fetch_status "$status_response"
+      upload_state="$(jq -r '.lastAsyncUploadState // empty' "$status_response")"
+      if [[ "$upload_state" != "IN_PROGRESS" ]]; then
+        break
+      fi
+    done
+  fi
 
-if [[ "$upload_state" != "SUCCEEDED" ]]; then
-  echo "Chrome package upload did not succeed (state: ${upload_state:-missing})." >&2
-  jq . "$upload_response" >&2
-  exit 1
+  if [[ "$upload_state" != "SUCCEEDED" ]]; then
+    echo "Chrome package upload did not succeed (state: ${upload_state:-missing})." >&2
+    jq . "$upload_response" >&2
+    exit 1
+  fi
 fi
 
 publish_response="$response_dir/publish.json"

--- a/.github/scripts/extensions/test-extension-deployment.sh
+++ b/.github/scripts/extensions/test-extension-deployment.sh
@@ -127,7 +127,7 @@ run_readiness_check() {
     CHROME_PUBLISHER_ID=test-publisher \
     CHROME_EXTENSION_ID=abcdefghijklmnopabcdefghijklmnop \
     CHROME_WEB_STORE_API_ORIGIN=https://chrome.example \
-    FIREFOX_EXTENSION_ID=extension@serial.tube \
+    FIREFOX_EXTENSION_ID=serial@megaflora.net \
     FIREFOX_JWT_ISSUER=test-issuer \
     FIREFOX_JWT_SECRET=test-secret \
     FIREFOX_ADDONS_API_ORIGIN=https://firefox.example/api/v5 \

--- a/.github/scripts/extensions/test-extension-deployment.sh
+++ b/.github/scripts/extensions/test-extension-deployment.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+version_generator="$script_dir/generate-version.mjs"
+publisher="$script_dir/publish-chrome.sh"
+readiness_check="$script_dir/check-store-readiness.sh"
+fake_curl="$script_dir/test-fixtures/fake-curl.sh"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+assert_version() {
+  local timestamp="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(RELEASE_TIMESTAMP="$timestamp" node "$version_generator")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Expected version $expected for $timestamp, got $actual" >&2
+    exit 1
+  fi
+}
+
+assert_version "2026-01-01T00:00:00Z" "2026.1.0.0"
+assert_version "2026-08-03T14:30:32Z" "2026.215.14.1832"
+assert_version "2026-12-31T23:59:59Z" "2026.365.23.3599"
+
+amo_jwt="$(
+  FIREFOX_JWT_ISSUER=test-issuer \
+    FIREFOX_JWT_SECRET=test-secret \
+    node "$script_dir/generate-amo-jwt.mjs"
+)"
+amo_jwt_payload="$(
+  node -e \
+    'process.stdout.write(Buffer.from(process.argv[1], "base64url").toString())' \
+    "$(cut -d. -f2 <<< "$amo_jwt")"
+)"
+if ! jq -e \
+  '.iss == "test-issuer" and (.exp - .iat == 60) and (.jti | length > 0)' \
+  <<< "$amo_jwt_payload" > /dev/null; then
+  echo "AMO JWT did not contain the expected claims" >&2
+  exit 1
+fi
+
+if RELEASE_TIMESTAMP="not-a-date" node "$version_generator" >/dev/null 2>&1; then
+  echo "Expected an invalid release timestamp to fail" >&2
+  exit 1
+fi
+
+chrome_zip="$temp_dir/chrome.zip"
+printf 'test package\n' > "$chrome_zip"
+
+run_publisher() {
+  CHROME_ACCESS_TOKEN=test-token \
+    CHROME_PUBLISHER_ID=test-publisher \
+    CHROME_EXTENSION_ID=abcdefghijklmnopabcdefghijklmnop \
+    CHROME_WEB_STORE_API_ORIGIN=https://chrome.example \
+    CURL_BIN="$fake_curl" \
+    SLEEP_BIN="${SLEEP_BIN:-sleep}" \
+    FAKE_CURL_LOG="$temp_dir/curl.log" \
+    FAKE_STATUS_RESPONSE="${FAKE_STATUS_RESPONSE-}" \
+    FAKE_UPLOAD_RESPONSE="${FAKE_UPLOAD_RESPONSE-}" \
+    FAKE_PUBLISH_RESPONSE="${FAKE_PUBLISH_RESPONSE-}" \
+    FAKE_FAIL_ENDPOINT="${FAKE_FAIL_ENDPOINT:-}" \
+    "$publisher" "$chrome_zip"
+}
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{"submittedItemRevisionStatus":{"state":"PENDING_REVIEW","distributionChannels":[{"crxVersion":"2026.214.10.1"}]}}'
+export FAKE_STATUS_RESPONSE
+if run_publisher >"$temp_dir/pending.out" 2>&1; then
+  echo "Expected a pending Chrome review to stop deployment" >&2
+  exit 1
+fi
+if ! grep -q "preserve it and rerun" "$temp_dir/pending.out"; then
+  echo "Pending-review failure did not include retry guidance" >&2
+  exit 1
+fi
+if [[ "$(wc -l < "$temp_dir/curl.log" | tr -d ' ')" != "1" ]]; then
+  echo "Pending-review deployment called Chrome after the status check" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{}'
+FAKE_UPLOAD_RESPONSE='{"itemId":"abcdefghijklmnopabcdefghijklmnop","crxVersion":"2026.215.14.1832","uploadState":"SUCCEEDED"}'
+FAKE_PUBLISH_RESPONSE='{"itemId":"abcdefghijklmnopabcdefghijklmnop","state":"PENDING_REVIEW"}'
+export FAKE_STATUS_RESPONSE FAKE_UPLOAD_RESPONSE FAKE_PUBLISH_RESPONSE
+run_publisher > "$temp_dir/success.out"
+if ! grep -q "submitted successfully" "$temp_dir/success.out"; then
+  echo "Successful Chrome submission was not reported" >&2
+  exit 1
+fi
+if [[ "$(wc -l < "$temp_dir/curl.log" | tr -d ' ')" != "3" ]]; then
+  echo "Successful deployment did not call status, upload, and publish" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{"lastAsyncUploadState":"SUCCEEDED"}'
+FAKE_UPLOAD_RESPONSE='{"itemId":"abcdefghijklmnopabcdefghijklmnop","uploadState":"IN_PROGRESS"}'
+FAKE_PUBLISH_RESPONSE='{"itemId":"abcdefghijklmnopabcdefghijklmnop","state":"PENDING_REVIEW"}'
+SLEEP_BIN=true
+export FAKE_STATUS_RESPONSE FAKE_UPLOAD_RESPONSE FAKE_PUBLISH_RESPONSE SLEEP_BIN
+run_publisher > "$temp_dir/async-success.out"
+if ! grep -q "submitted successfully" "$temp_dir/async-success.out"; then
+  echo "Asynchronous Chrome upload was not submitted after processing" >&2
+  exit 1
+fi
+unset SLEEP_BIN
+
+: > "$temp_dir/curl.log"
+FAKE_UPLOAD_RESPONSE='{"uploadState":"FAILED"}'
+export FAKE_UPLOAD_RESPONSE
+if run_publisher >"$temp_dir/upload-failure.out" 2>&1; then
+  echo "Expected a failed Chrome upload to stop deployment" >&2
+  exit 1
+fi
+if ! grep -q "upload did not succeed" "$temp_dir/upload-failure.out"; then
+  echo "Failed Chrome upload did not report its state" >&2
+  exit 1
+fi
+
+run_readiness_check() {
+  CHROME_ACCESS_TOKEN=test-token \
+    CHROME_PUBLISHER_ID=test-publisher \
+    CHROME_EXTENSION_ID=abcdefghijklmnopabcdefghijklmnop \
+    CHROME_WEB_STORE_API_ORIGIN=https://chrome.example \
+    FIREFOX_EXTENSION_ID=extension@serial.tube \
+    FIREFOX_JWT_ISSUER=test-issuer \
+    FIREFOX_JWT_SECRET=test-secret \
+    FIREFOX_ADDONS_API_ORIGIN=https://firefox.example/api/v5 \
+    CURL_BIN="$fake_curl" \
+    FAKE_CURL_LOG="$temp_dir/curl.log" \
+    FAKE_STATUS_RESPONSE="${FAKE_STATUS_RESPONSE-}" \
+    FAKE_FIREFOX_VERSIONS_RESPONSE="${FAKE_FIREFOX_VERSIONS_RESPONSE-}" \
+    "$readiness_check"
+}
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{}'
+FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.214.10.1","file":{"status":"public"}}]}'
+export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE
+run_readiness_check > "$temp_dir/ready.out"
+if ! grep -q "ready for a synchronized" "$temp_dir/ready.out"; then
+  echo "Ready stores did not pass the synchronized release gate" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{"submittedItemRevisionStatus":{"state":"PENDING_REVIEW","distributionChannels":[{"crxVersion":"2026.215.10.1"}]}}'
+FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.215.10.1","file":{"status":"unreviewed"}}]}'
+export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE
+if run_readiness_check >"$temp_dir/blocked.out" 2>&1; then
+  echo "Expected active store reviews to block the synchronized release" >&2
+  exit 1
+fi
+if ! grep -q "Chrome revision" "$temp_dir/blocked.out" || \
+  ! grep -q "Firefox revision" "$temp_dir/blocked.out" || \
+  ! grep -q "synchronized browser-extension release is blocked" "$temp_dir/blocked.out"; then
+  echo "The synchronized release gate did not report both active reviews" >&2
+  exit 1
+fi
+
+echo "Extension deployment checks passed."

--- a/.github/scripts/extensions/test-extension-deployment.sh
+++ b/.github/scripts/extensions/test-extension-deployment.sh
@@ -49,7 +49,12 @@ if RELEASE_TIMESTAMP="not-a-date" node "$version_generator" >/dev/null 2>&1; the
 fi
 
 chrome_zip="$temp_dir/chrome.zip"
-printf 'test package\n' > "$chrome_zip"
+mkdir "$temp_dir/chrome-package"
+printf '{"version":"2026.215.14.1832"}\n' > "$temp_dir/chrome-package/manifest.json"
+(
+  cd "$temp_dir/chrome-package"
+  zip -q "$chrome_zip" manifest.json
+)
 
 run_publisher() {
   CHROME_ACCESS_TOKEN=test-token \
@@ -79,6 +84,36 @@ if ! grep -q "preserve it and rerun" "$temp_dir/pending.out"; then
 fi
 if [[ "$(wc -l < "$temp_dir/curl.log" | tr -d ' ')" != "1" ]]; then
   echo "Pending-review deployment called Chrome after the status check" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{"submittedItemRevisionStatus":{"state":"STAGED","distributionChannels":[{"crxVersion":"2026.215.14.1832"}]}}'
+FAKE_PUBLISH_RESPONSE='{"itemId":"abcdefghijklmnopabcdefghijklmnop","state":"PENDING_REVIEW"}'
+export FAKE_STATUS_RESPONSE FAKE_PUBLISH_RESPONSE
+run_publisher > "$temp_dir/staged-retry.out"
+if ! grep -q "submitted successfully" "$temp_dir/staged-retry.out"; then
+  echo "Matching staged Chrome revision was not resumed" >&2
+  exit 1
+fi
+if [[ "$(wc -l < "$temp_dir/curl.log" | tr -d ' ')" != "2" ]]; then
+  echo "Staged Chrome retry did not call only status and publish" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{"submittedItemRevisionStatus":{"state":"STAGED","distributionChannels":[{"crxVersion":"2026.215.14.999"}]}}'
+export FAKE_STATUS_RESPONSE
+if run_publisher >"$temp_dir/unrelated-staged.out" 2>&1; then
+  echo "Expected an unrelated staged Chrome revision to stop deployment" >&2
+  exit 1
+fi
+if ! grep -q "does not match retained package" "$temp_dir/unrelated-staged.out"; then
+  echo "Unrelated staged Chrome revision did not report the version mismatch" >&2
+  exit 1
+fi
+if [[ "$(wc -l < "$temp_dir/curl.log" | tr -d ' ')" != "1" ]]; then
+  echo "Unrelated staged Chrome revision called Chrome after the status check" >&2
   exit 1
 fi
 

--- a/.github/scripts/extensions/test-extension-deployment.sh
+++ b/.github/scripts/extensions/test-extension-deployment.sh
@@ -149,6 +149,20 @@ if ! grep -q "ready for a synchronized" "$temp_dir/ready.out"; then
 fi
 
 : > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{}'
+FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.215.10.0","file":{"status":"awaiting_review"}}]}'
+export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE
+if run_readiness_check >"$temp_dir/firefox-awaiting-review.out" 2>&1; then
+  echo "Expected an awaiting-review Firefox revision to block the synchronized release" >&2
+  exit 1
+fi
+if ! grep -q "Firefox revision" "$temp_dir/firefox-awaiting-review.out" || \
+  ! grep -q "synchronized browser-extension release is blocked" "$temp_dir/firefox-awaiting-review.out"; then
+  echo "The synchronized release gate did not report the awaiting-review Firefox revision" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
 FAKE_STATUS_RESPONSE='{"submittedItemRevisionStatus":{"state":"PENDING_REVIEW","distributionChannels":[{"crxVersion":"2026.215.10.1"}]}}'
 FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.215.10.1","file":{"status":"unreviewed"}}]}'
 export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE

--- a/.github/scripts/extensions/test-extension-deployment.sh
+++ b/.github/scripts/extensions/test-extension-deployment.sh
@@ -140,11 +140,25 @@ run_readiness_check() {
 
 : > "$temp_dir/curl.log"
 FAKE_STATUS_RESPONSE='{}'
-FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.214.10.1","file":{"status":"public"}}]}'
+FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.214.10.1","file":{"status":"public"}},{"version":"2026.213.9.1","file":{"status":"disabled"}}]}'
 export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE
 run_readiness_check > "$temp_dir/ready.out"
 if ! grep -q "ready for a synchronized" "$temp_dir/ready.out"; then
   echo "Ready stores did not pass the synchronized release gate" >&2
+  exit 1
+fi
+
+: > "$temp_dir/curl.log"
+FAKE_STATUS_RESPONSE='{}'
+FAKE_FIREFOX_VERSIONS_RESPONSE='{"results":[{"version":"2026.215.9.0","file":{"status":"future_review_state"}}]}'
+export FAKE_STATUS_RESPONSE FAKE_FIREFOX_VERSIONS_RESPONSE
+if run_readiness_check >"$temp_dir/firefox-unknown-status.out" 2>&1; then
+  echo "Expected an unknown Firefox status to block the synchronized release" >&2
+  exit 1
+fi
+if ! grep -q "future_review_state" "$temp_dir/firefox-unknown-status.out" || \
+  ! grep -q "synchronized browser-extension release is blocked" "$temp_dir/firefox-unknown-status.out"; then
+  echo "The synchronized release gate did not report the unknown Firefox status" >&2
   exit 1
 fi
 

--- a/.github/scripts/extensions/test-fixtures/fake-curl.sh
+++ b/.github/scripts/extensions/test-fixtures/fake-curl.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+method=GET
+output_file=""
+url=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --request)
+      method="$2"
+      shift 2
+      ;;
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    --header | --retry | --connect-timeout | --max-time | --upload-file | --data)
+      shift 2
+      ;;
+    --fail-with-body | --show-error | --silent | --retry-all-errors)
+      shift
+      ;;
+    http*)
+      url="$1"
+      shift
+      ;;
+    *)
+      echo "Unexpected fake curl argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+: "${FAKE_CURL_LOG:?FAKE_CURL_LOG must be set}"
+: "${output_file:?fake curl expected --output}"
+: "${url:?fake curl expected a URL}"
+
+printf '%s %s\n' "$method" "$url" >> "$FAKE_CURL_LOG"
+
+case "$url" in
+  *:fetchStatus)
+    response="${FAKE_STATUS_RESPONSE-}"
+    endpoint=status
+    ;;
+  *:upload)
+    response="${FAKE_UPLOAD_RESPONSE-}"
+    endpoint=upload
+    ;;
+  *:publish)
+    response="${FAKE_PUBLISH_RESPONSE-}"
+    endpoint=publish
+    ;;
+  */addons/addon/*/versions/*)
+    response="${FAKE_FIREFOX_VERSIONS_RESPONSE-}"
+    endpoint=firefox-versions
+    ;;
+  *)
+    echo "Unexpected fake Chrome endpoint: $url" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "$response" ]]; then
+  response='{}'
+fi
+
+printf '%s\n' "$response" > "$output_file"
+
+if [[ "${FAKE_FAIL_ENDPOINT:-}" == "$endpoint" ]]; then
+  exit 22
+fi

--- a/.github/scripts/test-check-deployable-affected.sh
+++ b/.github/scripts/test-check-deployable-affected.sh
@@ -9,12 +9,17 @@ trap 'rm -rf "$temp_dir"' EXIT
 
 fixture_repo="$temp_dir/repo"
 fake_bin="$temp_dir/bin"
-mkdir -p "$fixture_repo/apps/app" "$fixture_repo/apps/www" "$fake_bin"
+mkdir -p \
+  "$fixture_repo/apps/app" \
+  "$fixture_repo/apps/extension" \
+  "$fixture_repo/apps/www" \
+  "$fake_bin"
 
 git -C "$fixture_repo" init --quiet
 git -C "$fixture_repo" config user.email "deployment-test@example.com"
 git -C "$fixture_repo" config user.name "Deployment Test"
 printf 'base\n' > "$fixture_repo/apps/app/source.txt"
+printf 'base\n' > "$fixture_repo/apps/extension/source.txt"
 printf 'base\n' > "$fixture_repo/apps/www/source.txt"
 git -C "$fixture_repo" add .
 git -C "$fixture_repo" commit --quiet -m "base"
@@ -30,6 +35,10 @@ printf '%s\n' \
   'separator=""' \
   'if grep -q "^apps/app/" <<< "$changed_files"; then' \
   '  printf '\''%s{"taskId":"@serial/app#build:artifact"}'\'' "$separator"' \
+  '  separator=","' \
+  'fi' \
+  'if grep -q "^apps/extension/" <<< "$changed_files"; then' \
+  '  printf '\''%s{"taskId":"@serial/extension#build:artifact"}'\'' "$separator"' \
   '  separator=","' \
   'fi' \
   'if grep -q "^apps/www/" <<< "$changed_files"; then' \
@@ -104,18 +113,27 @@ assert_detection_failure_is_not_masked() {
 
 app_sha="$(commit_change "apps/app/source.txt" "app change")"
 assert_affected app true "$base_sha" "$app_sha"
+assert_affected extension false "$base_sha" "$app_sha"
 assert_affected www false "$base_sha" "$app_sha"
 
+extension_sha="$(commit_change "apps/extension/source.txt" "extension change")"
+assert_affected app false "$app_sha" "$extension_sha"
+assert_affected extension true "$app_sha" "$extension_sha"
+assert_affected www false "$app_sha" "$extension_sha"
+
 www_sha="$(commit_change "apps/www/source.txt" "website change")"
-assert_affected app false "$app_sha" "$www_sha"
-assert_affected www true "$app_sha" "$www_sha"
-assert_detection_failure_is_not_masked "$app_sha" "$www_sha"
+assert_affected app false "$extension_sha" "$www_sha"
+assert_affected extension false "$extension_sha" "$www_sha"
+assert_affected www true "$extension_sha" "$www_sha"
+assert_detection_failure_is_not_masked "$extension_sha" "$www_sha"
 
 root_sha="$(commit_change "package.json" "{}")"
 assert_affected app true "$www_sha" "$root_sha"
+assert_affected extension true "$www_sha" "$root_sha"
 assert_affected www true "$www_sha" "$root_sha"
 
 assert_affected app true "" "$root_sha" workflow_dispatch
+assert_affected extension true "" "$root_sha" workflow_dispatch
 assert_affected www true "0000000000000000000000000000000000000000" "$root_sha"
 
 echo "Deployable affected checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,20 @@ jobs:
       - name: Check formatting
         run: pnpm format
 
-      - name: Test deployment change detection
-        run: .github/scripts/test-check-deployable-affected.sh
+      - name: Test deployment scripts
+        run: |
+          .github/scripts/test-check-deployable-affected.sh
+          .github/scripts/extensions/test-extension-deployment.sh
+
+      - name: Verify extension store packages
+        env:
+          SERIAL_EXTENSION_VERSION: 2026.1.0.0
+        run: |
+          pnpm --filter @serial/extension zip:stores
+          .github/scripts/extensions/collect-store-packages.sh \
+            apps/extension/.output \
+            "$RUNNER_TEMP/extension-store-packages" \
+            "$SERIAL_EXTENSION_VERSION"
 
   e2e:
     needs: changes

--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -1,0 +1,228 @@
+name: Deploy Browser Extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/extension/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - ".node-version"
+      - ".github/scripts/check-deployable-affected.sh"
+      - ".github/scripts/extensions/**"
+      - ".github/workflows/deploy-extension.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-extension-main
+  cancel-in-progress: false
+
+jobs:
+  affected:
+    if: github.repository == 'megaflorasoftware/serial'
+    runs-on: ubuntu-latest
+    outputs:
+      extension: ${{ steps.check.outputs.extension }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Check whether the browser extension artifact is affected
+        id: check
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: .github/scripts/check-deployable-affected.sh extension
+
+  release-gate:
+    needs: affected
+    if: needs.affected.outputs.extension == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Check extension store configuration
+        env:
+          CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ vars.CHROME_PUBLISHER_ID }}
+          CHROME_SERVICE_ACCOUNT: ${{ vars.CHROME_SERVICE_ACCOUNT }}
+          CHROME_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
+          FIREFOX_EXTENSION_ID: ${{ vars.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          : "${CHROME_EXTENSION_ID:?Set the CHROME_EXTENSION_ID repository variable}"
+          : "${CHROME_PUBLISHER_ID:?Set the CHROME_PUBLISHER_ID repository variable}"
+          : "${CHROME_SERVICE_ACCOUNT:?Set the CHROME_SERVICE_ACCOUNT repository variable}"
+          : "${CHROME_WORKLOAD_IDENTITY_PROVIDER:?Set the CHROME_WORKLOAD_IDENTITY_PROVIDER repository variable}"
+          : "${FIREFOX_EXTENSION_ID:?Set the FIREFOX_EXTENSION_ID repository variable}"
+          : "${FIREFOX_JWT_ISSUER:?Set the FIREFOX_JWT_ISSUER repository secret}"
+          : "${FIREFOX_JWT_SECRET:?Set the FIREFOX_JWT_SECRET repository secret}"
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.CHROME_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/chromewebstore
+          create_credentials_file: false
+
+      - name: Block while either store has an active review
+        env:
+          CHROME_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+          CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ vars.CHROME_PUBLISHER_ID }}
+          FIREFOX_EXTENSION_ID: ${{ vars.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: .github/scripts/extensions/check-store-readiness.sh
+
+  build:
+    needs: [affected, release-gate]
+    if: needs.affected.outputs.extension == 'true' && needs.release-gate.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Generate store version
+        id: version
+        run: node .github/scripts/extensions/generate-version.mjs
+
+      - name: Build store packages
+        env:
+          SERIAL_EXTENSION_VERSION: ${{ steps.version.outputs.version }}
+        run: pnpm --filter @serial/extension zip:stores
+
+      - name: Collect and verify store packages
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          .github/scripts/extensions/collect-store-packages.sh
+          apps/extension/.output store-packages "$RELEASE_VERSION"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: extension-store-packages-${{ steps.version.outputs.version }}
+          path: store-packages
+          if-no-files-found: error
+          retention-days: 30
+
+  deploy-chrome:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: extension-store-packages-${{ needs.build.outputs.version }}
+          path: store-packages
+
+      - name: Check Chrome deployment configuration
+        env:
+          CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ vars.CHROME_PUBLISHER_ID }}
+          CHROME_SERVICE_ACCOUNT: ${{ vars.CHROME_SERVICE_ACCOUNT }}
+          CHROME_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
+        run: |
+          : "${CHROME_EXTENSION_ID:?Set the CHROME_EXTENSION_ID repository variable}"
+          : "${CHROME_PUBLISHER_ID:?Set the CHROME_PUBLISHER_ID repository variable}"
+          : "${CHROME_SERVICE_ACCOUNT:?Set the CHROME_SERVICE_ACCOUNT repository variable}"
+          : "${CHROME_WORKLOAD_IDENTITY_PROVIDER:?Set the CHROME_WORKLOAD_IDENTITY_PROVIDER repository variable}"
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.CHROME_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/chromewebstore
+          create_credentials_file: false
+
+      - name: Submit Chrome extension
+        env:
+          CHROME_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+          CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ vars.CHROME_PUBLISHER_ID }}
+        run: .github/scripts/extensions/publish-chrome.sh store-packages/chrome.zip
+
+  deploy-firefox:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: extension-store-packages-${{ needs.build.outputs.version }}
+          path: store-packages
+
+      - name: Check Firefox deployment configuration
+        env:
+          FIREFOX_EXTENSION_ID: ${{ vars.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          : "${FIREFOX_EXTENSION_ID:?Set the FIREFOX_EXTENSION_ID repository variable}"
+          : "${FIREFOX_JWT_ISSUER:?Set the FIREFOX_JWT_ISSUER repository secret}"
+          : "${FIREFOX_JWT_SECRET:?Set the FIREFOX_JWT_SECRET repository secret}"
+
+      - name: Submit Firefox extension
+        working-directory: apps/extension
+        env:
+          FIREFOX_CHANNEL: listed
+          FIREFOX_EXTENSION_ID: ${{ vars.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          pnpm publish:firefox \
+            --firefox-zip "$GITHUB_WORKSPACE/store-packages/firefox.zip" \
+            --firefox-sources-zip "$GITHUB_WORKSPACE/store-packages/firefox-sources.zip"

--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -135,6 +135,9 @@ jobs:
           .github/scripts/extensions/collect-store-packages.sh
           apps/extension/.output store-packages "$RELEASE_VERSION"
 
+      - name: Verify Firefox store lint
+        run: pnpm --filter @serial/extension lint:firefox
+
       - uses: actions/upload-artifact@v4
         with:
           name: extension-store-packages-${{ steps.version.outputs.version }}

--- a/apps/app/tests/unit/auth/extension-auth-flow.test.ts
+++ b/apps/app/tests/unit/auth/extension-auth-flow.test.ts
@@ -9,7 +9,7 @@ vi.mock("~/server/email", () => ({
 
 const VALID_CONNECT_CALLBACK = `/auth/connect-extension?${new URLSearchParams({
   redirect_uri:
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   state: "s".repeat(43),
   code_challenge: "c".repeat(43),
   code_challenge_method: "S256",

--- a/apps/app/tests/unit/auth/extension-redirect.test.ts
+++ b/apps/app/tests/unit/auth/extension-redirect.test.ts
@@ -10,7 +10,7 @@ import {
 
 const VALID_CONNECT_SEARCH = new URLSearchParams({
   redirect_uri:
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   state: "s".repeat(43),
   code_challenge: "c".repeat(43),
   code_challenge_method: "S256",
@@ -25,11 +25,11 @@ describe("Serial extension redirect URIs", () => {
 
   it.each([
     "not-a-url",
-    "http://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "http://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
     "https://example.com/serial-auth",
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/wrong-path",
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth?next=x",
-    "https://user:password@abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/wrong-path",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth?next=x",
+    "https://user:password@olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   ])("rejects %s", (redirectUri) => {
     expect(() => parseExtensionRedirectUri(redirectUri)).toThrow(
       "Invalid Serial extension redirect URI",

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -30,7 +30,7 @@ the submitted extension's `manifest.json`:
 
 ```sh
 corepack pnpm install --frozen-lockfile
-SERIAL_EXTENSION_VERSION=<manifest-version> corepack pnpm --filter @serial/extension zip:firefox
+SERIAL_EXTENSION_STORE_BUILD=true SERIAL_EXTENSION_VERSION=<manifest-version> corepack pnpm --filter @serial/extension zip:firefox
 ```
 
 Run the app in demo mode and open it in WXT's extension-enabled Chrome test
@@ -80,6 +80,8 @@ pre-extraction page source. The selected Serial server stores the Bookmark and
 may perform bounded Feed discovery only when the page declares no Feeds.
 
 Before the first Chrome Web Store release, replace the checked-in manifest key
-with the key assigned to the uploaded extension. The identity tests derive the
-Chrome and Firefox redirect URLs from their manifest identities and ensure the
-server allowlist stays in sync.
+with the key assigned to the uploaded extension. Local and unpacked builds use
+that key to preserve the Chrome extension ID. Store submission ZIPs omit the
+development-only `key` field because the Chrome Web Store assigns identity from
+the listing. The identity tests derive the Chrome and Firefox redirect URLs from
+their manifest identities and ensure the server allowlist stays in sync.

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -68,9 +68,10 @@ save:
 - `identity` completes the approved connection to a Serial instance.
 - `storage` keeps the selected instance and its opaque extension session token
   in the browser.
-- Optional host access is requested for the selected HTTPS Serial instance, or
-  for a loopback HTTP instance during local development. Signing out removes
-  that host access.
+- Optional host access is requested for the selected HTTPS Serial instance.
+  Development builds additionally allow loopback HTTP instances; production
+  and store builds omit those permissions and reject loopback instance
+  addresses. Signing out removes the selected instance's host access.
 
 The Firefox manifest declares `authenticationInfo`, `browsingActivity`,
 `websiteActivity`, and `websiteContent` because signing in and opening the popup

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -19,6 +19,20 @@ pnpm --filter @serial/extension dev:firefox
 The root `build`, `typecheck`, `lint`, and `format` commands include this
 workspace automatically.
 
+Production Chrome and Firefox store deployment is documented in
+[`../../.github/EXTENSION_DEPLOYMENT.md`](../../.github/EXTENSION_DEPLOYMENT.md).
+The first store listings are created manually; affected updates are submitted
+from `main` by GitHub Actions after that bootstrap is complete.
+
+The Firefox source archive contains the locked monorepo inputs needed to
+reproduce the submitted package. From the archive root, use the version from
+the submitted extension's `manifest.json`:
+
+```sh
+corepack pnpm install --frozen-lockfile
+SERIAL_EXTENSION_VERSION=<manifest-version> corepack pnpm --filter @serial/extension zip:firefox
+```
+
 Run the app in demo mode and open it in WXT's extension-enabled Chrome test
 browser:
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -31,7 +31,12 @@ the submitted extension's `manifest.json`:
 ```sh
 corepack pnpm install --frozen-lockfile
 SERIAL_EXTENSION_STORE_BUILD=true SERIAL_EXTENSION_VERSION=<manifest-version> corepack pnpm --filter @serial/extension zip:firefox
+corepack pnpm --filter @serial/extension lint:firefox
 ```
+
+Firefox lint is expected to pass with five reviewed warnings from unmodified
+Mozilla Readability, DOMPurify, and React DOM code. Any additional or changed
+warning fails validation.
 
 Run the app in demo mode and open it in WXT's extension-enabled Chrome test
 browser:

--- a/apps/extension/entrypoints/bookmark-capture.content.ts
+++ b/apps/extension/entrypoints/bookmark-capture.content.ts
@@ -1,7 +1,6 @@
 import { extractPageObservation } from "@serial/bookmark-capture/extract";
 
 export default defineContentScript({
-  matches: ["http://*/*", "https://*/*"],
   registration: "runtime",
   main() {
     return extractPageObservation(document);

--- a/apps/extension/entrypoints/bookmark-capture.content.ts
+++ b/apps/extension/entrypoints/bookmark-capture.content.ts
@@ -1,4 +1,4 @@
-import { extractPageObservation } from "@serial/bookmark-capture";
+import { extractPageObservation } from "@serial/bookmark-capture/extract";
 
 export default defineContentScript({
   matches: ["http://*/*", "https://*/*"],

--- a/apps/extension/lib/auth.test.ts
+++ b/apps/extension/lib/auth.test.ts
@@ -43,6 +43,18 @@ describe("normalizeInstanceUrl", () => {
     ).toThrowError("Serial instances must use HTTPS");
   });
 
+  it("rejects HTTP loopback instances in production", () => {
+    for (const instance of [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://[::1]:3000",
+    ]) {
+      expect(() =>
+        normalizeInstanceUrl(instance, { allowHttpLoopback: false }),
+      ).toThrowError("Serial instances must use HTTPS");
+    }
+  });
+
   it("rejects embedded credentials", () => {
     expect(() =>
       normalizeInstanceUrl("https://user:secret@serial.example.com"),

--- a/apps/extension/lib/auth.ts
+++ b/apps/extension/lib/auth.ts
@@ -158,7 +158,16 @@ export function parseStoredAuthSession(
   };
 }
 
-export function normalizeInstanceUrl(value: string): string {
+type NormalizeInstanceUrlOptions = {
+  allowHttpLoopback?: boolean;
+};
+
+export function normalizeInstanceUrl(
+  value: string,
+  {
+    allowHttpLoopback = import.meta.env.MODE !== "production",
+  }: NormalizeInstanceUrlOptions = {},
+): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Enter a Serial instance address");
 
@@ -176,7 +185,10 @@ export function normalizeInstanceUrl(value: string): string {
     throw new Error("Instance addresses cannot contain credentials");
   }
   const isLocal = isLoopbackHostname(url.hostname);
-  if (url.protocol !== "https:" && !(isLocal && url.protocol === "http:")) {
+  if (
+    url.protocol !== "https:" &&
+    !(allowHttpLoopback && isLocal && url.protocol === "http:")
+  ) {
     throw new Error("Serial instances must use HTTPS");
   }
   return url.origin;

--- a/apps/extension/lib/bookmark-capture.test.ts
+++ b/apps/extension/lib/bookmark-capture.test.ts
@@ -1,9 +1,7 @@
 import { JSDOM } from "jsdom";
 import { describe, expect, it, vi } from "vitest";
-import {
-  BOOKMARK_CAPTURE_LIMITS,
-  extractPageObservation,
-} from "@serial/bookmark-capture";
+import { BOOKMARK_CAPTURE_LIMITS } from "@serial/bookmark-capture";
+import { extractPageObservation } from "@serial/bookmark-capture/extract";
 import { serializeBookmarkRequest } from "./bookmarks";
 
 const YOUTUBE_THUMBNAIL_URL =

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@serial/extension",
   "description": "A companion extension for Serial, a calm and customizable feed reader.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -13,6 +13,8 @@
     "build:firefox": "wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
+    "zip:stores": "wxt clean && wxt zip && wxt zip -b firefox",
+    "publish:firefox": "wxt submit",
     "typecheck": "wxt prepare && tsc --noEmit",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -13,7 +13,7 @@
     "build:firefox": "wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
-    "zip:stores": "wxt clean && wxt zip && wxt zip -b firefox",
+    "zip:stores": "wxt clean && SERIAL_EXTENSION_STORE_BUILD=true wxt zip && SERIAL_EXTENSION_STORE_BUILD=true wxt zip -b firefox",
     "publish:firefox": "wxt submit",
     "typecheck": "wxt prepare && tsc --noEmit",
     "format": "prettier --check .",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serial/extension",
-  "description": "An extension for Serial, a calm and customizable feed reader. Allows you to bookmark content and subscribe to feeds from anywhere across the web.",
+  "description": "A companion extension for Serial, a calm and customizable feed reader.",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint .",
+    "lint:firefox": "web-ext lint --source-dir .output/firefox-mv2 --output=json --boring --no-input | node scripts/check-firefox-lint.mjs",
     "lint:fix": "eslint --fix .",
     "test:unit": "vitest run",
     "postinstall": "wxt prepare"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serial/extension",
-  "description": "The Serial browser extension.",
+  "description": "An extension for Serial, a calm and customizable feed reader. Allows you to bookmark content and subscribe to feeds from anywhere across the web.",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/apps/extension/scripts/check-firefox-lint.mjs
+++ b/apps/extension/scripts/check-firefox-lint.mjs
@@ -1,0 +1,59 @@
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+
+let report;
+try {
+  report = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+} catch (error) {
+  throw new Error("Firefox lint did not produce a JSON report", {
+    cause: error,
+  });
+}
+
+const expectedWarnings = new Map([
+  ["UNSAFE_VAR_ASSIGNMENT:content-scripts/bookmark-capture.js", 3],
+  ["UNSAFE_VAR_ASSIGNMENT:chunks/popup", 2],
+]);
+const actualWarnings = new Map();
+
+for (const warning of report.warnings ?? []) {
+  const file = warning.file?.startsWith("chunks/popup-")
+    ? "chunks/popup"
+    : warning.file;
+  const key = `${warning.code}:${file}`;
+  actualWarnings.set(key, (actualWarnings.get(key) ?? 0) + 1);
+}
+
+const failures = [];
+if (report.summary?.errors !== 0) {
+  failures.push(
+    `expected 0 errors, found ${report.summary?.errors ?? "unknown"}`,
+  );
+}
+if (report.summary?.notices !== 0) {
+  failures.push(
+    `expected 0 notices, found ${report.summary?.notices ?? "unknown"}`,
+  );
+}
+for (const [key, count] of expectedWarnings) {
+  if (actualWarnings.get(key) !== count) {
+    failures.push(
+      `expected ${count} ${key} warnings, found ${actualWarnings.get(key) ?? 0}`,
+    );
+  }
+}
+for (const [key, count] of actualWarnings) {
+  if (!expectedWarnings.has(key)) {
+    failures.push(`unexpected warning ${key} (${count})`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(
+    `Firefox lint validation failed:\n- ${failures.join("\n- ")}`,
+  );
+}
+
+console.log(
+  `Firefox lint passed with ${report.summary.warnings} reviewed third-party warnings.`,
+);

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -9,6 +9,13 @@ import {
 const startUrl = process.env.SERIAL_EXTENSION_START_URL;
 const releaseVersion = process.env.SERIAL_EXTENSION_VERSION;
 const isStoreBuild = process.env.SERIAL_EXTENSION_STORE_BUILD === "true";
+const productionInstanceOrigins = ["https://*/*"];
+const developmentInstanceOrigins = [
+  ...productionInstanceOrigins,
+  "http://localhost/*",
+  "http://127.0.0.1/*",
+  "http://[::1]/*",
+];
 const extensionIcons = {
   16: "icon/16.png",
   32: "icon/32.png",
@@ -54,49 +61,40 @@ export default defineConfig({
     plugins: [tailwindcss()],
   }),
   webExt: startUrl ? { startUrls: [startUrl] } : undefined,
-  manifest: ({ manifestVersion }) => ({
-    name: "Serial",
-    ...(releaseVersion ? { version: releaseVersion } : {}),
-    ...(!isStoreBuild ? { key: CHROME_EXTENSION_MANIFEST_KEY } : {}),
-    icons: extensionIcons,
-    ...(manifestVersion === 2
-      ? { browser_action: { default_icon: extensionIcons } }
-      : { action: { default_icon: extensionIcons } }),
-    permissions: ["identity", "storage", "activeTab", "scripting"],
-    optional_permissions:
-      manifestVersion === 2
-        ? [
-            "https://*/*",
-            "http://localhost/*",
-            "http://127.0.0.1/*",
-            "http://[::1]/*",
-          ]
-        : undefined,
-    optional_host_permissions:
-      manifestVersion === 3
-        ? [
-            "https://*/*",
-            "http://localhost/*",
-            "http://127.0.0.1/*",
-            "http://[::1]/*",
-          ]
-        : undefined,
-    browser_specific_settings: {
-      gecko: {
-        id: FIREFOX_EXTENSION_ID,
-        strict_min_version: "140.0",
-        data_collection_permissions: {
-          required: [
-            "authenticationInfo",
-            "browsingActivity",
-            "websiteActivity",
-            "websiteContent",
-          ],
+  manifest: ({ manifestVersion, mode }) => {
+    const instanceOrigins =
+      mode === "production"
+        ? productionInstanceOrigins
+        : developmentInstanceOrigins;
+    return {
+      name: "Serial",
+      ...(releaseVersion ? { version: releaseVersion } : {}),
+      ...(!isStoreBuild ? { key: CHROME_EXTENSION_MANIFEST_KEY } : {}),
+      icons: extensionIcons,
+      ...(manifestVersion === 2
+        ? { browser_action: { default_icon: extensionIcons } }
+        : { action: { default_icon: extensionIcons } }),
+      permissions: ["identity", "storage", "activeTab", "scripting"],
+      optional_permissions: manifestVersion === 2 ? instanceOrigins : undefined,
+      optional_host_permissions:
+        manifestVersion === 3 ? instanceOrigins : undefined,
+      browser_specific_settings: {
+        gecko: {
+          id: FIREFOX_EXTENSION_ID,
+          strict_min_version: "140.0",
+          data_collection_permissions: {
+            required: [
+              "authenticationInfo",
+              "browsingActivity",
+              "websiteActivity",
+              "websiteContent",
+            ],
+          },
+        },
+        gecko_android: {
+          strict_min_version: "142.0",
         },
       },
-      gecko_android: {
-        strict_min_version: "142.0",
-      },
-    },
-  }),
+    };
+  },
 });

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
 import {
   CHROME_EXTENSION_MANIFEST_KEY,
   FIREFOX_EXTENSION_ID,
 } from "@serial/extension-identity";
 
 const startUrl = process.env.SERIAL_EXTENSION_START_URL;
+const releaseVersion = process.env.SERIAL_EXTENSION_VERSION;
 const extensionIcons = {
   16: "icon/16.png",
   32: "icon/32.png",
@@ -17,12 +19,42 @@ const extensionIcons = {
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
+  zip: {
+    sourcesRoot: fileURLToPath(new URL("../..", import.meta.url)),
+    excludeSources: ["**/*"],
+    includeSources: [
+      ".gitignore",
+      ".node-version",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "turbo.json",
+      "apps/extension/README.md",
+      "apps/extension/package.json",
+      "apps/extension/tsconfig.json",
+      "apps/extension/wxt.config.ts",
+      "apps/extension/assets/**",
+      "apps/extension/entrypoints/**",
+      "apps/extension/lib/**",
+      "apps/extension/public/**",
+      "packages/bookmark-capture/package.json",
+      "packages/bookmark-capture/tsconfig.json",
+      "packages/bookmark-capture/src/**",
+      "packages/extension-identity/package.json",
+      "packages/extension-identity/tsconfig.json",
+      "packages/extension-identity/src/**",
+      "packages/ui/package.json",
+      "packages/ui/tsconfig.json",
+      "packages/ui/src/**",
+    ],
+  },
   vite: () => ({
     plugins: [tailwindcss()],
   }),
   webExt: startUrl ? { startUrls: [startUrl] } : undefined,
   manifest: ({ manifestVersion }) => ({
     name: "Serial",
+    ...(releaseVersion ? { version: releaseVersion } : {}),
     key: CHROME_EXTENSION_MANIFEST_KEY,
     icons: extensionIcons,
     ...(manifestVersion === 2

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -8,6 +8,7 @@ import {
 
 const startUrl = process.env.SERIAL_EXTENSION_START_URL;
 const releaseVersion = process.env.SERIAL_EXTENSION_VERSION;
+const isStoreBuild = process.env.SERIAL_EXTENSION_STORE_BUILD === "true";
 const extensionIcons = {
   16: "icon/16.png",
   32: "icon/32.png",
@@ -55,7 +56,7 @@ export default defineConfig({
   manifest: ({ manifestVersion }) => ({
     name: "Serial",
     ...(releaseVersion ? { version: releaseVersion } : {}),
-    key: CHROME_EXTENSION_MANIFEST_KEY,
+    ...(!isStoreBuild ? { key: CHROME_EXTENSION_MANIFEST_KEY } : {}),
     icons: extensionIcons,
     ...(manifestVersion === 2
       ? { browser_action: { default_icon: extensionIcons } }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       "turbo.json",
       "apps/extension/README.md",
       "apps/extension/package.json",
+      "apps/extension/scripts/**",
       "apps/extension/tsconfig.json",
       "apps/extension/wxt.config.ts",
       "apps/extension/assets/**",
@@ -92,6 +93,9 @@ export default defineConfig({
             "websiteContent",
           ],
         },
+      },
+      gecko_android: {
+        strict_min_version: "142.0",
       },
     },
   }),

--- a/packages/bookmark-capture/package.json
+++ b/packages/bookmark-capture/package.json
@@ -7,7 +7,8 @@
     "typecheck": "tsc --noEmit"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./extract": "./src/extract.ts"
   },
   "dependencies": {
     "@mozilla/readability": "^0.6.0",

--- a/packages/bookmark-capture/src/index.ts
+++ b/packages/bookmark-capture/src/index.ts
@@ -1,6 +1,9 @@
 export * from "./capabilities";
 export * from "./contracts";
-export * from "./extract";
 export * from "./mutations";
 export * from "./policy";
 export * from "./thumbnail";
+export type {
+  ExtensionCaptureCandidate,
+  ExtensionPageObservation,
+} from "./extract";

--- a/packages/bookmark-capture/src/sanitize.ts
+++ b/packages/bookmark-capture/src/sanitize.ts
@@ -133,8 +133,11 @@ export function sanitizeCaptureHtml(
   effectiveUrl: string,
   sourceDocument: Document,
 ) {
-  const captureDocument = sourceDocument.implementation.createHTMLDocument("");
-  captureDocument.body.innerHTML = contentHtml;
+  const captureDocument =
+    new sourceDocument.defaultView!.DOMParser().parseFromString(
+      contentHtml,
+      "text/html",
+    );
   const base = captureDocument.createElement("base");
   base.href = effectiveUrl;
   captureDocument.head.append(base);

--- a/packages/extension-identity/src/index.ts
+++ b/packages/extension-identity/src/index.ts
@@ -1,10 +1,10 @@
 export const EXTENSION_AUTH_REDIRECT_PATH = "serial-auth";
 export const CHROME_EXTENSION_MANIFEST_KEY =
-  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvq3bqhiFWK5G3Yi3g200Rg8k9kXUjs4Vkqutz1+Pk5+aKWjWKjnXG+pjG7eUyIq7wspsXHrJQcOV7RDRoWuVT0oTYok7J+kyYDGxZMHc5VS9ZADVKlvhB7HuM8pBE4HvU6dGu4sskAznN8co6XtTx0bZZyX+xp1R5EGncBUtycvc1BB93TRd2G29dLs5Cb/ek3zMk0pqrmNEgrZnLCNu536Oa5ViYJVWEZeg/qa3+rhE+cDux4pU9nRFE63p5TOb+dGmziQk89xKvsmS53P+CZPgzpXXhBnlHFjlC7O3pKn8W4TCxbhnPB7C3H+BzLzf10ZtKZeJri+h7Zsf/tA52QIDAQAB";
-export const CHROME_EXTENSION_ID = "abfgpdgoffipbnfjcdoejalehhbegamc";
-export const FIREFOX_EXTENSION_ID = "extension@serial.tube";
+  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz6erNNcBr2lZ+NMB8IFlHdfHhoCOH5b30EQhVM0yjxEW63uNVLiSfxYN7CNa9vHe0bPUat+DFHAky0/4fw2W0HWUXsbAvPVFDXvIEWdf0pwk2lqSgRwbiM/RB4uBuGNxnwc0YXQY5iM0isqxORm8CrpIv7BSsU3aaoOlL7gIsiELaJDb3Q+xduL7Hv/bjRC9EbBgiYhVsw4VnYoQQjPbwp/6cT5bGNig2DFokI+EdVb9nE1ExklAbja6Qk7zJKDomoit4E3kjNZBNvgRfX8cJwY4wxctiv2kkdZ+LRuG5ibXEKwzd2syu0fSgV0yxxBzFwYpxVI98qHEWW54RSCcowIDAQAB";
+export const CHROME_EXTENSION_ID = "olpaonddchkbjpmjjfamplfaibopllam";
+export const FIREFOX_EXTENSION_ID = "serial@megaflora.net";
 
 export const EXTENSION_IDENTITY_REDIRECT_URIS = {
   chrome: `https://${CHROME_EXTENSION_ID}.chromiumapp.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
-  firefox: `https://316a919b8777a95fa74b9564f4685cbe813b1a1d.extensions.allizom.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
+  firefox: `https://854bc1aa653d4d81ecb8ca73d66e35ec8bd16b60.extensions.allizom.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
 } as const;


### PR DESCRIPTION
Adds synchronized Chrome Web Store and Firefox Add-ons deployment after affected changes reach main. Both stores share a calendar version and the workflow blocks before upload while either store has an active review. Chrome uses Web Store API v2 with GitHub OIDC; Firefox uses listed AMO submission. Includes deterministic packaging, clean-room Firefox source reproduction, deployment tests, and the manual bootstrap/setup guide.\n\nThe first store listings and repository credentials must be configured before beta is promoted to main. No Edge deployment is included.