### PR TITLE
Refine extension unbookmarkable state

### DIFF
--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   BookmarkEditorPopupLayout,
   FeedDiscovery,
+  IneligiblePageNotice,
 } from "./BookmarkWorkspaceView";
 import type { BookmarkWorkspace } from "../../lib/bookmarks";
 
@@ -98,5 +99,17 @@ describe("extension Bookmark editor sizing", () => {
     );
     expect(markup).not.toContain("min-h-full");
     expect(markup).not.toContain("max-w-");
+  });
+});
+
+describe("extension ineligible-page notice", () => {
+  it("explains the rejected web-page URL without blaming browser pages", () => {
+    const markup = renderToStaticMarkup(createElement(IneligiblePageNotice));
+
+    expect(markup).toContain("This page can’t be bookmarked.");
+    expect(markup).toContain(
+      "Serial can’t bookmark pages whose address includes sign-in credentials.",
+    );
+    expect(markup).not.toContain("Open an HTTP(S) page");
   });
 });

--- a/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
+++ b/apps/extension/entrypoints/popup/BookmarkWorkspaceView.tsx
@@ -34,6 +34,17 @@ export function BookmarkEditorPopupLayout({
   );
 }
 
+export function IneligiblePageNotice() {
+  return (
+    <div className="mt-8">
+      <p className="text-sm font-medium">This page can’t be bookmarked.</p>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Serial can’t bookmark pages whose address includes sign-in credentials.
+      </p>
+    </div>
+  );
+}
+
 export function FeedDiscovery({
   workspace,
   pendingFeedUrls,
@@ -235,14 +246,7 @@ export function BookmarkWorkspaceView({
         </div>
       )}
 
-      {controller.status === "ineligible" && (
-        <div className="mt-8">
-          <p className="text-sm font-medium">This page can’t be bookmarked.</p>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Open an HTTP(S) page and try again.
-          </p>
-        </div>
-      )}
+      {controller.status === "ineligible" && <IneligiblePageNotice />}
 
       {(externalError || controller.error) && (
         <Alert variant="destructive" className="mt-5">

--- a/apps/extension/lib/background-bookmarks.test.ts
+++ b/apps/extension/lib/background-bookmarks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EXTENSION_FEED_ADD_REQUEST_TIMEOUT_MS } from "@serial/bookmark-capture";
 
 import {
@@ -47,6 +47,25 @@ function authenticatedDependencies(
   };
 }
 
+async function captureActiveTab(tab?: { id?: number; url?: string }) {
+  const fetchFromInstance = vi.fn();
+  const executeScript = vi.fn();
+  vi.stubGlobal("browser", {
+    tabs: { query: vi.fn(() => Promise.resolve(tab ? [tab] : [])) },
+    scripting: { executeScript },
+  });
+
+  const response = await handleBookmarkMessage(
+    { type: "bookmark.capture-active" },
+    authenticatedDependencies(fetchFromInstance),
+  );
+  return { executeScript, fetchFromInstance, response };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("extension Bookmark page eligibility", () => {
   it("treats every path on the connected Serial origin as the base extension", () => {
     expect(
@@ -70,6 +89,50 @@ describe("extension Bookmark page eligibility", () => {
         "http://localhost:3001",
       ),
     ).toBe(false);
+  });
+
+  it.each([
+    ["new-tab", "chrome://newtab/"],
+    ["settings", "about:preferences"],
+    ["extension", "moz-extension://serial/popup.html"],
+    ["local-file", "file:///Users/example/article.html"],
+  ])("uses the base extension for %s tabs", async (_name, url) => {
+    const result = await captureActiveTab({ id: 1, url });
+
+    expect(result.response).toEqual({ ok: true, status: "base" });
+    expect(result.executeScript).not.toHaveBeenCalled();
+    expect(result.fetchFromInstance).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing tab", undefined],
+    ["missing tab ID", { url: "https://example.com/article" }],
+    ["missing tab URL", { id: 1 }],
+  ])("uses the base extension for %s metadata", async (_name, tab) => {
+    const result = await captureActiveTab(tab);
+
+    expect(result.response).toEqual({ ok: true, status: "base" });
+    expect(result.executeScript).not.toHaveBeenCalled();
+    expect(result.fetchFromInstance).not.toHaveBeenCalled();
+  });
+
+  it("keeps credential-bearing web pages ineligible", async () => {
+    const result = await captureActiveTab({
+      id: 1,
+      url: "https://reader:secret@example.com/private",
+    });
+
+    expect(result.response).toEqual({ ok: true, status: "ineligible" });
+    expect(result.executeScript).not.toHaveBeenCalled();
+    expect(result.fetchFromInstance).not.toHaveBeenCalled();
+  });
+
+  it("keeps malformed web-page URLs ineligible", async () => {
+    const result = await captureActiveTab({ id: 1, url: "https://[invalid" });
+
+    expect(result.response).toEqual({ ok: true, status: "ineligible" });
+    expect(result.executeScript).not.toHaveBeenCalled();
+    expect(result.fetchFromInstance).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/extension/lib/background-bookmarks.ts
+++ b/apps/extension/lib/background-bookmarks.ts
@@ -30,17 +30,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function eligiblePageUrl(value: string | undefined) {
-  if (!value) return null;
+type ActivePageClassification =
+  { status: "base" | "ineligible" } | { status: "eligible"; sourceUrl: string };
+
+function classifyActivePageUrl(
+  value: string | undefined,
+): ActivePageClassification {
+  if (!value) return { status: "base" };
   try {
     const url = new URL(value);
-    return (url.protocol === "http:" || url.protocol === "https:") &&
-      !url.username &&
-      !url.password
-      ? url.toString()
-      : null;
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return { status: "base" };
+    }
+    if (url.username || url.password) return { status: "ineligible" };
+    return { status: "eligible", sourceUrl: url.toString() };
   } catch {
-    return null;
+    return /^https?:/i.test(value)
+      ? { status: "ineligible" }
+      : { status: "base" };
   }
 }
 
@@ -143,8 +150,12 @@ async function captureActiveBookmark(
   dependencies: BookmarkBackgroundDependencies,
 ): Promise<BookmarkMessageResponse> {
   const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-  const sourceUrl = eligiblePageUrl(tab?.url);
-  if (!tab?.id || !sourceUrl) return { ok: true, status: "ineligible" };
+  if (typeof tab?.id !== "number" || tab.id < 0) {
+    return { ok: true, status: "base" };
+  }
+  const page = classifyActivePageUrl(tab.url);
+  if (page.status !== "eligible") return { ok: true, status: page.status };
+  const { sourceUrl } = page;
   if (isConnectedInstancePage(sourceUrl, session.instance)) {
     return { ok: true, status: "base" };
   }


### PR DESCRIPTION
- Show the signed-in base UI on browser-owned, non-web, and missing-tab states
- Reserve the unbookmarkable notice for rejected web URLs and clarify its credential restriction
- Add regression coverage for page classification and notice copy