### PR TITLE
Stretch extension popup height

### DIFF
--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
@@ -91,11 +91,12 @@ describe("extension Bookmark editor sizing", () => {
 
     expect(markup).toContain('data-slot="extension-bookmark-editor-viewport"');
     expect(markup).toContain(
-      "h-full min-w-0 overflow-x-hidden overflow-y-auto",
+      "min-h-[380px] max-h-[570px] min-w-0 overflow-x-hidden overflow-y-auto",
     );
     expect(markup).toContain(
-      "[&amp;&gt;[data-slot=bookmark-editor]]:min-h-full",
+      "[&amp;&gt;[data-slot=bookmark-editor]]:min-h-[380px]",
     );
+    expect(markup).not.toContain("min-h-full");
     expect(markup).not.toContain("max-w-");
   });
 });

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
@@ -26,7 +26,7 @@ export function BookmarkEditorPopupLayout({
   return (
     <main
       data-slot="extension-bookmark-editor-viewport"
-      className="h-full min-w-0 overflow-x-hidden overflow-y-auto [&>[data-slot=bookmark-editor]]:min-h-full"
+      className="min-h-[380px] max-h-[570px] min-w-0 overflow-x-hidden overflow-y-auto [&>[data-slot=bookmark-editor]]:min-h-[380px]"
     >
       {children}
     </main>

--- a/apps/extension/entrypoints/popup/PopupLayout.test.tsx
+++ b/apps/extension/entrypoints/popup/PopupLayout.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PopupLayout } from "./PopupLayout";
+
+describe("extension popup layout", () => {
+  it("stretches its middle content across the square minimum", () => {
+    const markup = renderToStaticMarkup(
+      <PopupLayout footer={<div>Footer</div>}>
+        <div>Content</div>
+      </PopupLayout>,
+    );
+
+    expect(markup).toContain("flex min-h-[380px] flex-col");
+    expect(markup).toContain("flex flex-1 flex-col");
+    expect(markup).toContain("sticky bottom-0");
+    expect(markup).not.toContain("min-h-full");
+  });
+});

--- a/apps/extension/entrypoints/popup/PopupLayout.tsx
+++ b/apps/extension/entrypoints/popup/PopupLayout.tsx
@@ -7,7 +7,7 @@ type PopupLayoutProps = {
 
 export function PopupLayout({ children, footer }: PopupLayoutProps) {
   return (
-    <main className="flex min-h-full flex-col">
+    <main className="flex min-h-[380px] flex-col">
       <div className="flex flex-1 flex-col px-5 pt-5">{children}</div>
       {footer && (
         <footer className="from-background sticky bottom-0 z-10 bg-gradient-to-t from-70% to-transparent px-5 pt-10 pb-5">

--- a/apps/extension/entrypoints/popup/style.css
+++ b/apps/extension/entrypoints/popup/style.css
@@ -8,7 +8,8 @@ html,
 body,
 #root {
   width: 380px;
-  height: 380px;
+  min-height: 380px;
+  max-height: 570px;
 }
 
 body {

--- a/apps/extension/entrypoints/popup/style.test.ts
+++ b/apps/extension/entrypoints/popup/style.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const popupStyles = readFileSync(
+  new URL("./style.css", import.meta.url),
+  "utf8",
+);
+
+describe("extension popup sizing", () => {
+  it("grows from a square to one and a half times its width", () => {
+    expect(popupStyles).toContain("width: 380px;");
+    expect(popupStyles).toContain("min-height: 380px;");
+    expect(popupStyles).toContain("max-height: 570px;");
+    expect(popupStyles).not.toMatch(/^\s*height: 380px;/m);
+  });
+
+  it("keeps overflow inside the popup at its maximum height", () => {
+    expect(popupStyles).toContain("overflow-y: auto;");
+    expect(popupStyles).toContain("overflow-x: hidden;");
+  });
+});


### PR DESCRIPTION
- Let every extension popup state grow from 380px to 570px with its content.
- Keep overflow beyond the height cap vertically scrollable inside the popup.
- Stretch generic and Bookmark editor layout shells across the 380px square minimum so their flexible middle regions keep sticky footers bottom-aligned.
- Add regression coverage for global sizing, overflow, and both sticky-footer layouts.
- Validation: extension format, 59 unit tests, lint, typecheck, and production build passed.
- Performance: no runtime logic or DOM additions; generated utility CSS adds 74 bytes.
- Headless QA: both short-content shells and footer bottoms aligned at 380px, while the Bookmark viewport retained its 570px cap.