### PR TITLE
Prevent extension startup view flash

### DIFF
--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useReducer, useRef, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import {
   Alert,
   AlertDescription,
@@ -31,6 +37,7 @@ import type {
   ExtensionAuthSession,
 } from "../../lib/auth";
 import { ExtensionHeader } from "./ExtensionHeader";
+import { ExtensionLoadingView } from "./ExtensionLoadingView";
 import { PopupLayout } from "./PopupLayout";
 import { BookmarkWorkspaceView } from "./BookmarkWorkspaceView";
 
@@ -297,7 +304,7 @@ function App() {
   const [action, setAction] = useState<"connect" | "disconnect" | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     applySerialTheme(session);
   }, [session]);
 
@@ -425,13 +432,7 @@ function App() {
   }
 
   if (loading) {
-    return (
-      <PopupLayout>
-        <div className="grid flex-1 place-items-center">
-          <Loader2 className="text-muted-foreground size-5 animate-spin" />
-        </div>
-      </PopupLayout>
-    );
+    return <ExtensionLoadingView />;
   }
 
   if (session) {

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
@@ -14,6 +14,7 @@ import { Check, Info, Loader2, LogOut, Plus, Rss } from "lucide-react";
 import type { ExtensionAuthSession } from "../../lib/auth";
 import type { BookmarkWorkspace } from "../../lib/bookmarks";
 import { ExtensionHeader } from "./ExtensionHeader";
+import { ExtensionLoadingView } from "./ExtensionLoadingView";
 import { PopupLayout } from "./PopupLayout";
 import { useBookmarkWorkspace } from "./useBookmarkWorkspace";
 import type { FeedDiscoveryStatus } from "./useBookmarkWorkspace";
@@ -138,6 +139,11 @@ export function BookmarkWorkspaceView({
   onAuthExpired: () => void;
 }) {
   const controller = useBookmarkWorkspace({ session, onAuthExpired });
+
+  if (controller.status === "loading") {
+    return <ExtensionLoadingView />;
+  }
+
   const signOutButton = (
     <Button
       type="button"
@@ -226,15 +232,6 @@ export function BookmarkWorkspaceView({
             <Check className="size-4" />
             Signed in
           </div>
-        </div>
-      )}
-
-      {controller.status === "loading" && (
-        <div
-          className="text-muted-foreground mt-8 flex items-center gap-2 text-sm"
-          role="status"
-        >
-          <Loader2 className="size-4 animate-spin" /> Preparing Bookmark…
         </div>
       )}
 

--- a/apps/extension/entrypoints/popup/ExtensionLoadingView.test.tsx
+++ b/apps/extension/entrypoints/popup/ExtensionLoadingView.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import App from "./App";
+import { BookmarkWorkspaceView } from "./BookmarkWorkspaceView";
+import type { ExtensionAuthSession } from "../../lib/auth";
+
+const session: ExtensionAuthSession = {
+  version: 2,
+  instance: "https://serial.example",
+  token: "serial_ext_test",
+  expiresAt: Date.now() + 60_000,
+  user: { id: "user-one", name: "User" },
+};
+
+function expectCenteredLoadingView(markup: string) {
+  expect(markup).toContain('role="status"');
+  expect(markup).toContain('aria-label="Loading"');
+  expect(markup).toContain("grid min-h-[380px] place-items-center");
+  expect(markup).toContain("lucide-loader-circle");
+  expect(markup).toContain("animate-spin");
+  expect(markup).not.toContain("Serial");
+  expect(markup).not.toContain("Bookmark");
+  expect(markup).not.toContain("footer");
+}
+
+describe("extension unresolved startup view", () => {
+  it("shows only a centered product spinner during session lookup", () => {
+    expectCenteredLoadingView(renderToStaticMarkup(<App />));
+  });
+
+  it("keeps the same blank loading view during page classification", () => {
+    expectCenteredLoadingView(
+      renderToStaticMarkup(
+        <BookmarkWorkspaceView
+          session={session}
+          signingOut={false}
+          externalError={null}
+          onSignOut={() => undefined}
+          onAuthExpired={() => undefined}
+        />,
+      ),
+    );
+  });
+});

--- a/apps/extension/entrypoints/popup/ExtensionLoadingView.tsx
+++ b/apps/extension/entrypoints/popup/ExtensionLoadingView.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from "lucide-react";
+
+export function ExtensionLoadingView() {
+  return (
+    <main
+      className="grid min-h-[380px] place-items-center"
+      role="status"
+      aria-label="Loading"
+    >
+      <Loader2 className="text-muted-foreground size-5 animate-spin" />
+    </main>
+  );
+}


### PR DESCRIPTION
- Show only the centered product spinner while session lookup or page classification is unresolved
- Apply the signed-in user theme before the authenticated startup view paints
- Cover both unresolved phases with focused no-speculative-UI regression tests