### PR TITLE
Set canonical browser extension identities

### DIFF
--- a/apps/app/tests/unit/auth/extension-auth-flow.test.ts
+++ b/apps/app/tests/unit/auth/extension-auth-flow.test.ts
@@ -9,7 +9,7 @@ vi.mock("~/server/email", () => ({
 
 const VALID_CONNECT_CALLBACK = `/auth/connect-extension?${new URLSearchParams({
   redirect_uri:
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   state: "s".repeat(43),
   code_challenge: "c".repeat(43),
   code_challenge_method: "S256",

--- a/apps/app/tests/unit/auth/extension-redirect.test.ts
+++ b/apps/app/tests/unit/auth/extension-redirect.test.ts
@@ -10,7 +10,7 @@ import {
 
 const VALID_CONNECT_SEARCH = new URLSearchParams({
   redirect_uri:
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   state: "s".repeat(43),
   code_challenge: "c".repeat(43),
   code_challenge_method: "S256",
@@ -25,11 +25,11 @@ describe("Serial extension redirect URIs", () => {
 
   it.each([
     "not-a-url",
-    "http://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "http://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
     "https://example.com/serial-auth",
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/wrong-path",
-    "https://abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth?next=x",
-    "https://user:password@abfgpdgoffipbnfjcdoejalehhbegamc.chromiumapp.org/serial-auth",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/wrong-path",
+    "https://olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth?next=x",
+    "https://user:password@olpaonddchkbjpmjjfamplfaibopllam.chromiumapp.org/serial-auth",
   ])("rejects %s", (redirectUri) => {
     expect(() => parseExtensionRedirectUri(redirectUri)).toThrow(
       "Invalid Serial extension redirect URI",

--- a/packages/extension-identity/src/index.ts
+++ b/packages/extension-identity/src/index.ts
@@ -1,10 +1,10 @@
 export const EXTENSION_AUTH_REDIRECT_PATH = "serial-auth";
 export const CHROME_EXTENSION_MANIFEST_KEY =
-  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvq3bqhiFWK5G3Yi3g200Rg8k9kXUjs4Vkqutz1+Pk5+aKWjWKjnXG+pjG7eUyIq7wspsXHrJQcOV7RDRoWuVT0oTYok7J+kyYDGxZMHc5VS9ZADVKlvhB7HuM8pBE4HvU6dGu4sskAznN8co6XtTx0bZZyX+xp1R5EGncBUtycvc1BB93TRd2G29dLs5Cb/ek3zMk0pqrmNEgrZnLCNu536Oa5ViYJVWEZeg/qa3+rhE+cDux4pU9nRFE63p5TOb+dGmziQk89xKvsmS53P+CZPgzpXXhBnlHFjlC7O3pKn8W4TCxbhnPB7C3H+BzLzf10ZtKZeJri+h7Zsf/tA52QIDAQAB";
-export const CHROME_EXTENSION_ID = "abfgpdgoffipbnfjcdoejalehhbegamc";
-export const FIREFOX_EXTENSION_ID = "extension@serial.tube";
+  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz6erNNcBr2lZ+NMB8IFlHdfHhoCOH5b30EQhVM0yjxEW63uNVLiSfxYN7CNa9vHe0bPUat+DFHAky0/4fw2W0HWUXsbAvPVFDXvIEWdf0pwk2lqSgRwbiM/RB4uBuGNxnwc0YXQY5iM0isqxORm8CrpIv7BSsU3aaoOlL7gIsiELaJDb3Q+xduL7Hv/bjRC9EbBgiYhVsw4VnYoQQjPbwp/6cT5bGNig2DFokI+EdVb9nE1ExklAbja6Qk7zJKDomoit4E3kjNZBNvgRfX8cJwY4wxctiv2kkdZ+LRuG5ibXEKwzd2syu0fSgV0yxxBzFwYpxVI98qHEWW54RSCcowIDAQAB";
+export const CHROME_EXTENSION_ID = "olpaonddchkbjpmjjfamplfaibopllam";
+export const FIREFOX_EXTENSION_ID = "serial@megaflora.net";
 
 export const EXTENSION_IDENTITY_REDIRECT_URIS = {
   chrome: `https://${CHROME_EXTENSION_ID}.chromiumapp.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
-  firefox: `https://316a919b8777a95fa74b9564f4685cbe813b1a1d.extensions.allizom.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
+  firefox: `https://854bc1aa653d4d81ecb8ca73d66e35ec8bd16b60.extensions.allizom.org/${EXTENSION_AUTH_REDIRECT_PATH}`,
 } as const;


### PR DESCRIPTION
## Summary

- replace the temporary Chrome manifest key and extension ID with the Chrome Web Store identity
- replace the temporary Firefox add-on ID and derived redirect host with the Megaflora-owned identity
- update focused authentication fixtures without including extension deployment CI or packaging changes

## Validation

- `pnpm test:unit tests/unit/auth/extension-auth-flow.test.ts tests/unit/auth/extension-redirect.test.ts` (15 passed)
- `pnpm test:unit lib/identity.test.ts` (2 passed)
- `pnpm typecheck`
- `pnpm lint` (passes with 29 existing warnings)
- `pnpm format`
- `pnpm benchmark:inventory:check` (590 accesses checked)
- `pnpm benchmark:client:coverage:check` (340 files checked)
- `pnpm build` and `pnpm build:firefox`; generated manifests contain the canonical Chrome key and Firefox ID

## Performance impact

The runtime change replaces static identity constants only. It adds no queries, synchronization work, rendering work, or new client code paths. Inventory and client-audit coverage checks pass; no deterministic performance benchmark applies to this constant-only authentication configuration update.