### PR TITLE
Remove loopback access from extension store builds

### DIFF
--- a/.github/scripts/extensions/collect-store-packages.sh
+++ b/.github/scripts/extensions/collect-store-packages.sh
@@ -45,6 +45,24 @@ for browser in chrome firefox; do
     echo "$browser store package contains the development-only manifest key" >&2
     exit 1
   fi
+
+  if jq -e \
+    '[.host_permissions[]?, .permissions[]?] | any(test("^https?://"))' \
+    <<< "$manifest" >/dev/null; then
+    echo "$browser store package contains required host access" >&2
+    exit 1
+  fi
+
+  optional_origins="$(
+    jq -c '.optional_host_permissions // .optional_permissions // []' \
+      <<< "$manifest"
+  )"
+  if [[ "$optional_origins" != '["https://*/*"]' ]]; then
+    echo \
+      "$browser store package must request only optional HTTPS host access" \
+      >&2
+    exit 1
+  fi
 done
 
 required_source_paths=(

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -68,9 +68,10 @@ save:
 - `identity` completes the approved connection to a Serial instance.
 - `storage` keeps the selected instance and its opaque extension session token
   in the browser.
-- Optional host access is requested for the selected HTTPS Serial instance, or
-  for a loopback HTTP instance during local development. Signing out removes
-  that host access.
+- Optional host access is requested for the selected HTTPS Serial instance.
+  Development builds additionally allow loopback HTTP instances; production
+  and store builds omit those permissions and reject loopback instance
+  addresses. Signing out removes the selected instance's host access.
 
 The Firefox manifest declares `authenticationInfo`, `browsingActivity`,
 `websiteActivity`, and `websiteContent` because signing in and opening the popup

--- a/apps/extension/entrypoints/bookmark-capture.content.ts
+++ b/apps/extension/entrypoints/bookmark-capture.content.ts
@@ -1,7 +1,6 @@
 import { extractPageObservation } from "@serial/bookmark-capture/extract";
 
 export default defineContentScript({
-  matches: ["http://*/*", "https://*/*"],
   registration: "runtime",
   main() {
     return extractPageObservation(document);

--- a/apps/extension/lib/auth.test.ts
+++ b/apps/extension/lib/auth.test.ts
@@ -43,6 +43,18 @@ describe("normalizeInstanceUrl", () => {
     ).toThrowError("Serial instances must use HTTPS");
   });
 
+  it("rejects HTTP loopback instances in production", () => {
+    for (const instance of [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://[::1]:3000",
+    ]) {
+      expect(() =>
+        normalizeInstanceUrl(instance, { allowHttpLoopback: false }),
+      ).toThrowError("Serial instances must use HTTPS");
+    }
+  });
+
   it("rejects embedded credentials", () => {
     expect(() =>
       normalizeInstanceUrl("https://user:secret@serial.example.com"),

--- a/apps/extension/lib/auth.ts
+++ b/apps/extension/lib/auth.ts
@@ -158,7 +158,16 @@ export function parseStoredAuthSession(
   };
 }
 
-export function normalizeInstanceUrl(value: string): string {
+type NormalizeInstanceUrlOptions = {
+  allowHttpLoopback?: boolean;
+};
+
+export function normalizeInstanceUrl(
+  value: string,
+  {
+    allowHttpLoopback = import.meta.env.MODE !== "production",
+  }: NormalizeInstanceUrlOptions = {},
+): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Enter a Serial instance address");
 
@@ -176,7 +185,10 @@ export function normalizeInstanceUrl(value: string): string {
     throw new Error("Instance addresses cannot contain credentials");
   }
   const isLocal = isLoopbackHostname(url.hostname);
-  if (url.protocol !== "https:" && !(isLocal && url.protocol === "http:")) {
+  if (
+    url.protocol !== "https:" &&
+    !(allowHttpLoopback && isLocal && url.protocol === "http:")
+  ) {
     throw new Error("Serial instances must use HTTPS");
   }
   return url.origin;

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
   "name": "@serial/extension",
   "description": "A companion extension for Serial, a calm and customizable feed reader.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -9,6 +9,13 @@ import {
 const startUrl = process.env.SERIAL_EXTENSION_START_URL;
 const releaseVersion = process.env.SERIAL_EXTENSION_VERSION;
 const isStoreBuild = process.env.SERIAL_EXTENSION_STORE_BUILD === "true";
+const productionInstanceOrigins = ["https://*/*"];
+const developmentInstanceOrigins = [
+  ...productionInstanceOrigins,
+  "http://localhost/*",
+  "http://127.0.0.1/*",
+  "http://[::1]/*",
+];
 const extensionIcons = {
   16: "icon/16.png",
   32: "icon/32.png",
@@ -54,49 +61,40 @@ export default defineConfig({
     plugins: [tailwindcss()],
   }),
   webExt: startUrl ? { startUrls: [startUrl] } : undefined,
-  manifest: ({ manifestVersion }) => ({
-    name: "Serial",
-    ...(releaseVersion ? { version: releaseVersion } : {}),
-    ...(!isStoreBuild ? { key: CHROME_EXTENSION_MANIFEST_KEY } : {}),
-    icons: extensionIcons,
-    ...(manifestVersion === 2
-      ? { browser_action: { default_icon: extensionIcons } }
-      : { action: { default_icon: extensionIcons } }),
-    permissions: ["identity", "storage", "activeTab", "scripting"],
-    optional_permissions:
-      manifestVersion === 2
-        ? [
-            "https://*/*",
-            "http://localhost/*",
-            "http://127.0.0.1/*",
-            "http://[::1]/*",
-          ]
-        : undefined,
-    optional_host_permissions:
-      manifestVersion === 3
-        ? [
-            "https://*/*",
-            "http://localhost/*",
-            "http://127.0.0.1/*",
-            "http://[::1]/*",
-          ]
-        : undefined,
-    browser_specific_settings: {
-      gecko: {
-        id: FIREFOX_EXTENSION_ID,
-        strict_min_version: "140.0",
-        data_collection_permissions: {
-          required: [
-            "authenticationInfo",
-            "browsingActivity",
-            "websiteActivity",
-            "websiteContent",
-          ],
+  manifest: ({ manifestVersion, mode }) => {
+    const instanceOrigins =
+      mode === "production"
+        ? productionInstanceOrigins
+        : developmentInstanceOrigins;
+    return {
+      name: "Serial",
+      ...(releaseVersion ? { version: releaseVersion } : {}),
+      ...(!isStoreBuild ? { key: CHROME_EXTENSION_MANIFEST_KEY } : {}),
+      icons: extensionIcons,
+      ...(manifestVersion === 2
+        ? { browser_action: { default_icon: extensionIcons } }
+        : { action: { default_icon: extensionIcons } }),
+      permissions: ["identity", "storage", "activeTab", "scripting"],
+      optional_permissions: manifestVersion === 2 ? instanceOrigins : undefined,
+      optional_host_permissions:
+        manifestVersion === 3 ? instanceOrigins : undefined,
+      browser_specific_settings: {
+        gecko: {
+          id: FIREFOX_EXTENSION_ID,
+          strict_min_version: "140.0",
+          data_collection_permissions: {
+            required: [
+              "authenticationInfo",
+              "browsingActivity",
+              "websiteActivity",
+              "websiteContent",
+            ],
+          },
+        },
+        gecko_android: {
+          strict_min_version: "142.0",
         },
       },
-      gecko_android: {
-        strict_min_version: "142.0",
-      },
-    },
-  }),
+    };
+  },
 });


### PR DESCRIPTION
## Summary

- omit HTTP loopback origins from production and Store manifests while retaining them in development builds
- reject loopback instance URLs at runtime in production
- rely on activeTab injection instead of WXT-generated required all-site host access
- make Store package collection reject required host access or any optional origins beyond HTTPS
- record 0.1.1 as the corrected manual Firefox bootstrap version; synchronized CI releases retain the existing higher calendar-version scheme

This is stacked on #283 because that branch owns the keyless Chrome and Firefox Store packaging workflow.

## Validation

- pnpm --filter @serial/extension test:unit — 57 passed
- pnpm --filter @serial/extension typecheck
- pnpm --filter @serial/extension lint
- pnpm --filter @serial/extension format
- pnpm --filter @serial/extension zip:stores
- pnpm --filter @serial/extension lint:firefox — passed with five reviewed third-party warnings
- .github/scripts/extensions/test-extension-deployment.sh
- collect-store-packages.sh accepted the rebuilt 0.1.1 Chrome, Firefox, and Firefox-source packages
- inspected the Chrome ZIP manifest: no key, no required host_permissions, optional_host_permissions contains only https://*/*
- development Chrome manifest retains the three loopback origins
- manual Chrome install confirmed the host-permission prompt is gone

## Performance impact

No hot path changes. The runtime change adds one build-time-folded boolean check only when parsing a Serial instance URL; page capture and rendering are unchanged. No performance benchmark is applicable.