### PR TITLE
Add reconciliation foundation

### DIFF
--- a/apps/app/src/lib/reconciliation/contracts.ts
+++ b/apps/app/src/lib/reconciliation/contracts.ts
@@ -1,0 +1,230 @@
+import type { ContentStatusFilter } from "~/lib/content-status";
+import type {
+  ApplicationFeed,
+  ApplicationFeedItem,
+  ApplicationView,
+  DatabaseContentCategory,
+  DatabaseFeedCategory,
+  DatabaseViewFeed,
+} from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type { NavigationSnapshot } from "~/server/navigation/snapshot";
+import { buildContentStatusKey } from "~/lib/content-status";
+
+export const REQUIRED_RECONCILIATION_DOMAINS = [
+  "organization",
+  "active-scope",
+  "navigation",
+  "bookmarks",
+] as const;
+
+export type RequiredReconciliationDomain =
+  (typeof REQUIRED_RECONCILIATION_DOMAINS)[number];
+
+export type AutomaticRssOwner = "client" | "background-task";
+
+export type ReconciliationScope =
+  | { type: "view"; viewId: number }
+  | { type: "feed"; feedId: number }
+  | { type: "tag"; tagId: number };
+
+export type ReconciliationScopeTarget = {
+  type: "scope";
+  scope: ReconciliationScope;
+  contentStatus: ContentStatusFilter;
+};
+
+export type ReconciliationTarget =
+  | { type: "organization" }
+  | { type: "navigation" }
+  | { type: "bookmarks" }
+  | ReconciliationScopeTarget;
+
+export type OrganizationSnapshot = {
+  views: ApplicationView[];
+  feeds: ApplicationFeed[];
+  tags: DatabaseContentCategory[];
+  feedTags: DatabaseFeedCategory[];
+  directViewFeeds: DatabaseViewFeed[];
+};
+
+export type ReconciliationEntityKind = "bookmark" | "feed-item";
+
+export type ReconciliationReference = {
+  entityKind: ReconciliationEntityKind;
+  entityId: string;
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+};
+
+export type ReconciliationCursor =
+  | {
+      type: "feed";
+      placement?: number;
+      postedAt: Date;
+      id: string;
+      isWatchedUpdatedAt?: Date | null;
+      isWatchLaterUpdatedAt?: Date | null;
+    }
+  | {
+      type: "mixed";
+      sectionPlacement: number | null;
+      normalizedAt: Date;
+      entityKind: ReconciliationEntityKind;
+      entityId: string;
+    }
+  | null;
+
+export type ReconciliationEntityManifestEntry = {
+  id: string;
+  version: string;
+};
+
+export type ReconciliationPageManifest = {
+  orderedRefs: ReconciliationReference[];
+  feedItems: ReconciliationEntityManifestEntry[];
+  bookmarks: ReconciliationEntityManifestEntry[];
+  cursor: ReconciliationCursor;
+};
+
+export type BookmarkBucketManifestEntry = {
+  bucket: number;
+  version: string;
+};
+
+export type ReconciliationScopeInput = {
+  target: ReconciliationScopeTarget;
+  pageManifest: ReconciliationPageManifest;
+  membershipRevision: number;
+};
+
+export type TargetedReconciliationInput =
+  | { target: { type: "organization" } }
+  | { target: { type: "navigation" } }
+  | {
+      target: { type: "bookmarks" };
+      bookmarkManifest: BookmarkBucketManifestEntry[];
+    }
+  | ReconciliationScopeInput;
+
+export type ReconciliationInput =
+  | {
+      type: "full";
+      reconciliationId: string;
+      selectedScope: ReconciliationScopeInput;
+      bookmarkManifest: BookmarkBucketManifestEntry[];
+    }
+  | {
+      type: "targeted";
+      reconciliationId: string;
+      targets: TargetedReconciliationInput[];
+    };
+
+export type EntityDiff<TEntity extends { id: string }> =
+  | { status: "unchanged"; id: string }
+  | { status: "upsert"; entity: TEntity }
+  | { status: "delete"; id: string };
+
+export type ActiveFirstPageResult = {
+  target: ReconciliationScopeTarget;
+  membershipRevision: number;
+  orderedRefs: ReconciliationReference[];
+  feedItemDiffs: Array<EntityDiff<ApplicationFeedItem>>;
+  bookmarkDiffs: Array<EntityDiff<ApplicationBookmark>>;
+  cursor: ReconciliationCursor;
+  hasMore: boolean;
+};
+
+export type BookmarkSyncPage = {
+  bucket: number;
+  version: string;
+  pageIndex: number;
+  diffs: Array<EntityDiff<ApplicationBookmark>>;
+  completesBucket: boolean;
+};
+
+export type ReconciliationDomainFailure = {
+  domain: RequiredReconciliationDomain;
+  target?: ReconciliationScopeTarget;
+  message: string;
+};
+
+export type ReconciliationChunk =
+  | {
+      type: "organization-snapshot";
+      snapshot: OrganizationSnapshot;
+    }
+  | {
+      type: "active-first-page";
+      page: ActiveFirstPageResult;
+    }
+  | {
+      type: "navigation-snapshot";
+      snapshot: NavigationSnapshot;
+    }
+  | {
+      type: "bookmark-sync-page";
+      page: BookmarkSyncPage;
+    }
+  | {
+      type: "domain-complete";
+      domain: RequiredReconciliationDomain;
+      target?: ReconciliationScopeTarget;
+    }
+  | {
+      type: "domain-error";
+      failure: ReconciliationDomainFailure;
+    }
+  | {
+      type: "epoch-complete";
+      requiredDomains: RequiredReconciliationDomain[];
+    };
+
+export type ReconciliationResult = {
+  reconciliationId: string;
+  chunks: ReconciliationChunk[];
+  automaticRssOwner?: AutomaticRssOwner;
+};
+
+export type ReconciliationRequestIntent =
+  | {
+      type: "full";
+      selectedScope: ReconciliationScopeTarget;
+    }
+  | {
+      type: "targeted";
+      targets: ReconciliationTarget[];
+    };
+
+export function getReconciliationScopeKey(target: ReconciliationScopeTarget) {
+  const scopeId =
+    target.scope.type === "view"
+      ? target.scope.viewId
+      : target.scope.type === "feed"
+        ? target.scope.feedId
+        : target.scope.tagId;
+  return `${target.scope.type}:${scopeId}:${buildContentStatusKey(target.contentStatus)}`;
+}
+
+export function getReconciliationTargetKey(target: ReconciliationTarget) {
+  return target.type === "scope"
+    ? `scope:${getReconciliationScopeKey(target)}`
+    : target.type;
+}
+
+export function getRequiredTargetsForFullReconciliation(
+  selectedScope: ReconciliationScopeTarget,
+): ReconciliationTarget[] {
+  return [
+    { type: "organization" },
+    selectedScope,
+    { type: "navigation" },
+    { type: "bookmarks" },
+  ];
+}
+
+export function getTargetDomain(
+  target: ReconciliationTarget,
+): RequiredReconciliationDomain {
+  return target.type === "scope" ? "active-scope" : target.type;
+}

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -1,0 +1,702 @@
+import {
+  getReconciliationScopeKey,
+  getReconciliationTargetKey,
+  getRequiredTargetsForFullReconciliation,
+  getTargetDomain,
+  REQUIRED_RECONCILIATION_DOMAINS,
+} from "./contracts";
+import type {
+  AutomaticRssOwner,
+  ReconciliationRequestIntent,
+  ReconciliationScopeTarget,
+  ReconciliationTarget,
+  RequiredReconciliationDomain,
+} from "./contracts";
+
+export type ReconciliationTargetStatus =
+  "unverified" | "syncing" | "verified" | "dirty";
+
+export type ReconciliationTargetState = {
+  target: ReconciliationTarget;
+  status: ReconciliationTargetStatus;
+  revision: number;
+  requestedReconciliationId: string | null;
+  appliedAt: number | null;
+  appliedReconciliationId: string | null;
+};
+
+export type ReconciliationDomainState = {
+  status: ReconciliationTargetStatus;
+  appliedAt: number | null;
+};
+
+export type ReconciliationRequestDescriptor = {
+  reconciliationId: string;
+  intent: ReconciliationRequestIntent;
+  capturedRevisions: Record<string, number>;
+};
+
+type ReconciliationRequestRecord = ReconciliationRequestDescriptor & {
+  targets: ReconciliationTarget[];
+};
+
+type FullEpoch = {
+  reconciliationId: string;
+  selectedScope: ReconciliationScopeTarget;
+  requiredTargetKeys: string[];
+  completed: boolean;
+  established: boolean;
+};
+
+type BufferedAuthoritative<TAuthoritative> = {
+  type: "authoritative";
+  reconciliationId: string;
+  target: ReconciliationTarget;
+  targetKeys: string[];
+  requiresHydration: RequiredReconciliationDomain[];
+  payload: TAuthoritative;
+};
+
+type BufferedLiveEvent<TLiveEvent> = {
+  type: "live-event";
+  eventId: string;
+  targetKeys: string[];
+  requiresHydration: RequiredReconciliationDomain[];
+  payload: TLiveEvent;
+};
+
+type BufferedApplication<TAuthoritative, TLiveEvent> =
+  BufferedAuthoritative<TAuthoritative> | BufferedLiveEvent<TLiveEvent>;
+
+export type ReconciliationCoordinatorState<
+  TAuthoritative = unknown,
+  TLiveEvent = unknown,
+> = {
+  sessionId: string;
+  nextReconciliationSequence: number;
+  inFlight: ReconciliationRequestDescriptor | null;
+  trailingIntent: ReconciliationRequestIntent | null;
+  requests: Record<string, ReconciliationRequestRecord>;
+  targets: Record<string, ReconciliationTargetState>;
+  scopes: Record<string, ReconciliationTargetState>;
+  domains: Record<RequiredReconciliationDomain, ReconciliationDomainState>;
+  dirtyTargets: Record<string, ReconciliationTarget>;
+  hydratedDomains: Record<RequiredReconciliationDomain, boolean>;
+  bufferedApplications: Array<BufferedApplication<TAuthoritative, TLiveEvent>>;
+  latestFullEpoch: FullEpoch | null;
+  cacheUsableAt: number | null;
+  serverParityAppliedAt: number | null;
+  sseConnected: boolean;
+  automaticRssOwner: AutomaticRssOwner | null;
+  trustedUpToDate: boolean;
+};
+
+export type ReconciliationCommand<TAuthoritative, TLiveEvent> =
+  | {
+      type: "start-reconciliation";
+      request: ReconciliationRequestDescriptor;
+    }
+  | {
+      type: "apply-authoritative";
+      reconciliationId: string;
+      target: ReconciliationTarget;
+      payload: TAuthoritative;
+    }
+  | {
+      type: "apply-live-event";
+      eventId: string;
+      payload: TLiveEvent;
+    };
+
+export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
+  | { type: "cache-usable"; at: number }
+  | {
+      type: "sse-connection-changed";
+      connected: boolean;
+    }
+  | {
+      type: "hydration-complete";
+      domain: RequiredReconciliationDomain;
+    }
+  | {
+      type: "request-reconciliation";
+      intent: ReconciliationRequestIntent;
+    }
+  | {
+      type: "authoritative-received";
+      reconciliationId: string;
+      target: ReconciliationTarget;
+      requiresHydration: RequiredReconciliationDomain[];
+      payload: TAuthoritative;
+    }
+  | {
+      type: "authoritative-applied";
+      reconciliationId: string;
+      target: ReconciliationTarget;
+      at: number;
+    }
+  | {
+      type: "live-event-received";
+      eventId: string;
+      targets: ReconciliationTarget[];
+      requiresHydration: RequiredReconciliationDomain[];
+      payload?: TLiveEvent;
+      invalidates?: ReconciliationTarget[];
+      repairIntent?: ReconciliationRequestIntent;
+    }
+  | {
+      type: "request-settled";
+      reconciliationId: string;
+      at: number;
+      failedTargets?: ReconciliationTarget[];
+    }
+  | {
+      type: "automatic-rss-owner-resolved";
+      owner: AutomaticRssOwner;
+    };
+
+export type ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> = {
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>;
+  commands: Array<ReconciliationCommand<TAuthoritative, TLiveEvent>>;
+};
+
+function initialDomainStates(): Record<
+  RequiredReconciliationDomain,
+  ReconciliationDomainState
+> {
+  return Object.fromEntries(
+    REQUIRED_RECONCILIATION_DOMAINS.map((domain) => [
+      domain,
+      { status: "unverified", appliedAt: null },
+    ]),
+  ) as Record<RequiredReconciliationDomain, ReconciliationDomainState>;
+}
+
+function initialHydrationState(): Record<
+  RequiredReconciliationDomain,
+  boolean
+> {
+  return Object.fromEntries(
+    REQUIRED_RECONCILIATION_DOMAINS.map((domain) => [domain, false]),
+  ) as Record<RequiredReconciliationDomain, boolean>;
+}
+
+export function createReconciliationCoordinatorState<
+  TAuthoritative = unknown,
+  TLiveEvent = unknown,
+>(
+  sessionId: string,
+): ReconciliationCoordinatorState<TAuthoritative, TLiveEvent> {
+  return {
+    sessionId,
+    nextReconciliationSequence: 1,
+    inFlight: null,
+    trailingIntent: null,
+    requests: {},
+    targets: {},
+    scopes: {},
+    domains: initialDomainStates(),
+    dirtyTargets: {},
+    hydratedDomains: initialHydrationState(),
+    bufferedApplications: [],
+    latestFullEpoch: null,
+    cacheUsableAt: null,
+    serverParityAppliedAt: null,
+    sseConnected: false,
+    automaticRssOwner: null,
+    trustedUpToDate: false,
+  };
+}
+
+function requestTargets(intent: ReconciliationRequestIntent) {
+  return intent.type === "full"
+    ? getRequiredTargetsForFullReconciliation(intent.selectedScope)
+    : intent.targets;
+}
+
+function uniqueTargets(targets: readonly ReconciliationTarget[]) {
+  return [
+    ...new Map(
+      targets.map((target) => [getReconciliationTargetKey(target), target]),
+    ).values(),
+  ];
+}
+
+function mergeRequestIntents(
+  current: ReconciliationRequestIntent | null,
+  incoming: ReconciliationRequestIntent,
+): ReconciliationRequestIntent {
+  if (!current) return incoming;
+  if (incoming.type === "full") return incoming;
+  if (current.type === "full") return current;
+  return {
+    type: "targeted",
+    targets: uniqueTargets([...current.targets, ...incoming.targets]),
+  };
+}
+
+function targetState(
+  state: ReconciliationCoordinatorState,
+  target: ReconciliationTarget,
+): ReconciliationTargetState {
+  return (
+    state.targets[getReconciliationTargetKey(target)] ?? {
+      target,
+      status: "unverified",
+      revision: 0,
+      requestedReconciliationId: null,
+      appliedAt: null,
+      appliedReconciliationId: null,
+    }
+  );
+}
+
+function withTargetState<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  nextTarget: ReconciliationTargetState,
+) {
+  const targetKey = getReconciliationTargetKey(nextTarget.target);
+  const domain = getTargetDomain(nextTarget.target);
+  return {
+    ...state,
+    targets: { ...state.targets, [targetKey]: nextTarget },
+    scopes:
+      nextTarget.target.type === "scope"
+        ? {
+            ...state.scopes,
+            [getReconciliationScopeKey(nextTarget.target)]: nextTarget,
+          }
+        : state.scopes,
+    domains: {
+      ...state.domains,
+      [domain]: {
+        status: nextTarget.status,
+        appliedAt: nextTarget.appliedAt,
+      },
+    },
+  };
+}
+
+function startRequest<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  intent: ReconciliationRequestIntent,
+): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
+  const targets = uniqueTargets(requestTargets(intent));
+  const reconciliationId = `${state.sessionId}:${state.nextReconciliationSequence}`;
+  const capturedRevisions = Object.fromEntries(
+    targets.map((target) => [
+      getReconciliationTargetKey(target),
+      targetState(state, target).revision,
+    ]),
+  );
+  const descriptor = { reconciliationId, intent, capturedRevisions };
+  let nextState: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent> = {
+    ...state,
+    nextReconciliationSequence: state.nextReconciliationSequence + 1,
+    inFlight: descriptor,
+    requests: {
+      ...state.requests,
+      [reconciliationId]: { ...descriptor, targets },
+    },
+  };
+  for (const target of targets) {
+    nextState = withTargetState(nextState, {
+      ...targetState(nextState, target),
+      status: "syncing",
+      requestedReconciliationId: reconciliationId,
+    });
+  }
+  if (intent.type === "full") {
+    nextState = {
+      ...nextState,
+      latestFullEpoch: {
+        reconciliationId,
+        selectedScope: intent.selectedScope,
+        requiredTargetKeys: targets.map(getReconciliationTargetKey),
+        completed: false,
+        established: false,
+      },
+      serverParityAppliedAt: null,
+    };
+  }
+  return {
+    state: withDerivedTrust(nextState),
+    commands: [{ type: "start-reconciliation", request: descriptor }],
+  };
+}
+
+function enqueueRequest<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  intent: ReconciliationRequestIntent,
+): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
+  if (!state.inFlight) return startRequest(state, intent);
+  return {
+    state: withDerivedTrust({
+      ...state,
+      trailingIntent: mergeRequestIntents(state.trailingIntent, intent),
+    }),
+    commands: [],
+  };
+}
+
+function repairIntentFor<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  targets: ReconciliationTarget[],
+): ReconciliationRequestIntent {
+  const fullEpoch = state.latestFullEpoch;
+  return fullEpoch && !fullEpoch.established
+    ? { type: "full", selectedScope: fullEpoch.selectedScope }
+    : { type: "targeted", targets: uniqueTargets(targets) };
+}
+
+function markTargetsDirty<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  targets: readonly ReconciliationTarget[],
+  advanceRevision: boolean,
+) {
+  let nextState = state;
+  const dirtyTargets = { ...state.dirtyTargets };
+  for (const target of uniqueTargets(targets)) {
+    const targetKey = getReconciliationTargetKey(target);
+    const current = targetState(nextState, target);
+    dirtyTargets[targetKey] = target;
+    nextState = withTargetState(nextState, {
+      ...current,
+      status: "dirty",
+      revision: current.revision + (advanceRevision ? 1 : 0),
+    });
+  }
+  return withDerivedTrust({ ...nextState, dirtyTargets });
+}
+
+function isHydrated<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  domains: readonly RequiredReconciliationDomain[],
+) {
+  return domains.every((domain) => state.hydratedDomains[domain]);
+}
+
+function targetKeysOverlap(left: readonly string[], right: Set<string>) {
+  return left.some((key) => right.has(key));
+}
+
+function requestRevisionIsCurrent<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  reconciliationId: string,
+  target: ReconciliationTarget,
+) {
+  const targetKey = getReconciliationTargetKey(target);
+  const capturedRevision =
+    state.requests[reconciliationId]?.capturedRevisions[targetKey];
+  return (
+    capturedRevision !== undefined &&
+    capturedRevision === targetState(state, target).revision &&
+    targetState(state, target).requestedReconciliationId === reconciliationId
+  );
+}
+
+function bufferApplication<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  application: BufferedApplication<TAuthoritative, TLiveEvent>,
+) {
+  return withDerivedTrust({
+    ...state,
+    bufferedApplications: [...state.bufferedApplications, application],
+  });
+}
+
+function flushBufferedApplications<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
+  const blockedTargetKeys = new Set<string>();
+  const remaining: Array<BufferedApplication<TAuthoritative, TLiveEvent>> = [];
+  const commands: Array<ReconciliationCommand<TAuthoritative, TLiveEvent>> = [];
+  const staleTargets: ReconciliationTarget[] = [];
+  for (const application of state.bufferedApplications) {
+    const blocked =
+      !isHydrated(state, application.requiresHydration) ||
+      targetKeysOverlap(application.targetKeys, blockedTargetKeys);
+    if (blocked) {
+      remaining.push(application);
+      for (const targetKey of application.targetKeys) {
+        blockedTargetKeys.add(targetKey);
+      }
+      continue;
+    }
+    if (application.type === "live-event") {
+      commands.push({
+        type: "apply-live-event",
+        eventId: application.eventId,
+        payload: application.payload,
+      });
+      continue;
+    }
+    if (
+      !requestRevisionIsCurrent(
+        state,
+        application.reconciliationId,
+        application.target,
+      )
+    ) {
+      staleTargets.push(application.target);
+      continue;
+    }
+    commands.push({
+      type: "apply-authoritative",
+      reconciliationId: application.reconciliationId,
+      target: application.target,
+      payload: application.payload,
+    });
+  }
+  let nextState = withDerivedTrust({
+    ...state,
+    bufferedApplications: remaining,
+  });
+  if (staleTargets.length === 0) return { state: nextState, commands };
+  nextState = markTargetsDirty(nextState, staleTargets, false);
+  const queued = enqueueRequest(
+    nextState,
+    repairIntentFor(nextState, staleTargets),
+  );
+  return { state: queued.state, commands: [...commands, ...queued.commands] };
+}
+
+function fullEpochIsApplied<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+) {
+  const fullEpoch = state.latestFullEpoch;
+  if (!fullEpoch?.completed) return false;
+  return fullEpoch.requiredTargetKeys.every((targetKey) => {
+    const target = state.targets[targetKey];
+    return (
+      target?.status === "verified" &&
+      target.appliedReconciliationId === fullEpoch.reconciliationId
+    );
+  });
+}
+
+function withEstablishedFullParity<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  at: number,
+) {
+  if (!fullEpochIsApplied(state) || !state.latestFullEpoch) return state;
+  return {
+    ...state,
+    latestFullEpoch: { ...state.latestFullEpoch, established: true },
+    serverParityAppliedAt: at,
+  };
+}
+
+function deriveTrustedUpToDate<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+) {
+  const hasBufferedAuthoritative = state.bufferedApplications.some(
+    (application) => application.type === "authoritative",
+  );
+  return Boolean(
+    state.cacheUsableAt !== null &&
+    state.latestFullEpoch?.established &&
+    state.serverParityAppliedAt !== null &&
+    state.sseConnected &&
+    Object.keys(state.dirtyTargets).length === 0 &&
+    !hasBufferedAuthoritative,
+  );
+}
+
+function withDerivedTrust<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+) {
+  const trustedUpToDate = deriveTrustedUpToDate(state);
+  return state.trustedUpToDate === trustedUpToDate
+    ? state
+    : { ...state, trustedUpToDate };
+}
+
+export function transitionReconciliation<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  event: ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent>,
+): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
+  switch (event.type) {
+    case "cache-usable":
+      return {
+        state: withDerivedTrust({ ...state, cacheUsableAt: event.at }),
+        commands: [],
+      };
+    case "sse-connection-changed":
+      return {
+        state: withDerivedTrust({
+          ...state,
+          sseConnected: event.connected,
+        }),
+        commands: [],
+      };
+    case "automatic-rss-owner-resolved":
+      return {
+        state: { ...state, automaticRssOwner: event.owner },
+        commands: [],
+      };
+    case "hydration-complete": {
+      const hydratedState = {
+        ...state,
+        hydratedDomains: {
+          ...state.hydratedDomains,
+          [event.domain]: true,
+        },
+      };
+      return flushBufferedApplications(hydratedState);
+    }
+    case "request-reconciliation":
+      return enqueueRequest(state, event.intent);
+    case "authoritative-received": {
+      if (
+        !requestRevisionIsCurrent(state, event.reconciliationId, event.target)
+      ) {
+        const dirtyState = markTargetsDirty(state, [event.target], false);
+        return enqueueRequest(
+          dirtyState,
+          repairIntentFor(dirtyState, [event.target]),
+        );
+      }
+      const targetKeys = [getReconciliationTargetKey(event.target)];
+      const hasEarlierBlockedTarget = state.bufferedApplications.some(
+        (application) =>
+          targetKeysOverlap(application.targetKeys, new Set(targetKeys)),
+      );
+      if (
+        !isHydrated(state, event.requiresHydration) ||
+        hasEarlierBlockedTarget
+      ) {
+        return {
+          state: bufferApplication(state, {
+            type: "authoritative",
+            reconciliationId: event.reconciliationId,
+            target: event.target,
+            targetKeys,
+            requiresHydration: event.requiresHydration,
+            payload: event.payload,
+          }),
+          commands: [],
+        };
+      }
+      return {
+        state,
+        commands: [
+          {
+            type: "apply-authoritative",
+            reconciliationId: event.reconciliationId,
+            target: event.target,
+            payload: event.payload,
+          },
+        ],
+      };
+    }
+    case "authoritative-applied": {
+      if (
+        !requestRevisionIsCurrent(state, event.reconciliationId, event.target)
+      ) {
+        const dirtyState = markTargetsDirty(state, [event.target], false);
+        return enqueueRequest(
+          dirtyState,
+          repairIntentFor(dirtyState, [event.target]),
+        );
+      }
+      const targetKey = getReconciliationTargetKey(event.target);
+      const dirtyTargets = { ...state.dirtyTargets };
+      delete dirtyTargets[targetKey];
+      let nextState = withTargetState(state, {
+        ...targetState(state, event.target),
+        status: "verified",
+        appliedAt: event.at,
+        appliedReconciliationId: event.reconciliationId,
+      });
+      nextState = { ...nextState, dirtyTargets };
+      nextState = withEstablishedFullParity(nextState, event.at);
+      return { state: withDerivedTrust(nextState), commands: [] };
+    }
+    case "live-event-received": {
+      let nextState = state;
+      let commands: Array<ReconciliationCommand<TAuthoritative, TLiveEvent>> =
+        [];
+      const invalidatedTargets = event.invalidates ?? [];
+      if (invalidatedTargets.length > 0) {
+        nextState = markTargetsDirty(nextState, invalidatedTargets, true);
+        const repairIntent =
+          event.repairIntent ?? repairIntentFor(nextState, invalidatedTargets);
+        const queued = enqueueRequest(nextState, repairIntent);
+        nextState = queued.state;
+        commands = queued.commands;
+      }
+      if (event.payload === undefined) {
+        return { state: withDerivedTrust(nextState), commands };
+      }
+      const targetKeys = event.targets.map(getReconciliationTargetKey);
+      const targetKeySet = new Set(targetKeys);
+      const hasEarlierBlockedTarget = nextState.bufferedApplications.some(
+        (application) =>
+          application.targetKeys.some((targetKey) =>
+            targetKeySet.has(targetKey),
+          ),
+      );
+      if (
+        !isHydrated(nextState, event.requiresHydration) ||
+        hasEarlierBlockedTarget
+      ) {
+        return {
+          state: bufferApplication(nextState, {
+            type: "live-event",
+            eventId: event.eventId,
+            targetKeys,
+            requiresHydration: event.requiresHydration,
+            payload: event.payload,
+          }),
+          commands,
+        };
+      }
+      return {
+        state: nextState,
+        commands: [
+          ...commands,
+          {
+            type: "apply-live-event",
+            eventId: event.eventId,
+            payload: event.payload,
+          },
+        ],
+      };
+    }
+    case "request-settled": {
+      let nextState = state;
+      if (event.failedTargets && event.failedTargets.length > 0) {
+        nextState = markTargetsDirty(nextState, event.failedTargets, false);
+      }
+      if (
+        nextState.latestFullEpoch?.reconciliationId ===
+          event.reconciliationId &&
+        (!event.failedTargets || event.failedTargets.length === 0)
+      ) {
+        nextState = withEstablishedFullParity(
+          {
+            ...nextState,
+            latestFullEpoch: {
+              ...nextState.latestFullEpoch,
+              completed: true,
+            },
+          },
+          event.at,
+        );
+      }
+      if (nextState.inFlight?.reconciliationId !== event.reconciliationId) {
+        return { state: withDerivedTrust(nextState), commands: [] };
+      }
+      const trailingIntent = nextState.trailingIntent;
+      nextState = {
+        ...nextState,
+        inFlight: null,
+        trailingIntent: null,
+      };
+      return trailingIntent
+        ? startRequest(nextState, trailingIntent)
+        : { state: withDerivedTrust(nextState), commands: [] };
+    }
+  }
+}

--- a/apps/app/src/lib/reconciliation/index.ts
+++ b/apps/app/src/lib/reconciliation/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts";
+export * from "./coordinator";
+export * from "./reducers";

--- a/apps/app/src/lib/reconciliation/reducers.ts
+++ b/apps/app/src/lib/reconciliation/reducers.ts
@@ -1,0 +1,186 @@
+import { getReconciliationScopeKey } from "./contracts";
+import type {
+  ActiveFirstPageResult,
+  BookmarkSyncPage,
+  EntityDiff,
+  OrganizationSnapshot,
+  ReconciliationCursor,
+  ReconciliationReference,
+} from "./contracts";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type { NavigationSnapshot } from "~/server/navigation/snapshot";
+
+export type ReconciledScope = {
+  orderedRefs: ReconciliationReference[];
+  cursor: ReconciliationCursor;
+  hasMore: boolean;
+  membershipRevision: number;
+};
+
+type PendingBookmarkBucket = {
+  version: string;
+  nextPageIndex: number;
+  diffs: Array<EntityDiff<ApplicationBookmark>>;
+};
+
+export type ReconciliationDataState = {
+  organization: OrganizationSnapshot | null;
+  navigation: NavigationSnapshot | null;
+  feedItems: Record<string, ApplicationFeedItem>;
+  bookmarks: Record<string, ApplicationBookmark>;
+  scopes: Record<string, ReconciledScope>;
+  bookmarkBucketVersions: Record<number, string>;
+  pendingBookmarkBuckets: Record<number, PendingBookmarkBucket>;
+};
+
+export type ReconciliationDataEvent =
+  | { type: "apply-organization"; snapshot: OrganizationSnapshot }
+  | { type: "apply-navigation"; snapshot: NavigationSnapshot }
+  | {
+      type: "apply-active-first-page";
+      page: ActiveFirstPageResult;
+      currentMembershipRevision: number;
+    }
+  | { type: "apply-bookmark-sync-page"; page: BookmarkSyncPage };
+
+export type ReconciliationDataTransition = {
+  state: ReconciliationDataState;
+  applied: boolean;
+};
+
+export function createReconciliationDataState(
+  initial: Partial<ReconciliationDataState> = {},
+): ReconciliationDataState {
+  return {
+    organization: null,
+    navigation: null,
+    feedItems: {},
+    bookmarks: {},
+    scopes: {},
+    bookmarkBucketVersions: {},
+    pendingBookmarkBuckets: {},
+    ...initial,
+  };
+}
+
+export function applyEntityDiffs<TEntity extends { id: string }>(
+  entities: Record<string, TEntity>,
+  diffs: ReadonlyArray<EntityDiff<TEntity>>,
+) {
+  let next = entities;
+  for (const diff of diffs) {
+    if (diff.status === "unchanged") continue;
+    if (next === entities) next = { ...entities };
+    if (diff.status === "delete") {
+      delete next[diff.id];
+    } else {
+      next[diff.entity.id] = diff.entity;
+    }
+  }
+  return next;
+}
+
+function applyActiveFirstPage(
+  state: ReconciliationDataState,
+  page: ActiveFirstPageResult,
+  currentMembershipRevision: number,
+): ReconciliationDataTransition {
+  if (page.membershipRevision !== currentMembershipRevision) {
+    return { state, applied: false };
+  }
+  const scopeKey = getReconciliationScopeKey(page.target);
+  return {
+    applied: true,
+    state: {
+      ...state,
+      feedItems: applyEntityDiffs(state.feedItems, page.feedItemDiffs),
+      bookmarks: applyEntityDiffs(state.bookmarks, page.bookmarkDiffs),
+      scopes: {
+        ...state.scopes,
+        [scopeKey]: {
+          orderedRefs: page.orderedRefs,
+          cursor: page.cursor,
+          hasMore: page.hasMore,
+          membershipRevision: page.membershipRevision,
+        },
+      },
+    },
+  };
+}
+
+function applyBookmarkSyncPage(
+  state: ReconciliationDataState,
+  page: BookmarkSyncPage,
+): ReconciliationDataTransition {
+  const current = state.pendingBookmarkBuckets[page.bucket];
+  if (page.pageIndex !== 0 && !current) return { state, applied: false };
+  if (
+    page.pageIndex !== 0 &&
+    current &&
+    (current.version !== page.version ||
+      current.nextPageIndex !== page.pageIndex)
+  ) {
+    return { state, applied: false };
+  }
+  const pending: PendingBookmarkBucket = {
+    version: page.version,
+    nextPageIndex: page.pageIndex + 1,
+    diffs: [
+      ...(page.pageIndex === 0 ? [] : (current?.diffs ?? [])),
+      ...page.diffs,
+    ],
+  };
+  if (!page.completesBucket) {
+    return {
+      applied: true,
+      state: {
+        ...state,
+        pendingBookmarkBuckets: {
+          ...state.pendingBookmarkBuckets,
+          [page.bucket]: pending,
+        },
+      },
+    };
+  }
+  const pendingBookmarkBuckets = { ...state.pendingBookmarkBuckets };
+  delete pendingBookmarkBuckets[page.bucket];
+  return {
+    applied: true,
+    state: {
+      ...state,
+      bookmarks: applyEntityDiffs(state.bookmarks, pending.diffs),
+      bookmarkBucketVersions: {
+        ...state.bookmarkBucketVersions,
+        [page.bucket]: page.version,
+      },
+      pendingBookmarkBuckets,
+    },
+  };
+}
+
+export function reduceReconciliationData(
+  state: ReconciliationDataState,
+  event: ReconciliationDataEvent,
+): ReconciliationDataTransition {
+  switch (event.type) {
+    case "apply-organization":
+      return {
+        applied: true,
+        state: { ...state, organization: event.snapshot },
+      };
+    case "apply-navigation":
+      return {
+        applied: true,
+        state: { ...state, navigation: event.snapshot },
+      };
+    case "apply-active-first-page":
+      return applyActiveFirstPage(
+        state,
+        event.page,
+        event.currentMembershipRevision,
+      );
+    case "apply-bookmark-sync-page":
+      return applyBookmarkSyncPage(state, event.page);
+  }
+}

--- a/apps/app/tests/unit/reconciliation/reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, it } from "vitest";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type {
+  ActiveFirstPageResult,
+  OrganizationSnapshot,
+  ReconciliationCommand,
+  ReconciliationCoordinatorEvent,
+  ReconciliationCoordinatorState,
+  ReconciliationRequestIntent,
+  ReconciliationScopeTarget,
+  ReconciliationTarget,
+  RequiredReconciliationDomain,
+} from "~/lib/reconciliation";
+import {
+  createReconciliationCoordinatorState,
+  createReconciliationDataState,
+  getReconciliationTargetKey,
+  reduceReconciliationData,
+  transitionReconciliation,
+} from "~/lib/reconciliation";
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+
+const ACTIVE_SCOPE = {
+  type: "scope",
+  scope: { type: "view", viewId: 7 },
+  contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+} satisfies ReconciliationScopeTarget;
+
+const OTHER_SCOPE = {
+  type: "scope",
+  scope: { type: "tag", tagId: 8 },
+  contentStatus: { saveStatus: "saved", archiveStatus: "archived" },
+} satisfies ReconciliationScopeTarget;
+
+const ORGANIZATION = { type: "organization" } as const;
+const NAVIGATION = { type: "navigation" } as const;
+const BOOKMARKS = { type: "bookmarks" } as const;
+
+function feedItem(
+  id: string,
+  overrides: Partial<ApplicationFeedItem> = {},
+): ApplicationFeedItem {
+  return {
+    id,
+    feedId: 1,
+    contentId: id,
+    title: id,
+    author: "Serial test",
+    url: `https://example.com/${id}`,
+    thumbnail: "",
+    content: id,
+    contentSnippet: id,
+    contentType: "text",
+    isWatched: false,
+    isWatchLater: false,
+    progress: 0,
+    duration: 0,
+    orientation: null,
+    postedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    isWatchedUpdatedAt: null,
+    isWatchLaterUpdatedAt: null,
+    contentHash: id,
+    platform: "website",
+    ...overrides,
+  };
+}
+
+function bookmark(
+  id: string,
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  return {
+    id,
+    title: id,
+    sourceUrl: `https://example.com/${id}`,
+    canonicalUrl: `https://example.com/${id}`,
+    ...overrides,
+  } as ApplicationBookmark;
+}
+
+function firstPage(
+  membershipRevision: number,
+  overrides: Partial<ActiveFirstPageResult> = {},
+): ActiveFirstPageResult {
+  return {
+    target: ACTIVE_SCOPE,
+    membershipRevision,
+    orderedRefs: [],
+    feedItemDiffs: [],
+    bookmarkDiffs: [],
+    cursor: null,
+    hasMore: false,
+    ...overrides,
+  };
+}
+
+function organizationSnapshot(name: string): OrganizationSnapshot {
+  return {
+    views: [{ id: 1, name }] as OrganizationSnapshot["views"],
+    feeds: [],
+    tags: [],
+    feedTags: [],
+    directViewFeeds: [],
+  };
+}
+
+describe("reconciliation data reducers", () => {
+  it("replaces small domains and page membership without inferring entity deletion", () => {
+    const originalOrganization = organizationSnapshot("Original");
+    const replacementOrganization = organizationSnapshot("Replacement");
+    const itemA = feedItem("a");
+    const itemB = feedItem("b");
+    const itemC = feedItem("c");
+    let state = createReconciliationDataState({
+      organization: originalOrganization,
+      feedItems: { a: itemA, b: itemB },
+    });
+
+    ({ state } = reduceReconciliationData(state, {
+      type: "apply-organization",
+      snapshot: replacementOrganization,
+    }));
+    expect(state.organization).toBe(replacementOrganization);
+
+    const applied = reduceReconciliationData(state, {
+      type: "apply-active-first-page",
+      currentMembershipRevision: 4,
+      page: firstPage(4, {
+        orderedRefs: [
+          {
+            entityKind: "feed-item",
+            entityId: "c",
+            sectionPlacement: null,
+            normalizedAt: NOW,
+          },
+        ],
+        feedItemDiffs: [
+          { status: "unchanged", id: "a" },
+          { status: "upsert", entity: itemC },
+        ],
+      }),
+    });
+
+    expect(applied.applied).toBe(true);
+    expect(Object.keys(applied.state.feedItems).sort()).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(
+      applied.state.scopes["view:7:inbox:unread"]?.orderedRefs.map(
+        ({ entityId }) => entityId,
+      ),
+    ).toEqual(["c"]);
+
+    const deleted = reduceReconciliationData(applied.state, {
+      type: "apply-active-first-page",
+      currentMembershipRevision: 4,
+      page: firstPage(4, {
+        feedItemDiffs: [{ status: "delete", id: "b" }],
+      }),
+    });
+    expect(deleted.state.feedItems.b).toBeUndefined();
+  });
+
+  it("rejects an active page whose membership revision is stale", () => {
+    const state = createReconciliationDataState({
+      feedItems: { a: feedItem("a") },
+    });
+    const result = reduceReconciliationData(state, {
+      type: "apply-active-first-page",
+      currentMembershipRevision: 2,
+      page: firstPage(1, {
+        feedItemDiffs: [{ status: "delete", id: "a" }],
+      }),
+    });
+    expect(result).toEqual({ state, applied: false });
+  });
+
+  it("applies a bounded Bookmark bucket only after its final page", () => {
+    const oldBookmark = bookmark("old");
+    const newBookmark = bookmark("new");
+    let state = createReconciliationDataState({
+      bookmarks: { old: oldBookmark },
+    });
+
+    ({ state } = reduceReconciliationData(state, {
+      type: "apply-bookmark-sync-page",
+      page: {
+        bucket: 3,
+        version: "next",
+        pageIndex: 0,
+        diffs: [{ status: "delete", id: "old" }],
+        completesBucket: false,
+      },
+    }));
+    expect(state.bookmarks.old).toBe(oldBookmark);
+
+    ({ state } = reduceReconciliationData(state, {
+      type: "apply-bookmark-sync-page",
+      page: {
+        bucket: 3,
+        version: "next",
+        pageIndex: 1,
+        diffs: [{ status: "upsert", entity: newBookmark }],
+        completesBucket: true,
+      },
+    }));
+    expect(state.bookmarks).toEqual({ new: newBookmark });
+    expect(state.bookmarkBucketVersions[3]).toBe("next");
+  });
+});
+
+type TestCoordinator = ReconciliationCoordinatorState<string, string>;
+type TestEvent = ReconciliationCoordinatorEvent<string, string>;
+type TestCommand = ReconciliationCommand<string, string>;
+
+function coordinatorHarness() {
+  let state: TestCoordinator = createReconciliationCoordinatorState<
+    string,
+    string
+  >("test-session");
+  return {
+    get state() {
+      return state;
+    },
+    send(event: TestEvent) {
+      const transition = transitionReconciliation(state, event);
+      state = transition.state;
+      return transition.commands;
+    },
+  };
+}
+
+function hydrateAll(send: (event: TestEvent) => TestCommand[]) {
+  for (const domain of [
+    "organization",
+    "active-scope",
+    "navigation",
+    "bookmarks",
+  ] satisfies RequiredReconciliationDomain[]) {
+    send({ type: "hydration-complete", domain });
+  }
+}
+
+function startedRequest(commands: TestCommand[]) {
+  const command = commands.find(
+    (candidate) => candidate.type === "start-reconciliation",
+  );
+  if (!command || command.type !== "start-reconciliation") {
+    throw new Error("Expected reconciliation request");
+  }
+  return command.request;
+}
+
+function requiredTargets(): ReconciliationTarget[] {
+  return [ORGANIZATION, ACTIVE_SCOPE, NAVIGATION, BOOKMARKS];
+}
+
+function hydrationFor(target: ReconciliationTarget) {
+  return [
+    target.type === "scope" ? "active-scope" : target.type,
+  ] as RequiredReconciliationDomain[];
+}
+
+describe("reconciliation coordinator", () => {
+  it("establishes trust only after a complete finite epoch and SSE connection", () => {
+    const harness = coordinatorHarness();
+    hydrateAll(harness.send);
+    harness.send({ type: "cache-usable", at: 1 });
+    const request = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "full", selectedScope: ACTIVE_SCOPE },
+      }),
+    );
+
+    for (const [index, target] of requiredTargets().entries()) {
+      const commands = harness.send({
+        type: "authoritative-received",
+        reconciliationId: request.reconciliationId,
+        target,
+        requiresHydration: hydrationFor(target),
+        payload: `domain-${index}`,
+      });
+      expect(commands).toHaveLength(1);
+      harness.send({
+        type: "authoritative-applied",
+        reconciliationId: request.reconciliationId,
+        target,
+        at: index + 2,
+      });
+    }
+
+    expect(harness.state.serverParityAppliedAt).toBeNull();
+    harness.send({
+      type: "request-settled",
+      reconciliationId: request.reconciliationId,
+      at: 6,
+    });
+    expect(harness.state.serverParityAppliedAt).toBe(6);
+    expect(harness.state.trustedUpToDate).toBe(false);
+    harness.send({ type: "sse-connection-changed", connected: true });
+    expect(harness.state.trustedUpToDate).toBe(true);
+    expect(harness.state.domains.organization.appliedAt).toBe(2);
+    expect(harness.state.domains["active-scope"].appliedAt).toBe(3);
+    expect(harness.state.domains.navigation.appliedAt).toBe(4);
+    expect(harness.state.domains.bookmarks.appliedAt).toBe(5);
+  });
+
+  it("preserves applied domains and withholds parity after partial failure", () => {
+    const harness = coordinatorHarness();
+    hydrateAll(harness.send);
+    harness.send({ type: "cache-usable", at: 1 });
+    harness.send({ type: "sse-connection-changed", connected: true });
+    const request = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "full", selectedScope: ACTIVE_SCOPE },
+      }),
+    );
+
+    for (const target of [ORGANIZATION, ACTIVE_SCOPE, BOOKMARKS]) {
+      harness.send({
+        type: "authoritative-received",
+        reconciliationId: request.reconciliationId,
+        target,
+        requiresHydration: hydrationFor(target),
+        payload: getReconciliationTargetKey(target),
+      });
+      harness.send({
+        type: "authoritative-applied",
+        reconciliationId: request.reconciliationId,
+        target,
+        at: 2,
+      });
+    }
+    const commands = harness.send({
+      type: "request-settled",
+      reconciliationId: request.reconciliationId,
+      at: 3,
+      failedTargets: [NAVIGATION],
+    });
+
+    expect(commands).toEqual([]);
+    expect(harness.state.cacheUsableAt).toBe(1);
+    expect(harness.state.domains.organization.status).toBe("verified");
+    expect(harness.state.domains.navigation.status).toBe("dirty");
+    expect(harness.state.serverParityAppliedAt).toBeNull();
+    expect(harness.state.trustedUpToDate).toBe(false);
+  });
+
+  it("rejects a stale target atomically and schedules one trailing full repair", () => {
+    const harness = coordinatorHarness();
+    hydrateAll(harness.send);
+    const request = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "full", selectedScope: ACTIVE_SCOPE },
+      }),
+    );
+
+    expect(
+      harness.send({
+        type: "live-event-received",
+        eventId: "mutation",
+        targets: [ACTIVE_SCOPE],
+        requiresHydration: ["active-scope"],
+        invalidates: [ACTIVE_SCOPE],
+      }),
+    ).toEqual([]);
+
+    expect(
+      harness.send({
+        type: "authoritative-received",
+        reconciliationId: request.reconciliationId,
+        target: ACTIVE_SCOPE,
+        requiresHydration: ["active-scope"],
+        payload: "stale-page-and-diffs",
+      }),
+    ).toEqual([]);
+    expect(
+      harness.state.dirtyTargets[getReconciliationTargetKey(ACTIVE_SCOPE)],
+    ).toBeDefined();
+    expect(harness.state.trailingIntent?.type).toBe("full");
+
+    const trailing = harness.send({
+      type: "request-settled",
+      reconciliationId: request.reconciliationId,
+      at: 2,
+    });
+    expect(startedRequest(trailing).intent).toEqual({
+      type: "full",
+      selectedScope: ACTIVE_SCOPE,
+    });
+  });
+
+  it("unions targeted work and lets one full intent subsume the trailing queue", () => {
+    const harness = coordinatorHarness();
+    const first = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [ACTIVE_SCOPE] },
+      }),
+    );
+    for (const intent of [
+      { type: "targeted", targets: [OTHER_SCOPE] },
+      { type: "targeted", targets: [NAVIGATION] },
+      { type: "full", selectedScope: ACTIVE_SCOPE },
+      { type: "targeted", targets: [BOOKMARKS] },
+    ] satisfies ReconciliationRequestIntent[]) {
+      expect(harness.send({ type: "request-reconciliation", intent })).toEqual(
+        [],
+      );
+    }
+
+    expect(harness.state.trailingIntent).toEqual({
+      type: "full",
+      selectedScope: ACTIVE_SCOPE,
+    });
+    const trailing = harness.send({
+      type: "request-settled",
+      reconciliationId: first.reconciliationId,
+      at: 1,
+    });
+    expect(trailing).toHaveLength(1);
+    expect(startedRequest(trailing).intent.type).toBe("full");
+    expect(harness.state.trailingIntent).toBeNull();
+  });
+
+  it("does not flush a buffered result after a newer request supersedes it", () => {
+    const harness = coordinatorHarness();
+    const first = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [ACTIVE_SCOPE] },
+      }),
+    );
+    harness.send({
+      type: "authoritative-received",
+      reconciliationId: first.reconciliationId,
+      target: ACTIVE_SCOPE,
+      requiresHydration: ["active-scope"],
+      payload: "buffered-old-result",
+    });
+    harness.send({
+      type: "request-settled",
+      reconciliationId: first.reconciliationId,
+      at: 1,
+    });
+    startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [ACTIVE_SCOPE] },
+      }),
+    );
+
+    expect(
+      harness.send({ type: "hydration-complete", domain: "active-scope" }),
+    ).toEqual([]);
+    expect(harness.state.bufferedApplications).toEqual([]);
+    expect(harness.state.trailingIntent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
+  });
+
+  it("buffers per target without letting one unhydrated domain block another", () => {
+    const harness = coordinatorHarness();
+    harness.send({
+      type: "live-event-received",
+      eventId: "scope-first",
+      targets: [ACTIVE_SCOPE],
+      requiresHydration: ["bookmarks"],
+      payload: "scope-first",
+    });
+    harness.send({
+      type: "live-event-received",
+      eventId: "scope-second",
+      targets: [ACTIVE_SCOPE],
+      requiresHydration: ["organization"],
+      payload: "scope-second",
+    });
+    harness.send({
+      type: "live-event-received",
+      eventId: "organization-independent",
+      targets: [ORGANIZATION],
+      requiresHydration: ["organization"],
+      payload: "organization-independent",
+    });
+
+    expect(
+      harness.send({ type: "hydration-complete", domain: "organization" }),
+    ).toEqual([
+      {
+        type: "apply-live-event",
+        eventId: "organization-independent",
+        payload: "organization-independent",
+      },
+    ]);
+    expect(
+      harness.send({ type: "hydration-complete", domain: "bookmarks" }),
+    ).toEqual([
+      {
+        type: "apply-live-event",
+        eventId: "scope-first",
+        payload: "scope-first",
+      },
+      {
+        type: "apply-live-event",
+        eventId: "scope-second",
+        payload: "scope-second",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
- Define finite reconciliation contracts and atomic domain reducers
- Add a pure coordinator for hydration barriers, live-event buffering, revision guards, request coalescing, and trust state