### PR TITLE
Invalidate incompatible IndexedDB cache state

### DIFF
--- a/apps/app/src/lib/data/idb-storage.ts
+++ b/apps/app/src/lib/data/idb-storage.ts
@@ -1,4 +1,5 @@
 import { clear, del, get, set } from "idb-keyval";
+import { withCurrentIndexedDbSchema } from "./indexed-db-schema";
 import type { PersistStorage, StorageValue } from "zustand/middleware";
 
 /**
@@ -36,26 +37,29 @@ export function createIDBStorage<T>(): PersistStorage<T> {
     writeTimeout = null;
     if (pendingName !== null && pendingValue !== null) {
       const name = pendingName;
-      void set(pendingName, pendingValue).catch((err: unknown) => {
-        const isDOMException = err instanceof DOMException;
-        const isQuotaExceeded =
-          isDOMException && err.name === "QuotaExceededError";
-        // InvalidStateError means the DB connection was closed or deleted
-        // from under us — cached data is unreliable either way.
-        const isInvalidState =
-          isDOMException && err.name === "InvalidStateError";
+      const value = pendingValue;
+      void withCurrentIndexedDbSchema(() => set(name, value)).catch(
+        (err: unknown) => {
+          const isDOMException = err instanceof DOMException;
+          const isQuotaExceeded =
+            isDOMException && err.name === "QuotaExceededError";
+          // InvalidStateError means the DB connection was closed or deleted
+          // from under us — cached data is unreliable either way.
+          const isInvalidState =
+            isDOMException && err.name === "InvalidStateError";
 
-        if (isQuotaExceeded || isInvalidState) {
-          console.warn(
-            `[idb-storage] ${isDOMException ? err.name : "Unknown error"} writing "${name}" — clearing cache so next load does a full refresh`,
-          );
-          // Wipe all keys so the next page load starts with empty stores
-          // and triggers a full SSE fetch instead of rehydrating stale data.
-          void clear();
-        } else {
-          console.warn("[idb-storage] write failed:", name, err);
-        }
-      });
+          if (isQuotaExceeded || isInvalidState) {
+            console.warn(
+              `[idb-storage] ${isDOMException ? err.name : "Unknown error"} writing "${name}" — clearing cache so next load does a full refresh`,
+            );
+            // Wipe all keys so the next page load starts with empty stores
+            // and triggers a full SSE fetch instead of rehydrating stale data.
+            void clear();
+          } else {
+            console.warn("[idb-storage] write failed:", name, err);
+          }
+        },
+      );
       pendingName = null;
       pendingValue = null;
     }
@@ -84,9 +88,10 @@ export function createIDBStorage<T>(): PersistStorage<T> {
   window.addEventListener("pagehide", flushPending);
 
   return {
-    getItem: async (name: string) => {
-      return (await get<StorageValue<T>>(name)) ?? null;
-    },
+    getItem: (name: string) =>
+      withCurrentIndexedDbSchema(
+        async () => (await get<StorageValue<T>>(name)) ?? null,
+      ),
 
     setItem: (name: string, value: StorageValue<T>) => {
       pendingName = name;
@@ -103,7 +108,7 @@ export function createIDBStorage<T>(): PersistStorage<T> {
       }
       pendingName = null;
       pendingValue = null;
-      await del(name);
+      await withCurrentIndexedDbSchema(() => del(name));
     },
   };
 }

--- a/apps/app/src/lib/data/indexed-db-schema.ts
+++ b/apps/app/src/lib/data/indexed-db-schema.ts
@@ -1,0 +1,51 @@
+import { clear, get, set } from "idb-keyval";
+
+export const INDEXED_DB_SCHEMA_KEY = "serial-indexed-db-schema-version";
+export const INDEXED_DB_SCHEMA_VERSION = 2;
+
+type IndexedDbSchemaStore = {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: unknown) => Promise<unknown>;
+  clear: () => Promise<unknown>;
+};
+
+/**
+ * Creates a one-shot gate that every IndexedDB-backed store passes through
+ * before reading or writing. Once initialized, operations take a synchronous
+ * fast path into their own IndexedDB transaction. A cache schema change
+ * invalidates the complete shared idb-keyval database so independently
+ * persisted stores cannot hydrate a mix of compatible and incompatible state.
+ */
+export function createIndexedDbSchemaGate(
+  currentVersion: number,
+  store: IndexedDbSchemaStore,
+) {
+  let initialization: Promise<void> | undefined;
+  let ready = false;
+
+  const ensure = () => {
+    initialization ??= (async () => {
+      const storedVersion = await store.get(INDEXED_DB_SCHEMA_KEY);
+      if (storedVersion !== currentVersion) {
+        await store.clear();
+        await store.set(INDEXED_DB_SCHEMA_KEY, currentVersion);
+      }
+      ready = true;
+    })();
+    return initialization;
+  };
+
+  return {
+    ensure,
+    run: <T>(operation: () => Promise<T>) =>
+      ready ? operation() : ensure().then(operation),
+  };
+}
+
+const currentIndexedDbSchema = createIndexedDbSchemaGate(
+  INDEXED_DB_SCHEMA_VERSION,
+  { get, set, clear },
+);
+
+export const ensureCurrentIndexedDbSchema = currentIndexedDbSchema.ensure;
+export const withCurrentIndexedDbSchema = currentIndexedDbSchema.run;

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -8,6 +8,7 @@ import {
   set,
   setMany,
 } from "idb-keyval";
+import { withCurrentIndexedDbSchema } from "./indexed-db-schema";
 import type { PersistStorage, StorageValue } from "zustand/middleware";
 
 const WRITE_THROTTLE_MS = 2_000;
@@ -316,15 +317,17 @@ export function createNormalizedIDBStorage<T>(
     pending = null;
     if (!current) return;
     writeChain = writeChain
-      .then(async () => {
-        await writeNormalized({
-          name: current.name,
-          previous: lastValue,
-          next: current.value,
-          options,
-        });
-        lastValue = current.value;
-      })
+      .then(() =>
+        withCurrentIndexedDbSchema(async () => {
+          await writeNormalized({
+            name: current.name,
+            previous: lastValue,
+            next: current.value,
+            options,
+          });
+          lastValue = current.value;
+        }),
+      )
       .catch((error: unknown) => reportWriteError(current.name, error));
   };
 
@@ -339,26 +342,27 @@ export function createNormalizedIDBStorage<T>(
   window.addEventListener("pagehide", flushPending);
 
   return {
-    getItem: async (name) => {
-      const normalized = await readNormalized<T>(name, options);
-      if (normalized) {
-        lastValue = normalized;
-        return normalized;
-      }
+    getItem: (name) =>
+      withCurrentIndexedDbSchema(async () => {
+        const normalized = await readNormalized<T>(name, options);
+        if (normalized) {
+          lastValue = normalized;
+          return normalized;
+        }
 
-      const legacy = (await get<StorageValue<T>>(name)) ?? null;
-      if (legacy) {
-        await writeNormalized({
-          name,
-          previous: null,
-          next: legacy,
-          options,
-        });
-        await del(name);
-        lastValue = legacy;
-      }
-      return legacy;
-    },
+        const legacy = (await get<StorageValue<T>>(name)) ?? null;
+        if (legacy) {
+          await writeNormalized({
+            name,
+            previous: null,
+            next: legacy,
+            options,
+          });
+          await del(name);
+          lastValue = legacy;
+        }
+        return legacy;
+      }),
     setItem: (name, value) => {
       pending = { name, value };
       if (writeTimeout === null) {
@@ -370,12 +374,14 @@ export function createNormalizedIDBStorage<T>(
       writeTimeout = null;
       pending = null;
       lastValue = null;
-      const prefix = normalizedPrefix(name);
-      const matchingKeys = (await keys<IDBValidKey>()).filter(
-        (key) => typeof key === "string" && key.startsWith(prefix),
-      );
-      await deleteInBatches(matchingKeys);
-      await del(name);
+      await withCurrentIndexedDbSchema(async () => {
+        const prefix = normalizedPrefix(name);
+        const matchingKeys = (await keys<IDBValidKey>()).filter(
+          (key) => typeof key === "string" && key.startsWith(prefix),
+        );
+        await deleteInBatches(matchingKeys);
+        await del(name);
+      });
     },
   };
 }

--- a/apps/app/tests/unit/data/indexed-db-schema.test.ts
+++ b/apps/app/tests/unit/data/indexed-db-schema.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createIndexedDbSchemaGate,
+  INDEXED_DB_SCHEMA_KEY,
+} from "~/lib/data/indexed-db-schema";
+
+function createMemoryStore(entries: Record<string, unknown> = {}) {
+  const data = new Map<string, unknown>(Object.entries(entries));
+  return {
+    data,
+    get: vi.fn((key: string) => Promise.resolve(data.get(key))),
+    set: vi.fn((key: string, value: unknown) => {
+      data.set(key, value);
+      return Promise.resolve();
+    }),
+    clear: vi.fn(() => {
+      data.clear();
+      return Promise.resolve();
+    }),
+  };
+}
+
+describe("IndexedDB schema gate", () => {
+  it.each([
+    ["missing", undefined],
+    ["mismatched", 1],
+  ])("clears all IndexedDB data when the version is %s", async (_, version) => {
+    const entries: Record<string, unknown> = {
+      "serial-application-store": { legacy: true },
+      "serial-feeds-store": { legacy: true },
+      "serial-bookmarks-store::normalized:v1::root": { legacy: true },
+    };
+    if (version !== undefined) entries[INDEXED_DB_SCHEMA_KEY] = version;
+    const store = createMemoryStore(entries);
+    const gate = createIndexedDbSchemaGate(2, store);
+
+    await gate.ensure();
+
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(Object.fromEntries(store.data)).toEqual({
+      [INDEXED_DB_SCHEMA_KEY]: 2,
+    });
+  });
+
+  it("preserves all IndexedDB data when the version matches", async () => {
+    const store = createMemoryStore({
+      [INDEXED_DB_SCHEMA_KEY]: 2,
+      "serial-application-store": { current: true },
+      "serial-feeds-store": { current: true },
+    });
+    const gate = createIndexedDbSchemaGate(2, store);
+
+    await gate.ensure();
+
+    expect(store.clear).not.toHaveBeenCalled();
+    expect(Object.fromEntries(store.data)).toEqual({
+      [INDEXED_DB_SCHEMA_KEY]: 2,
+      "serial-application-store": { current: true },
+      "serial-feeds-store": { current: true },
+    });
+  });
+
+  it("serializes concurrent hydration behind one schema check", async () => {
+    const store = createMemoryStore({
+      [INDEXED_DB_SCHEMA_KEY]: 1,
+      "serial-application-store": { legacy: true },
+    });
+    const gate = createIndexedDbSchemaGate(2, store);
+
+    await Promise.all([gate.ensure(), gate.ensure(), gate.ensure()]);
+
+    expect(store.get).toHaveBeenCalledOnce();
+    expect(store.clear).toHaveBeenCalledOnce();
+    expect(store.set).toHaveBeenCalledOnce();
+  });
+
+  it("runs operations directly after the schema is ready", async () => {
+    const store = createMemoryStore({ [INDEXED_DB_SCHEMA_KEY]: 2 });
+    const gate = createIndexedDbSchemaGate(2, store);
+    await gate.ensure();
+    let operationStarted = false;
+
+    const operation = gate.run(() => {
+      operationStarted = true;
+      return Promise.resolve("done");
+    });
+
+    expect(operationStarted).toBe(true);
+    await expect(operation).resolves.toBe("done");
+  });
+});


### PR DESCRIPTION
## Summary
- add one global IndexedDB schema version shared by every app persistence adapter
- clear the complete idb-keyval database before hydration when the version is missing or mismatched
- preserve matching-version data and use a synchronous fast path after the one-time schema check

## Root cause
The bookmark release added required content descriptor fields to persisted feed items without invalidating version 1 browser cache data. Long-lived clients could hydrate legacy items without contentType, causing the nativeOpening client exception before fresh server data arrived.

## Validation
- pnpm test:unit --reporter=dot — 62 files, 387 tests passed
- pnpm test:unit tests/unit/data/indexed-db-schema.test.ts tests/unit/data/normalized-idb-storage.test.ts --reporter=dot — 8 tests passed on the final branch
- pnpm typecheck
- pnpm format
- pnpm lint — zero errors, 29 pre-existing warnings
- pnpm build:atomic
- pnpm benchmark:inventory:check — 590 accesses checked
- pnpm benchmark:client:coverage:check — 341 files checked
- pnpm benchmark:client:gate — small, representative, and stress profiles passed
- pnpx react-doctor --verbose --scope changed — 100/100, no issues

## Performance impact
Every page load adds one schema-key IndexedDB read. Only a missing or changed version adds a one-time database clear, version write, and server rehydration. After initialization, reads and writes enter their existing IndexedDB operation synchronously with no repeated schema lookup or extra promise hop.

The small client smoke profile measured normalized persistence mutation at 0.134 ms and 11,058 bytes against the 524,288-byte budget. The stress gate measured 11.252 ms and passed.