### PR TITLE
Isolate container smoke check from runtime KV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ COPY --from=build-base /usr/src/app/packages/extension-identity /usr/src/app/pac
 # Catch missing transitive imports in the migration runtime before deployment.
 RUN PUBLIC_BASE_URL=http://localhost \
     BETTER_AUTH_SECRET=container-build-smoke-test \
+    KV_STORE=none \
     NODE_ENV=production \
     node --import=tsx -e "await import('./src/env.js'); await import('./src/server/db/schema.ts')"
 


### PR DESCRIPTION
## Summary

- force the Dockerfile migration-runtime import smoke check to use the backend-neutral KV mode
- keep every Compose runtime ioredis setting and Redis URL unchanged
- prevent deployment platforms from making image construction depend on runtime-only Redis configuration

## Root cause

The main-instance Coolify build exposed `KV_STORE=ioredis` while `REDIS_URL` remained runtime-only. The self-contained Dockerfile smoke import therefore failed environment validation before the image was produced. The same command fails deterministically with `KV_STORE=ioredis` and no `REDIS_URL`; `KV_STORE=none` makes the import pass without changing container startup validation.

## Validation

- reproduced the exact `REDIS_URL is required when KV_STORE is ioredis` failure locally
- verified the import succeeds with the explicit backend-neutral setting
- `docker build --target final -t serial-container-build-kv-smoke .` passed; the changed smoke layer reran successfully before the full app build and image export
- `docker compose -f docker-compose.build-main-instance-ioredis.yaml config --quiet` passed
- `docker compose -f docker-compose.build.yaml config --quiet` passed
- `git diff --check` passed

## Performance impact

None at runtime. The change affects one image-build smoke command only; deployed containers retain their existing ioredis configuration and startup validation.