### PR TITLE
Fix E2E process leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
           echo "$HOME/.turso" >> "$GITHUB_PATH"
 
       - name: Run app E2E tests
-        run: pnpm --filter @serial/app test:e2e
+        run: |
+          pnpm --filter @serial/app test:e2e
+          pnpm --filter @serial/app test:e2e:cleanup
 
   gate:
     if: always()

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -52,6 +52,7 @@
     "test:e2e:self-hosted-bootstrap": "SERIAL_CLIENT_PERFORMANCE_PRODUCTION=1 node --import=tsx scripts/run-e2e.ts self-hosted --project self-hosted-bootstrap",
     "test:e2e:self-hosted:dev": "node --import=tsx scripts/run-e2e.ts self-hosted",
     "test:e2e:self-hosted:ui": "node --import=tsx scripts/run-e2e.ts self-hosted --ui",
+    "test:e2e:cleanup": "node --import=tsx scripts/test-e2e-cleanup.ts",
     "test:e2e:demo": "node --import=tsx scripts/run-e2e.ts demo",
     "test:e2e:demo:ui": "node --import=tsx scripts/run-e2e.ts demo --ui",
     "benchmark:app": "node --expose-gc --import=tsx scripts/performance/run-app-benchmark.ts",

--- a/apps/app/playwright.demo.config.ts
+++ b/apps/app/playwright.demo.config.ts
@@ -4,6 +4,7 @@ import {
   DEMO_APP_PORT,
   DEMO_RSS_SERVER_PORT,
 } from "./tests/e2e/fixtures/ports";
+import { supervisedWebServerCommand } from "./tests/e2e/fixtures/web-server-command";
 
 export default defineConfig({
   ...baseConfig,
@@ -14,13 +15,15 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "pnpm dev:test:demo",
+      command: supervisedWebServerCommand("pnpm dev:test:demo"),
       url: `http://127.0.0.1:${DEMO_APP_PORT}/api/health`,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
     {
-      command: `node --import=tsx tests/e2e/fixtures/rss-server.ts ${DEMO_RSS_SERVER_PORT}`,
+      command: supervisedWebServerCommand(
+        `node --import=tsx tests/e2e/fixtures/rss-server.ts ${DEMO_RSS_SERVER_PORT}`,
+      ),
       url: `http://127.0.0.1:${DEMO_RSS_SERVER_PORT}`,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,

--- a/apps/app/playwright.main-instance.config.ts
+++ b/apps/app/playwright.main-instance.config.ts
@@ -4,6 +4,7 @@ import {
   MAIN_APP_PORT,
   MAIN_RSS_SERVER_PORT,
 } from "./tests/e2e/fixtures/ports";
+import { supervisedWebServerCommand } from "./tests/e2e/fixtures/web-server-command";
 
 export default defineConfig({
   ...baseConfig,
@@ -15,12 +16,14 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "pnpm dev:test:main",
+      command: supervisedWebServerCommand("pnpm dev:test:main"),
       url: `http://localhost:${MAIN_APP_PORT}`,
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `node --import=tsx tests/e2e/fixtures/rss-server.ts ${MAIN_RSS_SERVER_PORT}`,
+      command: supervisedWebServerCommand(
+        `node --import=tsx tests/e2e/fixtures/rss-server.ts ${MAIN_RSS_SERVER_PORT}`,
+      ),
       url: `http://127.0.0.1:${MAIN_RSS_SERVER_PORT}`,
       reuseExistingServer: !process.env.CI,
     },

--- a/apps/app/playwright.self-hosted.config.ts
+++ b/apps/app/playwright.self-hosted.config.ts
@@ -7,18 +7,19 @@ import {
   SELF_HOSTED_RSS_SERVER_PORT,
   SELF_HOSTED_TURSO_PORT,
 } from "./tests/e2e/fixtures/ports";
+import { supervisedWebServerCommand } from "./tests/e2e/fixtures/web-server-command";
 
 const productionTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +
   `"turso dev --db-file serial-test-self-hosted.db --port ${SELF_HOSTED_TURSO_PORT}" ` +
   `"./node_modules/.bin/dotenv -e .env.test.self-hosted -- node --import tsx src/server/db/migrate.ts && ` +
-  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- ./node_modules/.bin/vite preview --port ${SELF_HOSTED_APP_PORT} --strictPort"`;
+  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 ./node_modules/.bin/vite preview --port ${SELF_HOSTED_APP_PORT} --strictPort"`;
 
 const bootstrapProductionTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +
   `"turso dev --db-file serial-test-self-hosted-bootstrap.db --port ${SELF_HOSTED_BOOTSTRAP_TURSO_PORT}" ` +
   `"./node_modules/.bin/dotenv -e .env.test.self-hosted -- node --import tsx src/server/db/migrate.ts && ` +
-  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- ./node_modules/.bin/vite preview --port ${SELF_HOSTED_BOOTSTRAP_APP_PORT} --strictPort"`;
+  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 ./node_modules/.bin/vite preview --port ${SELF_HOSTED_BOOTSTRAP_APP_PORT} --strictPort"`;
 
 const bootstrapDevelopmentTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +
@@ -37,7 +38,10 @@ const bootstrapEnvironment = {
 export default defineConfig({
   ...baseConfig,
   workers: process.env.CI ? 2 : undefined,
-  globalSetup: "./tests/global-setup.self-hosted.ts",
+  globalSetup:
+    process.env.SERIAL_E2E_CLEANUP_PROBE === "1"
+      ? "./tests/global-setup.e2e-cleanup.ts"
+      : "./tests/global-setup.self-hosted.ts",
   testDir: "./tests/e2e",
   projects: [
     {
@@ -64,10 +68,11 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command:
+      command: supervisedWebServerCommand(
         process.env.SERIAL_CLIENT_PERFORMANCE_PRODUCTION === "1"
           ? productionTestServer
           : "pnpm dev:test:self-hosted",
+      ),
       url: `http://localhost:${SELF_HOSTED_APP_PORT}`,
       stdout: "pipe",
       timeout: 120_000,
@@ -76,10 +81,11 @@ export default defineConfig({
         !process.env.CI,
     },
     {
-      command:
+      command: supervisedWebServerCommand(
         process.env.SERIAL_CLIENT_PERFORMANCE_PRODUCTION === "1"
           ? bootstrapProductionTestServer
           : bootstrapDevelopmentTestServer,
+      ),
       env: bootstrapEnvironment,
       url: `${bootstrapBaseUrl}/api/health`,
       stdout: "pipe",
@@ -87,7 +93,9 @@ export default defineConfig({
       reuseExistingServer: false,
     },
     {
-      command: `node --import=tsx tests/e2e/fixtures/rss-server.ts ${SELF_HOSTED_RSS_SERVER_PORT}`,
+      command: supervisedWebServerCommand(
+        `node --import=tsx tests/e2e/fixtures/rss-server.ts ${SELF_HOSTED_RSS_SERVER_PORT}`,
+      ),
       url: `http://127.0.0.1:${SELF_HOSTED_RSS_SERVER_PORT}`,
       reuseExistingServer: !process.env.CI,
     },

--- a/apps/app/scripts/run-e2e.ts
+++ b/apps/app/scripts/run-e2e.ts
@@ -1,4 +1,5 @@
 import { randomInt } from "node:crypto";
+import { existsSync } from "node:fs";
 import net from "node:net";
 import { spawn, spawnSync } from "node:child_process";
 
@@ -122,43 +123,104 @@ const childEnvironment = {
   PORT: String(appPort),
 };
 
-console.log(
-  `${environmentName} test ports: app=${appPort}, db=${tursoPort}, rss=${rssPort}`,
-);
+const allocatedPortEnvironment = {
+  [environment.appPortVariable]: appPort,
+  [environment.tursoPortVariable]: tursoPort,
+  [environment.rssPortVariable]: rssPort,
+  ...Object.fromEntries(
+    additionalPortVariables.map((variable, index) => [
+      variable,
+      additionalPorts[index],
+    ]),
+  ),
+};
+
+console.log(`SERIAL_E2E_PORTS=${JSON.stringify(allocatedPortEnvironment)}`);
 
 if (process.env.SERIAL_CLIENT_PERFORMANCE_PRODUCTION === "1") {
-  const build = spawnSync("pnpm", ["build:atomic"], {
-    env: childEnvironment,
-    stdio: "inherit",
-  });
-  if (build.signal) {
-    process.kill(process.pid, build.signal);
-  }
-  if (build.status !== 0) {
-    process.exit(build.status ?? 1);
+  if (process.env.SERIAL_E2E_REUSE_BUILD === "1") {
+    if (!existsSync(".output/server/index.mjs")) {
+      console.error(
+        "SERIAL_E2E_REUSE_BUILD=1 requires an existing production build.",
+      );
+      process.exit(1);
+    }
+  } else {
+    const build = spawnSync("pnpm", ["build:atomic"], {
+      env: childEnvironment,
+      stdio: "inherit",
+    });
+    if (build.signal) {
+      process.kill(process.pid, build.signal);
+    }
+    if (build.status !== 0) {
+      process.exit(build.status ?? 1);
+    }
   }
 }
 
-const playwright = spawn(
-  "pnpm",
+let supervisorReady = false;
+let pendingSignal: NodeJS.Signals | undefined;
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+const signalHandlers = new Map<NodeJS.Signals, () => void>();
+
+const supervisor = spawn(
+  process.execPath,
   [
-    "exec",
-    "playwright",
-    "test",
-    "--config",
+    "--import=tsx",
+    "scripts/supervise-e2e.ts",
+    String(process.pid),
     environment.config,
     ...playwrightArguments,
   ],
   {
     env: childEnvironment,
-    stdio: "inherit",
+    stdio: ["inherit", "inherit", "inherit", "ipc"],
   },
 );
 
-playwright.once("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
+for (const signal of forwardedSignals) {
+  const handler = () => {
+    pendingSignal ??= signal;
+    if (!supervisorReady) return;
+    try {
+      supervisor.kill(signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  };
+  signalHandlers.set(signal, handler);
+  process.on(signal, handler);
+}
+
+supervisor.on("message", (message: unknown) => {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("type" in message) ||
+    message.type !== "ready"
+  ) {
     return;
   }
-  process.exitCode = code ?? 1;
+  supervisorReady = true;
+  if (pendingSignal) {
+    try {
+      supervisor.kill(pendingSignal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  }
+});
+
+supervisor.once("exit", (code, signal) => {
+  for (const [forwardedSignal, handler] of signalHandlers) {
+    process.off(forwardedSignal, handler);
+  }
+
+  const exitSignal = signal ?? pendingSignal;
+  if (exitSignal) {
+    process.kill(process.pid, exitSignal);
+  } else {
+    process.exitCode = code ?? 1;
+  }
 });

--- a/apps/app/scripts/supervise-e2e.ts
+++ b/apps/app/scripts/supervise-e2e.ts
@@ -1,0 +1,256 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  E2E_SERVER_PROCESS_GROUP_FILE,
+  E2E_SERVER_PROCESS_GROUP_MARKER,
+} from "../tests/e2e/fixtures/web-server-command";
+
+const GRACEFUL_SHUTDOWN_MS = 5_000;
+const FORCED_SHUTDOWN_MS = 2_000;
+const PROCESS_POLL_MS = 50;
+const PARENT_POLL_MS = 100;
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
+type ChildExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+type ShutdownReason =
+  | { type: "child-exit"; exit: ChildExit }
+  | { type: "signal"; signal: NodeJS.Signals }
+  | { type: "parent-death" };
+
+function delay(milliseconds: number) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isMissingProcess(error: unknown) {
+  return (error as NodeJS.ErrnoException).code === "ESRCH";
+}
+
+function isProcessGroupAlive(processGroupId: number) {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if (isMissingProcess(error)) return false;
+    throw error;
+  }
+}
+
+function signalProcessGroup(processGroupId: number, signal: NodeJS.Signals) {
+  try {
+    process.kill(-processGroupId, signal);
+  } catch (error) {
+    if (!isMissingProcess(error)) throw error;
+  }
+}
+
+const [launcherPidArgument, config, ...playwrightArguments] =
+  process.argv.slice(2);
+const launcherPid = Number(launcherPidArgument);
+if (!Number.isInteger(launcherPid) || launcherPid <= 0 || !config) {
+  console.error(
+    "Usage: supervise-e2e.ts <launcher pid> <playwright config> [...playwright args]",
+  );
+  process.exit(1);
+}
+
+if (process.platform === "win32") {
+  console.error("The E2E process supervisor requires POSIX process groups.");
+  process.exit(1);
+}
+
+if (process.ppid !== launcherPid) {
+  process.exit(1);
+}
+
+const processGroupDirectory = mkdtempSync(
+  join(tmpdir(), "serial-e2e-process-groups-"),
+);
+const processGroupFile = join(processGroupDirectory, "groups");
+const playwright = spawn(
+  "pnpm",
+  ["exec", "playwright", "test", "--config", config, ...playwrightArguments],
+  {
+    detached: true,
+    env: {
+      ...process.env,
+      [E2E_SERVER_PROCESS_GROUP_FILE]: processGroupFile,
+    },
+    stdio: "inherit",
+  },
+);
+const spawnedProcessId = playwright.pid;
+if (spawnedProcessId === undefined) {
+  throw new Error("Failed to start the Playwright process group.");
+}
+const processGroupId: number = spawnedProcessId;
+
+console.log(`SERIAL_E2E_PROCESS_GROUP=${processGroupId}`);
+
+const trackedProcessGroups = new Set([processGroupId]);
+let activeShutdownSignal: NodeJS.Signals | undefined;
+
+function readRegisteredProcessGroups() {
+  let contents = "";
+  try {
+    contents = readFileSync(processGroupFile, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  for (const value of contents.split("\n")) {
+    const registeredProcessGroup = Number(value);
+    if (
+      !Number.isInteger(registeredProcessGroup) ||
+      registeredProcessGroup <= 0 ||
+      trackedProcessGroups.has(registeredProcessGroup)
+    ) {
+      continue;
+    }
+    trackedProcessGroups.add(registeredProcessGroup);
+    console.log(`${E2E_SERVER_PROCESS_GROUP_MARKER}=${registeredProcessGroup}`);
+    if (activeShutdownSignal) {
+      signalProcessGroup(registeredProcessGroup, activeShutdownSignal);
+    }
+  }
+}
+
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code !== "EPIPE") throw error;
+  });
+}
+
+let resolveChildExit!: (exit: ChildExit) => void;
+const childExit = new Promise<ChildExit>((resolve) => {
+  resolveChildExit = resolve;
+});
+playwright.once("exit", (code, signal) => resolveChildExit({ code, signal }));
+
+let shutdownPromise: Promise<void> | undefined;
+const signalHandlers = new Map<NodeJS.Signals, () => void>();
+
+const parentWatch = setInterval(() => {
+  if (process.ppid !== launcherPid) {
+    void startShutdown({ type: "parent-death" });
+  }
+}, PARENT_POLL_MS);
+const processGroupWatch = setInterval(
+  readRegisteredProcessGroups,
+  PROCESS_POLL_MS,
+);
+
+process.once("disconnect", () => {
+  void startShutdown({ type: "parent-death" });
+});
+
+function signalTrackedProcessGroups(signal: NodeJS.Signals) {
+  for (const trackedProcessGroup of trackedProcessGroups) {
+    signalProcessGroup(trackedProcessGroup, signal);
+  }
+}
+
+async function waitForTrackedProcessGroupsExit(timeoutMilliseconds: number) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (Date.now() < deadline) {
+    readRegisteredProcessGroups();
+    if (
+      [...trackedProcessGroups].every(
+        (trackedProcessGroup) => !isProcessGroupAlive(trackedProcessGroup),
+      )
+    ) {
+      return true;
+    }
+    await delay(PROCESS_POLL_MS);
+  }
+  return [...trackedProcessGroups].every(
+    (trackedProcessGroup) => !isProcessGroupAlive(trackedProcessGroup),
+  );
+}
+
+async function cleanProcessGroups(initialSignal: NodeJS.Signals) {
+  activeShutdownSignal = initialSignal;
+  readRegisteredProcessGroups();
+  signalTrackedProcessGroups(initialSignal);
+  if (await waitForTrackedProcessGroupsExit(GRACEFUL_SHUTDOWN_MS)) {
+    return true;
+  }
+
+  console.error(
+    `E2E process groups did not exit after ${initialSignal}; forcing shutdown.`,
+  );
+  activeShutdownSignal = "SIGKILL";
+  signalTrackedProcessGroups("SIGKILL");
+  return waitForTrackedProcessGroupsExit(FORCED_SHUTDOWN_MS);
+}
+
+function removeLifecycleHandlers() {
+  clearInterval(parentWatch);
+  clearInterval(processGroupWatch);
+  rmSync(processGroupDirectory, { force: true, recursive: true });
+  if (process.connected) process.disconnect?.();
+  for (const [signal, handler] of signalHandlers) {
+    process.off(signal, handler);
+  }
+}
+
+function finishWithSignal(signal: NodeJS.Signals) {
+  removeLifecycleHandlers();
+  process.kill(process.pid, signal);
+}
+
+async function performShutdown(reason: ShutdownReason) {
+  const initialSignal = reason.type === "signal" ? reason.signal : "SIGTERM";
+  const groupExited = await cleanProcessGroups(initialSignal);
+  await Promise.race([childExit, delay(FORCED_SHUTDOWN_MS)]);
+
+  if (!groupExited) {
+    console.error("One or more E2E process groups survived SIGKILL.");
+    removeLifecycleHandlers();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (reason.type === "signal") {
+    finishWithSignal(reason.signal);
+    return;
+  }
+
+  if (reason.type === "parent-death") {
+    removeLifecycleHandlers();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (reason.exit.signal) {
+    finishWithSignal(reason.exit.signal);
+  } else {
+    removeLifecycleHandlers();
+    process.exitCode = reason.exit.code ?? 1;
+  }
+}
+
+function startShutdown(reason: ShutdownReason) {
+  shutdownPromise ??= performShutdown(reason).catch((error) => {
+    console.error(error);
+    removeLifecycleHandlers();
+    process.exitCode = 1;
+  });
+  return shutdownPromise;
+}
+
+for (const signal of forwardedSignals) {
+  const handler = () => void startShutdown({ type: "signal", signal });
+  signalHandlers.set(signal, handler);
+  process.on(signal, handler);
+}
+
+void childExit.then((exit) => startShutdown({ type: "child-exit", exit }));
+
+if (process.connected) {
+  process.send?.({ type: "ready" });
+}

--- a/apps/app/scripts/test-e2e-cleanup.ts
+++ b/apps/app/scripts/test-e2e-cleanup.ts
@@ -1,0 +1,290 @@
+import { spawn, spawnSync } from "node:child_process";
+import net from "node:net";
+
+const STARTUP_TIMEOUT_MS = 150_000;
+const CLEANUP_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 100;
+const REPETITIONS_PER_SIGNAL = 2;
+const expectedPortVariables = [
+  "SERIAL_TEST_SELF_HOSTED_APP_PORT",
+  "SERIAL_TEST_SELF_HOSTED_TURSO_PORT",
+  "SERIAL_TEST_SELF_HOSTED_RSS_PORT",
+  "SERIAL_TEST_SELF_HOSTED_BOOTSTRAP_APP_PORT",
+  "SERIAL_TEST_SELF_HOSTED_BOOTSTRAP_TURSO_PORT",
+] as const;
+
+type ProcessRow = {
+  pid: number;
+  parentPid: number;
+  processGroupId: number;
+  command: string;
+};
+
+type ExitResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+function delay(milliseconds: number) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function readProcessTable() {
+  const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,command="], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to inspect processes: ${result.stderr}`);
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((line): ProcessRow | undefined => {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+      if (!match) return undefined;
+      return {
+        pid: Number(match[1]),
+        parentPid: Number(match[2]),
+        processGroupId: Number(match[3]),
+        command: match[4] ?? "",
+      };
+    })
+    .filter((row): row is ProcessRow => row !== undefined);
+}
+
+function collectDescendants(processes: ProcessRow[], rootPid: number) {
+  const descendantPids = new Set([rootPid]);
+  let foundNewDescendant = true;
+  while (foundNewDescendant) {
+    foundNewDescendant = false;
+    for (const process of processes) {
+      if (
+        descendantPids.has(process.parentPid) &&
+        !descendantPids.has(process.pid)
+      ) {
+        descendantPids.add(process.pid);
+        foundNewDescendant = true;
+      }
+    }
+  }
+  descendantPids.delete(rootPid);
+  return processes.filter((process) => descendantPids.has(process.pid));
+}
+
+async function canBind(port: number, host: string) {
+  return new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.listen({ host, port, exclusive: true }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function arePortsAvailable(ports: number[]) {
+  const availability = await Promise.all(
+    ports.flatMap((port) => [canBind(port, "127.0.0.1"), canBind(port, "::1")]),
+  );
+  return availability.every(Boolean);
+}
+
+function parsePorts(output: string) {
+  const match = output.match(/^SERIAL_E2E_PORTS=(\{.+\})$/m);
+  if (!match?.[1]) return undefined;
+  const parsed = JSON.parse(match[1]) as Record<string, unknown>;
+  const ports = expectedPortVariables.map((variable) => parsed[variable]);
+  if (
+    ports.some(
+      (port) =>
+        typeof port !== "number" || !Number.isInteger(port) || port <= 0,
+    )
+  ) {
+    throw new Error(`Invalid E2E port report: ${match[1]}`);
+  }
+  return ports as number[];
+}
+
+function parseProcessGroupIds(output: string) {
+  return [
+    ...new Set(
+      [
+        ...output.matchAll(
+          /SERIAL_E2E_(?:PROCESS_GROUP|SERVER_PROCESS_GROUP)=(\d+)/g,
+        ),
+      ].map((match) => Number(match[1])),
+    ),
+  ];
+}
+
+async function waitForReady(
+  output: () => string,
+  launcher: ReturnType<typeof spawn>,
+) {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const currentOutput = output();
+    const ports = parsePorts(currentOutput);
+    const processGroupIds = parseProcessGroupIds(currentOutput);
+    if (
+      ports &&
+      processGroupIds.length >= 4 &&
+      currentOutput.includes("SERIAL_E2E_CLEANUP_READY")
+    ) {
+      return { ports, processGroupIds };
+    }
+    if (launcher.exitCode !== null || launcher.signalCode !== null) {
+      throw new Error(
+        `E2E launcher exited before the cleanup probe was ready.\n${currentOutput}`,
+      );
+    }
+    await delay(POLL_INTERVAL_MS);
+  }
+  throw new Error(`Timed out waiting for the E2E cleanup probe.\n${output()}`);
+}
+
+function assertExpectedServices(processes: ProcessRow[], ports: number[]) {
+  const processCommands = processes
+    .map((process) => process.command)
+    .join("\n");
+  const [appPort, tursoPort, rssPort, bootstrapAppPort, bootstrapTursoPort] =
+    ports;
+  const expectedFragments = [
+    `vite preview --port ${appPort}`,
+    `turso dev --db-file serial-test-self-hosted.db --port ${tursoPort}`,
+    `rss-server.ts ${rssPort}`,
+    `vite preview --port ${bootstrapAppPort}`,
+    `turso dev --db-file serial-test-self-hosted-bootstrap.db --port ${bootstrapTursoPort}`,
+  ];
+  const missingFragments = expectedFragments.filter(
+    (fragment) => !processCommands.includes(fragment),
+  );
+  if (missingFragments.length > 0) {
+    throw new Error(
+      `Cleanup probe did not start the expected services: ${missingFragments.join(", ")}\n${processCommands}`,
+    );
+  }
+}
+
+async function waitForCleanup(
+  observedProcesses: ProcessRow[],
+  processGroupIds: number[],
+  ports: number[],
+) {
+  const deadline = Date.now() + CLEANUP_TIMEOUT_MS;
+  let remainingObserved: ProcessRow[] = [];
+  let remainingGroup: ProcessRow[] = [];
+  let portsAvailable = false;
+
+  while (Date.now() < deadline) {
+    const processes = readProcessTable();
+    const currentByPid = new Map(
+      processes.map((process) => [process.pid, process]),
+    );
+    remainingObserved = observedProcesses.filter((observed) => {
+      const current = currentByPid.get(observed.pid);
+      return current?.command === observed.command;
+    });
+    remainingGroup = processes.filter((process) =>
+      processGroupIds.includes(process.processGroupId),
+    );
+    portsAvailable = await arePortsAvailable(ports);
+
+    if (
+      remainingObserved.length === 0 &&
+      remainingGroup.length === 0 &&
+      portsAvailable
+    ) {
+      return;
+    }
+    await delay(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    [
+      `E2E cleanup did not finish within ${CLEANUP_TIMEOUT_MS}ms.`,
+      `Remaining observed processes:\n${remainingObserved.map((process) => JSON.stringify(process)).join("\n") || "none"}`,
+      `Remaining process-group members:\n${remainingGroup.map((process) => JSON.stringify(process)).join("\n") || "none"}`,
+      `Ports available: ${portsAvailable}`,
+    ].join("\n"),
+  );
+}
+
+async function runCancellationCase(signal: "SIGTERM" | "SIGKILL", run: number) {
+  console.log(`E2E cleanup probe: ${signal} run ${run}`);
+  const launcher = spawn(
+    process.execPath,
+    ["--import=tsx", "scripts/run-e2e.ts", "self-hosted"],
+    {
+      env: {
+        ...process.env,
+        PLAYWRIGHT_HTML_OPEN: "never",
+        SERIAL_CLIENT_PERFORMANCE_PRODUCTION: "1",
+        SERIAL_E2E_CLEANUP_PROBE: "1",
+        SERIAL_E2E_REUSE_BUILD: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (!launcher.pid) throw new Error("Failed to start the E2E launcher.");
+
+  let combinedOutput = "";
+  launcher.stdout?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    combinedOutput += text;
+    process.stdout.write(text);
+  });
+  launcher.stderr?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    combinedOutput += text;
+    process.stderr.write(text);
+  });
+  const launcherExit = new Promise<ExitResult>((resolve) => {
+    launcher.once("exit", (code, exitSignal) =>
+      resolve({ code, signal: exitSignal }),
+    );
+  });
+
+  let cancellationSent = false;
+  try {
+    const { ports, processGroupIds } = await waitForReady(
+      () => combinedOutput,
+      launcher,
+    );
+    const processes = readProcessTable();
+    const observedProcesses = collectDescendants(processes, launcher.pid);
+    assertExpectedServices(observedProcesses, ports);
+
+    cancellationSent = launcher.kill(signal);
+    if (!cancellationSent) {
+      throw new Error(
+        `Failed to send ${signal} to E2E launcher ${launcher.pid}.`,
+      );
+    }
+
+    const exit = await launcherExit;
+    if (exit.signal !== signal) {
+      throw new Error(
+        `E2E launcher exited with code ${exit.code} and signal ${exit.signal}; expected ${signal}.`,
+      );
+    }
+    await waitForCleanup(observedProcesses, processGroupIds, ports);
+  } catch (error) {
+    if (!cancellationSent && launcher.exitCode === null) {
+      launcher.kill("SIGTERM");
+      await Promise.race([launcherExit, delay(CLEANUP_TIMEOUT_MS)]);
+    }
+    throw new Error(`${String(error)}\n${combinedOutput}`, { cause: error });
+  }
+}
+
+if (process.platform === "win32") {
+  throw new Error("The E2E cleanup regression requires POSIX process groups.");
+}
+
+for (let run = 1; run <= REPETITIONS_PER_SIGNAL; run += 1) {
+  await runCancellationCase("SIGTERM", run);
+  await runCancellationCase("SIGKILL", run);
+}
+
+console.log("E2E cleanup probes passed.");

--- a/apps/app/tests/e2e/fixtures/web-server-command.ts
+++ b/apps/app/tests/e2e/fixtures/web-server-command.ts
@@ -1,0 +1,11 @@
+export const E2E_SERVER_PROCESS_GROUP_MARKER =
+  "SERIAL_E2E_SERVER_PROCESS_GROUP";
+export const E2E_SERVER_PROCESS_GROUP_FILE =
+  "SERIAL_E2E_SERVER_PROCESS_GROUP_FILE";
+
+export function supervisedWebServerCommand(command: string) {
+  return (
+    `if [ -n "$${E2E_SERVER_PROCESS_GROUP_FILE}" ]; then ` +
+    `echo $$ >> "$${E2E_SERVER_PROCESS_GROUP_FILE}"; fi; exec ${command}`
+  );
+}

--- a/apps/app/tests/global-setup.e2e-cleanup.ts
+++ b/apps/app/tests/global-setup.e2e-cleanup.ts
@@ -1,0 +1,7 @@
+const PROBE_TIMEOUT_MS = 120_000;
+
+export default async function waitForCancellation() {
+  console.log("SERIAL_E2E_CLEANUP_READY");
+  await new Promise((resolve) => setTimeout(resolve, PROBE_TIMEOUT_MS));
+  throw new Error("E2E cleanup probe was not cancelled within two minutes.");
+}


### PR DESCRIPTION
- Own Playwright and web-server process-group cleanup across launcher exit paths
- Add real self-hosted cancellation coverage for graceful and abrupt termination
- Run preview servers non-interactively and enforce cleanup in CI