### PR TITLE
Build finite server reconciliation

### DIFF
--- a/apps/app/benchmarks/README.md
+++ b/apps/app/benchmarks/README.md
@@ -72,11 +72,11 @@ The initial executable pair uses the unassigned all-content View:
 - `feed-view-page`: the existing production View prerequisite loads, bounded
   Feed-item SQL query, row materialization, and application projection.
 - `mixed-view-page`: `queryMixedContentPage`, including all SQL, row
-  materialization, canonical suppression, membership and visibility filtering,
-  sorting, cursoring, and projection.
+  materialization, independent Bookmark and Feed-item membership and visibility
+  filtering, sorting, cursoring, and projection.
 
-The page size is 30. Operations return equivalent visible scopes; a Bookmark
-may suppress a colliding Feed item under the approved mixed-content semantics.
+The page size is 30. Matching Bookmark and Feed-item rows remain independent;
+either or both may appear when eligible for the visible scope.
 
 ## Measurements and exact pass/fail rule
 

--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -471,7 +471,6 @@ function seedClientFixture(profileName: BenchmarkProfileName) {
           hasMore: true,
         },
         replacesScope: true,
-        feedItems: feedItemsDict,
       });
     }
   }
@@ -568,7 +567,6 @@ function persistedPayloadBytes() {
   }).byteLength;
   const mixedContent = serialize({
     scopes: mixedContentStore.getState().scopes,
-    suppressedReferences: mixedContentStore.getState().suppressedReferences,
   }).byteLength;
   return {
     application,

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -6,7 +6,6 @@ import {
   bookmarkPropertiesChange,
 } from "@serial/bookmark-capture";
 import { useMutation } from "@tanstack/react-query";
-import { feedItemsStore } from "../store";
 import { mixedContentStore } from "../mixed-content/store";
 import { viewsStore } from "../views/store";
 import { refreshNavigationSnapshotSafely } from "../navigation/store";
@@ -25,7 +24,6 @@ function projectBookmark(
   mixedContentStore.getState().reprojectUpsert({
     bookmark,
     previousBookmark,
-    feedItems: feedItemsStore.getState().feedItemsDict,
     views: viewsStore.getState().views,
   });
 }
@@ -34,7 +32,6 @@ function removeProjectedBookmark(bookmark: ApplicationBookmark) {
   bookmarksStore.getState().remove(bookmark.id);
   mixedContentStore.getState().reprojectDeletion({
     bookmarkId: bookmark.id,
-    feedItems: feedItemsStore.getState().feedItemsDict,
   });
 }
 

--- a/apps/app/src/lib/data/feed-items/mutations.ts
+++ b/apps/app/src/lib/data/feed-items/mutations.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
 import { feedItemsStore, useFeedItemState } from "../store";
-import { bookmarksStore } from "../bookmarks/store";
 import { feedCategoriesStore } from "../feed-categories/store";
 import { mixedContentStore } from "../mixed-content/store";
 import { viewsStore } from "../views/store";
@@ -51,7 +50,6 @@ function setFeedItemsWithMixedProjection(items: ApplicationFeedItem[]) {
     itemIds: items.map((item) => item.id),
     previousFeedItems,
     feedItems: store.feedItemsDict,
-    bookmarks: bookmarksStore.getState().snapshot(),
     views: viewsStore.getState().views,
     feedCategories: feedCategoriesStore.getState().feedCategories,
   });

--- a/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
+++ b/apps/app/src/lib/data/mixed-content/bookmarkProjection.ts
@@ -25,8 +25,6 @@ export type LoadedMixedScope = {
 export type ProjectionIndexes = {
   bookmarkScopeKeys: Record<string, string[]>;
   feedItemScopeKeys: Record<string, string[]>;
-  canonicalByFeedItemId: Record<string, string>;
-  feedItemIdsByCanonical: Record<string, string[]>;
 };
 
 export function getMixedScopeKey(
@@ -36,7 +34,9 @@ export function getMixedScopeKey(
   const contentStatusKey = buildContentStatusKey(contentStatus);
   return scope.type === "view"
     ? `view:${scope.viewId}:${contentStatusKey}`
-    : `tag:${scope.tagId}:${contentStatusKey}`;
+    : scope.type === "feed"
+      ? `feed:${scope.feedId}:${contentStatusKey}`
+      : `tag:${scope.tagId}:${contentStatusKey}`;
 }
 
 function compareReferences(
@@ -83,27 +83,10 @@ export function referencesEqual(
   );
 }
 
-export function referenceRecordsEqual(
-  left: Record<string, MixedContentReference[]>,
-  right: Record<string, MixedContentReference[]>,
-) {
-  const leftKeys = Object.keys(left);
-  const rightKeys = Object.keys(right);
-  return (
-    leftKeys.length === rightKeys.length &&
-    leftKeys.every(
-      (key) =>
-        right[key] !== undefined && referencesEqual(left[key]!, right[key]),
-    )
-  );
-}
-
 export function emptyProjectionIndexes(): ProjectionIndexes {
   return {
     bookmarkScopeKeys: {},
     feedItemScopeKeys: {},
-    canonicalByFeedItemId: {},
-    feedItemIdsByCanonical: {},
   };
 }
 
@@ -128,18 +111,6 @@ function removeValue(
   else record[key] = nextValues;
 }
 
-export function canonicalize(url: string) {
-  try {
-    const parsed = new URL(url);
-    parsed.hash = "";
-    if (parsed.protocol === "http:" && parsed.port === "80") parsed.port = "";
-    if (parsed.protocol === "https:" && parsed.port === "443") parsed.port = "";
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
 function removeScopeFromIndexes(
   indexes: ProjectionIndexes,
   scopeKey: string,
@@ -152,16 +123,6 @@ function removeScopeFromIndexes(
     }
 
     removeValue(indexes.feedItemScopeKeys, reference.entityId, scopeKey);
-    if (indexes.feedItemScopeKeys[reference.entityId] !== undefined) continue;
-    const canonicalUrl = indexes.canonicalByFeedItemId[reference.entityId];
-    delete indexes.canonicalByFeedItemId[reference.entityId];
-    if (canonicalUrl) {
-      removeValue(
-        indexes.feedItemIdsByCanonical,
-        canonicalUrl,
-        reference.entityId,
-      );
-    }
   }
 }
 
@@ -169,7 +130,6 @@ function addScopeToIndexes(
   indexes: ProjectionIndexes,
   scopeKey: string,
   references: MixedContentReference[],
-  feedItems: Record<string, ApplicationFeedItem>,
 ) {
   for (const reference of references) {
     if (reference.entityKind === "bookmark") {
@@ -178,23 +138,6 @@ function addScopeToIndexes(
     }
 
     addUniqueValue(indexes.feedItemScopeKeys, reference.entityId, scopeKey);
-    const item = feedItems[reference.entityId];
-    if (!item?.url) continue;
-    const canonicalUrl = canonicalize(item.url);
-    const previousCanonical = indexes.canonicalByFeedItemId[reference.entityId];
-    if (previousCanonical && previousCanonical !== canonicalUrl) {
-      removeValue(
-        indexes.feedItemIdsByCanonical,
-        previousCanonical,
-        reference.entityId,
-      );
-    }
-    indexes.canonicalByFeedItemId[reference.entityId] = canonicalUrl;
-    addUniqueValue(
-      indexes.feedItemIdsByCanonical,
-      canonicalUrl,
-      reference.entityId,
-    );
   }
 }
 
@@ -203,21 +146,18 @@ export function replaceScopeInIndexes(input: {
   scopeKey: string;
   previousReferences: MixedContentReference[];
   nextReferences: MixedContentReference[];
-  feedItems: Record<string, ApplicationFeedItem>;
 }) {
-  const { indexes, scopeKey, previousReferences, nextReferences, feedItems } =
-    input;
+  const { indexes, scopeKey, previousReferences, nextReferences } = input;
   removeScopeFromIndexes(indexes, scopeKey, previousReferences);
-  addScopeToIndexes(indexes, scopeKey, nextReferences, feedItems);
+  addScopeToIndexes(indexes, scopeKey, nextReferences);
 }
 
 export function buildProjectionIndexes(
   scopes: Record<string, LoadedMixedScope>,
-  feedItems: Record<string, ApplicationFeedItem>,
 ) {
   const indexes = emptyProjectionIndexes();
   for (const [scopeKey, scope] of Object.entries(scopes)) {
-    addScopeToIndexes(indexes, scopeKey, scope.references, feedItems);
+    addScopeToIndexes(indexes, scopeKey, scope.references);
   }
   return indexes;
 }
@@ -243,11 +183,8 @@ export function isBookmarkProjectionChange(
 ) {
   if (!previousBookmark) return true;
   if (
-    previousBookmark.canonicalUrl !== bookmark.canonicalUrl ||
-    previousBookmark.platform !== bookmark.platform ||
     previousBookmark.contentType !== bookmark.contentType ||
     previousBookmark.orientation !== bookmark.orientation ||
-    previousBookmark.contentId !== bookmark.contentId ||
     previousBookmark.isSaved !== bookmark.isSaved ||
     previousBookmark.isRead !== bookmark.isRead ||
     previousBookmark.createdAt.getTime() !== bookmark.createdAt.getTime() ||
@@ -379,6 +316,7 @@ export function matchesScope(
   scope: MixedContentScope,
   views: ApplicationView[],
 ) {
+  if (scope.type === "feed") return false;
   if (scope.type === "tag") return bookmark.tagIds.includes(scope.tagId);
   const { index, matchingIds } = matchingCustomViewIds(bookmark, views);
   if (scope.viewId === UNCATEGORIZED_VIEW_ID) {
@@ -485,9 +423,6 @@ export function projectLocalMixedContentOrder(input: {
         new Set([assignment.categoryId]),
       );
   }
-  const bookmarkCanonicalUrls = new Set(
-    bookmarkValues.map((bookmark) => canonicalize(bookmark.canonicalUrl)),
-  );
   const entries: Array<{
     id: string;
     entityKind: "bookmark" | "feed-item";
@@ -498,7 +433,6 @@ export function projectLocalMixedContentOrder(input: {
   for (const id of feedItemIds) {
     const item = feedItems[id];
     if (!item) continue;
-    if (bookmarkCanonicalUrls.has(canonicalize(item.url))) continue;
     entries.push({
       id,
       entityKind: "feed-item",
@@ -576,18 +510,4 @@ export function bookmarkReference(
       : null,
     normalizedAt,
   };
-}
-
-export function collisionScopeKeys(
-  canonicalUrl: string,
-  indexes: ProjectionIndexes,
-) {
-  const keys = new Set<string>();
-  for (const feedItemId of indexes.feedItemIdsByCanonical[
-    canonicalize(canonicalUrl)
-  ] ?? []) {
-    for (const key of indexes.feedItemScopeKeys[feedItemId] ?? [])
-      keys.add(key);
-  }
-  return keys;
 }

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -56,7 +56,6 @@ export async function setMixedReadValue(input: {
     mixedContentStore.getState().reprojectUpsert({
       bookmark: optimisticBookmark,
       previousBookmark: bookmark,
-      feedItems: feedItemsStore.getState().feedItemsDict,
       views: viewsStore.getState().views,
     });
   }
@@ -86,7 +85,6 @@ export async function setMixedReadValue(input: {
       mixedContentStore.getState().reprojectUpsert({
         bookmark,
         previousBookmark: optimisticBookmark,
-        feedItems: feedItemsStore.getState().feedItemsDict,
         views: viewsStore.getState().views,
       });
     }

--- a/apps/app/src/lib/data/mixed-content/page-retention.ts
+++ b/apps/app/src/lib/data/mixed-content/page-retention.ts
@@ -28,14 +28,8 @@ export type LoadedMixedScope = {
   hasMore: boolean;
 };
 
-export type SuppressedReferences = Record<
-  string,
-  Record<string, MixedContentReference[]>
->;
-
 export type PersistedMixedContentState = {
   scopes: Record<string, LoadedMixedScope>;
-  suppressedReferences: SuppressedReferences;
 };
 
 export function mixedReferenceKey(reference: MixedContentReference) {
@@ -154,42 +148,8 @@ export function getMixedRetentionPins() {
   ]);
 }
 
-export function filterSuppressedReferences(
-  suppressedReferences: SuppressedReferences,
-  retainedKeysByScope: Record<string, ReadonlySet<string>>,
-  pinnedEntityIds: ReadonlySet<string> = new Set(),
-) {
-  return Object.fromEntries(
-    Object.entries(suppressedReferences).flatMap(
-      ([bookmarkId, referencesByScope]) => {
-        const nextReferencesByScope = Object.fromEntries(
-          Object.entries(referencesByScope).flatMap(
-            ([scopeKey, references]) => {
-              const retainedKeys = retainedKeysByScope[scopeKey];
-              const retainedReferences = retainedKeys
-                ? references.filter(
-                    (reference) =>
-                      retainedKeys.has(mixedReferenceKey(reference)) ||
-                      pinnedEntityIds.has(reference.entityId),
-                  )
-                : references;
-              return retainedReferences.length > 0
-                ? [[scopeKey, retainedReferences]]
-                : [];
-            },
-          ),
-        );
-        return Object.keys(nextReferencesByScope).length > 0
-          ? [[bookmarkId, nextReferencesByScope]]
-          : [];
-      },
-    ),
-  );
-}
-
 export function getPersistedMixedContentState(state: {
   scopes: Record<string, LoadedMixedScope>;
-  suppressedReferences: SuppressedReferences;
 }): PersistedMixedContentState {
   const scopes = Object.fromEntries(
     Object.entries(state.scopes).map(([key, scope]) => {
@@ -207,17 +167,5 @@ export function getPersistedMixedContentState(state: {
       ];
     }),
   );
-  const retainedKeysByScope = Object.fromEntries(
-    Object.entries(scopes).map(([key, scope]) => [
-      key,
-      retainedMixedReferenceKeys(scope.pages),
-    ]),
-  );
-  return {
-    scopes,
-    suppressedReferences: filterSuppressedReferences(
-      state.suppressedReferences,
-      retainedKeysByScope,
-    ),
-  };
+  return { scopes };
 }

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -12,20 +12,16 @@ import {
   bookmarkContentStatus,
   bookmarkReference,
   buildProjectionIndexes,
-  canonicalize,
-  collisionScopeKeys,
   emptyProjectionIndexes,
   getMixedScopeKey,
   isBookmarkProjectionChange,
   matchesScope,
   matchingLoadedScopeKeys,
-  referenceRecordsEqual,
   referencesEqual,
   replaceScopeInIndexes,
   uniqueReferences,
 } from "./bookmarkProjection";
 import {
-  filterSuppressedReferences,
   getMixedRetentionPins,
   getPersistedMixedContentState,
   mergeRetainedMixedPage,
@@ -38,7 +34,6 @@ import type { ProjectionIndexes } from "./bookmarkProjection";
 import type {
   LoadedMixedScope,
   PersistedMixedContentState,
-  SuppressedReferences,
 } from "./page-retention";
 import type {
   ApplicationFeedItem,
@@ -60,7 +55,6 @@ export type { LoadedMixedScope } from "./page-retention";
 type MixedContentStore = {
   scopes: Record<string, LoadedMixedScope>;
   fetchingScopes: Record<string, boolean>;
-  suppressedReferences: SuppressedReferences;
   projectionIndexes: ProjectionIndexes;
   projectionIndexesComplete: boolean;
   reset: () => void;
@@ -70,23 +64,17 @@ type MixedContentStore = {
     contentStatus: ContentStatusFilter;
     page: MixedContentPage;
     replacesScope: boolean;
-    feedItems: Record<string, ApplicationFeedItem>;
   }) => void;
   reprojectUpsert: (input: {
     bookmark: ApplicationBookmark;
     previousBookmark: ApplicationBookmark | undefined;
-    feedItems: Record<string, ApplicationFeedItem>;
     views: ApplicationView[];
   }) => LoadedMixedScope[];
-  reprojectDeletion: (input: {
-    bookmarkId: string;
-    feedItems: Record<string, ApplicationFeedItem>;
-  }) => LoadedMixedScope[];
+  reprojectDeletion: (input: { bookmarkId: string }) => LoadedMixedScope[];
   reprojectFeedItems: (input: {
     itemIds: string[];
     previousFeedItems?: Record<string, ApplicationFeedItem | undefined>;
     feedItems: Record<string, ApplicationFeedItem>;
-    bookmarks: Record<string, ApplicationBookmark>;
     views: ApplicationView[];
     feedCategories: DatabaseFeedCategory[];
   }) => LoadedMixedScope[];
@@ -118,14 +106,12 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
     (set, get) => ({
       scopes: {},
       fetchingScopes: {},
-      suppressedReferences: {},
       projectionIndexes: emptyProjectionIndexes(),
       projectionIndexesComplete: true,
       reset: () =>
         set({
           scopes: {},
           fetchingScopes: {},
-          suppressedReferences: {},
           projectionIndexes: emptyProjectionIndexes(),
           projectionIndexesComplete: true,
         }),
@@ -136,7 +122,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             [scopeKey]: isFetching,
           },
         })),
-      applyPage: ({ scope, contentStatus, page, replacesScope, feedItems }) => {
+      applyPage: ({ scope, contentStatus, page, replacesScope }) => {
         const key = getMixedScopeKey(scope, contentStatus);
         const current = get();
         const existing = current.scopes[key];
@@ -168,34 +154,28 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
         const scopes = { ...current.scopes, [key]: nextScope };
         const projectionIndexes = current.projectionIndexesComplete
           ? current.projectionIndexes
-          : buildProjectionIndexes(scopes, feedItems);
+          : buildProjectionIndexes(scopes);
         if (current.projectionIndexesComplete) {
           replaceScopeInIndexes({
             indexes: projectionIndexes,
             scopeKey: key,
             previousReferences: existing?.references ?? [],
             nextReferences: nextScope.references,
-            feedItems,
           });
         }
         set({
           scopes,
-          suppressedReferences: filterSuppressedReferences(
-            current.suppressedReferences,
-            { [key]: retainedKeys },
-            pinnedEntityIds,
-          ),
           projectionIndexes,
           projectionIndexesComplete: true,
         });
       },
-      reprojectUpsert: ({ bookmark, previousBookmark, feedItems, views }) => {
+      reprojectUpsert: ({ bookmark, previousBookmark, views }) => {
         if (!isBookmarkProjectionChange(previousBookmark, bookmark)) return [];
 
         const current = get();
         const projectionIndexes = current.projectionIndexesComplete
           ? current.projectionIndexes
-          : buildProjectionIndexes(current.scopes, feedItems);
+          : buildProjectionIndexes(current.scopes);
         const candidateKeys = new Set(
           projectionIndexes.bookmarkScopeKeys[bookmark.id] ?? [],
         );
@@ -216,25 +196,6 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           candidateKeys.add(key);
         }
 
-        const canonicalChanged =
-          previousBookmark?.canonicalUrl !== bookmark.canonicalUrl;
-        const previousSuppressed =
-          current.suppressedReferences[bookmark.id] ?? {};
-        const nextSuppressedForBookmark = canonicalChanged
-          ? {}
-          : { ...previousSuppressed };
-        if (canonicalChanged) {
-          for (const key of Object.keys(previousSuppressed)) {
-            candidateKeys.add(key);
-          }
-          for (const key of collisionScopeKeys(
-            bookmark.canonicalUrl,
-            projectionIndexes,
-          )) {
-            candidateKeys.add(key);
-          }
-        }
-
         let scopes = current.scopes;
         const affected: LoadedMixedScope[] = [];
         for (const key of candidateKeys) {
@@ -244,34 +205,6 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             (reference) =>
               reference.entityKind !== "bookmark" ||
               reference.entityId !== bookmark.id,
-          );
-          if (canonicalChanged) {
-            references = uniqueReferences([
-              ...references,
-              ...(previousSuppressed[key] ?? []),
-            ]);
-          }
-
-          const newlySuppressed = references.filter((reference) => {
-            if (reference.entityKind !== "feed-item") return false;
-            const item = feedItems[reference.entityId];
-            return item?.url
-              ? canonicalize(item.url) === bookmark.canonicalUrl
-              : false;
-          });
-          if (newlySuppressed.length > 0) {
-            nextSuppressedForBookmark[key] = uniqueReferences([
-              ...(nextSuppressedForBookmark[key] ?? []),
-              ...newlySuppressed,
-            ]);
-          }
-          const newlySuppressedIds = new Set(
-            newlySuppressed.map((reference) => reference.entityId),
-          );
-          references = references.filter(
-            (reference) =>
-              reference.entityKind !== "feed-item" ||
-              !newlySuppressedIds.has(reference.entityId),
           );
           if (
             buildContentStatusKey(bookmarkContentStatus(bookmark)) ===
@@ -306,61 +239,37 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             scopeKey: key,
             previousReferences: scopeState.references,
             nextReferences: references,
-            feedItems,
           });
           affected.push(nextScope);
         }
 
-        const suppressedReferences = { ...current.suppressedReferences };
-        if (Object.keys(nextSuppressedForBookmark).length > 0) {
-          suppressedReferences[bookmark.id] = nextSuppressedForBookmark;
-        } else {
-          delete suppressedReferences[bookmark.id];
-        }
-        const suppressionChanged = !referenceRecordsEqual(
-          previousSuppressed,
-          nextSuppressedForBookmark,
-        );
-        if (
-          affected.length > 0 ||
-          suppressionChanged ||
-          !current.projectionIndexesComplete
-        ) {
+        if (affected.length > 0 || !current.projectionIndexesComplete) {
           set({
             scopes,
-            suppressedReferences,
             projectionIndexes,
             projectionIndexesComplete: true,
           });
         }
         return affected;
       },
-      reprojectDeletion: ({ bookmarkId, feedItems }) => {
+      reprojectDeletion: ({ bookmarkId }) => {
         const current = get();
         const projectionIndexes = current.projectionIndexesComplete
           ? current.projectionIndexes
-          : buildProjectionIndexes(current.scopes, feedItems);
-        const hadSuppressedReferences =
-          current.suppressedReferences[bookmarkId] !== undefined;
-        const suppressedForBookmark =
-          current.suppressedReferences[bookmarkId] ?? {};
-        const candidateKeys = new Set([
-          ...(projectionIndexes.bookmarkScopeKeys[bookmarkId] ?? []),
-          ...Object.keys(suppressedForBookmark),
-        ]);
+          : buildProjectionIndexes(current.scopes);
+        const candidateKeys = new Set(
+          projectionIndexes.bookmarkScopeKeys[bookmarkId] ?? [],
+        );
         let scopes = current.scopes;
         const affected: LoadedMixedScope[] = [];
         for (const key of candidateKeys) {
           const scopeState = current.scopes[key];
           if (!scopeState) continue;
-          const references = uniqueReferences([
-            ...scopeState.references.filter(
-              (reference) =>
-                reference.entityKind !== "bookmark" ||
-                reference.entityId !== bookmarkId,
-            ),
-            ...(suppressedForBookmark[key] ?? []),
-          ]);
+          const references = scopeState.references.filter(
+            (reference) =>
+              reference.entityKind !== "bookmark" ||
+              reference.entityId !== bookmarkId,
+          );
           if (referencesEqual(scopeState.references, references)) continue;
 
           const nextScope = {
@@ -379,21 +288,12 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             scopeKey: key,
             previousReferences: scopeState.references,
             nextReferences: references,
-            feedItems,
           });
           affected.push(nextScope);
         }
-        const { [bookmarkId]: _removed, ...suppressedReferences } =
-          current.suppressedReferences;
-        void _removed;
-        if (
-          affected.length > 0 ||
-          hadSuppressedReferences ||
-          !current.projectionIndexesComplete
-        ) {
+        if (affected.length > 0 || !current.projectionIndexesComplete) {
           set({
             scopes,
-            suppressedReferences,
             projectionIndexes,
             projectionIndexesComplete: true,
           });
@@ -404,7 +304,6 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
         itemIds,
         previousFeedItems = {},
         feedItems,
-        bookmarks,
         views,
         feedCategories,
       }) => {
@@ -420,17 +319,10 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
         const current = get();
         const filterIndex = createFeedItemFilterIndex(feedCategories, views);
         const viewsById = new Map(views.map((view) => [view.id, view]));
-        const bookmarkByCanonical = new Map(
-          Object.values(bookmarks).map((bookmark) => [
-            canonicalize(bookmark.canonicalUrl),
-            bookmark,
-          ]),
-        );
         const projectionIndexes = current.projectionIndexesComplete
           ? current.projectionIndexes
-          : buildProjectionIndexes(current.scopes, feedItems);
+          : buildProjectionIndexes(current.scopes);
         let scopes = current.scopes;
-        let suppressedReferences = current.suppressedReferences;
         const affected: LoadedMixedScope[] = [];
 
         for (const [scopeKey, scopeState] of Object.entries(current.scopes)) {
@@ -443,7 +335,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           const doesItemBelongToScope = createFeedItemFilterPredicate({
             contentStatusFilter: scopeState.contentStatus,
             categoryFilter: scope.type === "tag" ? scope.tagId : -1,
-            feedFilter: -1,
+            feedFilter: scope.type === "feed" ? scope.feedId : -1,
             viewFilter: view,
             filterIndex,
           });
@@ -460,9 +352,6 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
               filterIndex,
             });
             const belongs = doesItemBelongToScope(item);
-            const collisionBookmark = bookmarkByCanonical.get(
-              canonicalize(item.url),
-            );
 
             references = references.filter(
               (reference) =>
@@ -475,56 +364,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
               belongs,
             );
 
-            let nextSuppressed = suppressedReferences;
-            for (const [bookmarkId, referencesByScope] of Object.entries(
-              suppressedReferences,
-            )) {
-              const scopedReferences = referencesByScope[scopeKey];
-              if (
-                !scopedReferences?.some(
-                  (reference) =>
-                    reference.entityKind === "feed-item" &&
-                    reference.entityId === itemId,
-                )
-              ) {
-                continue;
-              }
-              if (nextSuppressed === suppressedReferences) {
-                nextSuppressed = { ...suppressedReferences };
-              }
-              const nextReferencesByScope = { ...referencesByScope };
-              const remaining = scopedReferences.filter(
-                (reference) =>
-                  reference.entityKind !== "feed-item" ||
-                  reference.entityId !== itemId,
-              );
-              if (remaining.length > 0) {
-                nextReferencesByScope[scopeKey] = remaining;
-              } else {
-                delete nextReferencesByScope[scopeKey];
-              }
-              if (Object.keys(nextReferencesByScope).length > 0) {
-                nextSuppressed[bookmarkId] = nextReferencesByScope;
-              } else {
-                delete nextSuppressed[bookmarkId];
-              }
-            }
-            suppressedReferences = nextSuppressed;
-
-            if (belongs && collisionBookmark) {
-              const referencesByScope =
-                suppressedReferences[collisionBookmark.id] ?? {};
-              suppressedReferences = {
-                ...suppressedReferences,
-                [collisionBookmark.id]: {
-                  ...referencesByScope,
-                  [scopeKey]: uniqueReferences([
-                    ...(referencesByScope[scopeKey] ?? []),
-                    nextReference,
-                  ]),
-                },
-              };
-            } else if (belongs) {
+            if (belongs) {
               references = [...references, nextReference];
             }
           }
@@ -544,19 +384,13 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             scopeKey,
             previousReferences: scopeState.references,
             nextReferences: references,
-            feedItems,
           });
           affected.push(nextScope);
         }
 
-        if (
-          affected.length > 0 ||
-          suppressedReferences !== current.suppressedReferences ||
-          !current.projectionIndexesComplete
-        ) {
+        if (affected.length > 0 || !current.projectionIndexesComplete) {
           set({
             scopes,
-            suppressedReferences,
             projectionIndexes,
             projectionIndexesComplete: true,
           });
@@ -567,7 +401,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
     {
       name: "serial-mixed-content-store-v2",
       storage: createNormalizedIDBStorage({
-        recordFields: ["scopes", "suppressedReferences"],
+        recordFields: ["scopes"],
       }),
       partialize: getPersistedMixedContentState,
       merge: (persistedState, currentState) => {

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -101,7 +101,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
       itemIds: incomingItemIds,
       previousFeedItems,
       feedItems: feedItemsStore.getState().feedItemsDict,
-      bookmarks: bookmarksStore.getState().snapshot(),
       views: viewsStore.getState().views,
       feedCategories: feedCategoriesStore.getState().feedCategories,
     });
@@ -125,7 +124,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
     const affected = mixedContentStore.getState().reprojectUpsert({
       bookmark,
       previousBookmark,
-      feedItems: feedItemsStore.getState().feedItemsDict,
       views: viewsStore.getState().views,
     });
     for (const scope of affected) {
@@ -139,7 +137,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
     navigationSnapshotChanged = true;
     const affected = mixedContentStore.getState().reprojectDeletion({
       bookmarkId: bookmark.id,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     for (const scope of affected) {
       affectedScopes.set(
@@ -170,7 +167,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
         contentStatus: chunk.contentStatus,
         page: chunk.page,
         replacesScope: chunk.replacesScope,
-        feedItems: feedItemsStore.getState().feedItemsDict,
       });
       continue;
     }
@@ -191,7 +187,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
       const affected = mixedContentStore.getState().reprojectUpsert({
         bookmark: chunk.bookmark,
         previousBookmark,
-        feedItems: feedItemsStore.getState().feedItemsDict,
         views: viewsStore.getState().views,
       });
       for (const scope of affected) {
@@ -218,7 +213,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
         const affected = mixedContentStore.getState().reprojectUpsert({
           bookmark,
           previousBookmark: previousBookmarks.get(bookmark.id),
-          feedItems: feedItemsStore.getState().feedItemsDict,
           views: viewsStore.getState().views,
         });
         for (const scope of affected) {
@@ -234,7 +228,6 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
     bookmarksStore.getState().remove(chunk.id);
     const affected = mixedContentStore.getState().reprojectDeletion({
       bookmarkId: chunk.id,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     for (const scope of affected) {
       affectedScopes.set(

--- a/apps/app/src/lib/data/views/mutations.ts
+++ b/apps/app/src/lib/data/views/mutations.ts
@@ -72,7 +72,6 @@ export function useEditViewMutation() {
           mixedContentStore.getState().reprojectUpsert({
             bookmark,
             previousBookmark: undefined,
-            feedItems: feedItemsStore.getState().feedItemsDict,
             views: nextViews,
           });
         }
@@ -80,7 +79,6 @@ export function useEditViewMutation() {
         mixedContentStore.getState().reprojectFeedItems({
           itemIds: Object.keys(feedItems),
           feedItems,
-          bookmarks: bookmarksStore.getState().snapshot(),
           views: nextViews,
           feedCategories: feedCategoriesStore.getState().feedCategories,
         });

--- a/apps/app/src/lib/reconciliation/contracts.ts
+++ b/apps/app/src/lib/reconciliation/contracts.ts
@@ -15,11 +15,18 @@ export const REQUIRED_RECONCILIATION_DOMAINS = [
   "organization",
   "active-scope",
   "navigation",
-  "bookmarks",
 ] as const;
 
 export type RequiredReconciliationDomain =
   (typeof REQUIRED_RECONCILIATION_DOMAINS)[number];
+
+export const RECONCILIATION_HYDRATION_DOMAINS = [
+  ...REQUIRED_RECONCILIATION_DOMAINS,
+  "bookmarks",
+] as const;
+
+export type ReconciliationHydrationDomain =
+  (typeof RECONCILIATION_HYDRATION_DOMAINS)[number];
 
 export type AutomaticRssOwner = "client" | "background-task";
 
@@ -35,10 +42,7 @@ export type ReconciliationScopeTarget = {
 };
 
 export type ReconciliationTarget =
-  | { type: "organization" }
-  | { type: "navigation" }
-  | { type: "bookmarks" }
-  | ReconciliationScopeTarget;
+  { type: "organization" } | { type: "navigation" } | ReconciliationScopeTarget;
 
 export type OrganizationSnapshot = {
   views: ApplicationView[];
@@ -46,6 +50,7 @@ export type OrganizationSnapshot = {
   tags: DatabaseContentCategory[];
   feedTags: DatabaseFeedCategory[];
   directViewFeeds: DatabaseViewFeed[];
+  effectiveViewFeeds: Array<{ viewId: number; feedIds: number[] }>;
 };
 
 export type ReconciliationEntityKind = "bookmark" | "feed-item";
@@ -57,23 +62,12 @@ export type ReconciliationReference = {
   normalizedAt: Date;
 };
 
-export type ReconciliationCursor =
-  | {
-      type: "feed";
-      placement?: number;
-      postedAt: Date;
-      id: string;
-      isWatchedUpdatedAt?: Date | null;
-      isWatchLaterUpdatedAt?: Date | null;
-    }
-  | {
-      type: "mixed";
-      sectionPlacement: number | null;
-      normalizedAt: Date;
-      entityKind: ReconciliationEntityKind;
-      entityId: string;
-    }
-  | null;
+export type ReconciliationCursor = {
+  sectionPlacement: number | null;
+  normalizedAt: Date;
+  entityKind: ReconciliationEntityKind;
+  entityId: string;
+} | null;
 
 export type ReconciliationEntityManifestEntry = {
   id: string;
@@ -81,15 +75,8 @@ export type ReconciliationEntityManifestEntry = {
 };
 
 export type ReconciliationPageManifest = {
-  orderedRefs: ReconciliationReference[];
   feedItems: ReconciliationEntityManifestEntry[];
   bookmarks: ReconciliationEntityManifestEntry[];
-  cursor: ReconciliationCursor;
-};
-
-export type BookmarkBucketManifestEntry = {
-  bucket: number;
-  version: string;
 };
 
 export type ReconciliationScopeInput = {
@@ -101,18 +88,27 @@ export type ReconciliationScopeInput = {
 export type TargetedReconciliationInput =
   | { target: { type: "organization" } }
   | { target: { type: "navigation" } }
-  | {
-      target: { type: "bookmarks" };
-      bookmarkManifest: BookmarkBucketManifestEntry[];
-    }
   | ReconciliationScopeInput;
+
+export type ReconciliationSelectionInput =
+  | {
+      type: "cold";
+      contentStatus: ContentStatusFilter;
+      membershipRevision: number;
+    }
+  | {
+      type: "selected";
+      scope: ReconciliationScope;
+      contentStatus: ContentStatusFilter;
+      pageManifest: ReconciliationPageManifest;
+      membershipRevision: number;
+    };
 
 export type ReconciliationInput =
   | {
       type: "full";
       reconciliationId: string;
-      selectedScope: ReconciliationScopeInput;
-      bookmarkManifest: BookmarkBucketManifestEntry[];
+      selection: ReconciliationSelectionInput;
     }
   | {
       type: "targeted";
@@ -135,15 +131,12 @@ export type ActiveFirstPageResult = {
   hasMore: boolean;
 };
 
-export type BookmarkSyncPage = {
-  bucket: number;
-  version: string;
-  pageIndex: number;
-  diffs: Array<EntityDiff<ApplicationBookmark>>;
-  completesBucket: boolean;
-};
-
 export type ReconciliationDomainFailure = {
+  phase:
+    | "load-organization"
+    | "resolve-selection"
+    | "load-active-scope"
+    | "load-navigation";
   domain: RequiredReconciliationDomain;
   target?: ReconciliationScopeTarget;
   message: string;
@@ -162,10 +155,7 @@ export type ReconciliationChunk =
       type: "navigation-snapshot";
       snapshot: NavigationSnapshot;
     }
-  | {
-      type: "bookmark-sync-page";
-      page: BookmarkSyncPage;
-    }
+  | { type: "automatic-rss-owner"; owner: AutomaticRssOwner }
   | {
       type: "domain-complete";
       domain: RequiredReconciliationDomain;
@@ -180,10 +170,9 @@ export type ReconciliationChunk =
       requiredDomains: RequiredReconciliationDomain[];
     };
 
-export type ReconciliationResult = {
+export type ReconciliationStreamEvent = {
   reconciliationId: string;
-  chunks: ReconciliationChunk[];
-  automaticRssOwner?: AutomaticRssOwner;
+  chunk: ReconciliationChunk;
 };
 
 export type ReconciliationRequestIntent =
@@ -215,12 +204,7 @@ export function getReconciliationTargetKey(target: ReconciliationTarget) {
 export function getRequiredTargetsForFullReconciliation(
   selectedScope: ReconciliationScopeTarget,
 ): ReconciliationTarget[] {
-  return [
-    { type: "organization" },
-    selectedScope,
-    { type: "navigation" },
-    { type: "bookmarks" },
-  ];
+  return [{ type: "organization" }, selectedScope, { type: "navigation" }];
 }
 
 export function getTargetDomain(

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -3,10 +3,12 @@ import {
   getReconciliationTargetKey,
   getRequiredTargetsForFullReconciliation,
   getTargetDomain,
+  RECONCILIATION_HYDRATION_DOMAINS,
   REQUIRED_RECONCILIATION_DOMAINS,
 } from "./contracts";
 import type {
   AutomaticRssOwner,
+  ReconciliationHydrationDomain,
   ReconciliationRequestIntent,
   ReconciliationScopeTarget,
   ReconciliationTarget,
@@ -53,7 +55,7 @@ type BufferedAuthoritative<TAuthoritative> = {
   reconciliationId: string;
   target: ReconciliationTarget;
   targetKeys: string[];
-  requiresHydration: RequiredReconciliationDomain[];
+  requiresHydration: ReconciliationHydrationDomain[];
   payload: TAuthoritative;
 };
 
@@ -61,7 +63,7 @@ type BufferedLiveEvent<TLiveEvent> = {
   type: "live-event";
   eventId: string;
   targetKeys: string[];
-  requiresHydration: RequiredReconciliationDomain[];
+  requiresHydration: ReconciliationHydrationDomain[];
   payload: TLiveEvent;
 };
 
@@ -81,7 +83,7 @@ export type ReconciliationCoordinatorState<
   scopes: Record<string, ReconciliationTargetState>;
   domains: Record<RequiredReconciliationDomain, ReconciliationDomainState>;
   dirtyTargets: Record<string, ReconciliationTarget>;
-  hydratedDomains: Record<RequiredReconciliationDomain, boolean>;
+  hydratedDomains: Record<ReconciliationHydrationDomain, boolean>;
   bufferedApplications: Array<BufferedApplication<TAuthoritative, TLiveEvent>>;
   latestFullEpoch: FullEpoch | null;
   cacheUsableAt: number | null;
@@ -116,7 +118,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
     }
   | {
       type: "hydration-complete";
-      domain: RequiredReconciliationDomain;
+      domain: ReconciliationHydrationDomain;
     }
   | {
       type: "request-reconciliation";
@@ -126,7 +128,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       type: "authoritative-received";
       reconciliationId: string;
       target: ReconciliationTarget;
-      requiresHydration: RequiredReconciliationDomain[];
+      requiresHydration: ReconciliationHydrationDomain[];
       payload: TAuthoritative;
     }
   | {
@@ -139,7 +141,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       type: "live-event-received";
       eventId: string;
       targets: ReconciliationTarget[];
-      requiresHydration: RequiredReconciliationDomain[];
+      requiresHydration: ReconciliationHydrationDomain[];
       payload?: TLiveEvent;
       invalidates?: ReconciliationTarget[];
       repairIntent?: ReconciliationRequestIntent;
@@ -173,12 +175,12 @@ function initialDomainStates(): Record<
 }
 
 function initialHydrationState(): Record<
-  RequiredReconciliationDomain,
+  ReconciliationHydrationDomain,
   boolean
 > {
   return Object.fromEntries(
-    REQUIRED_RECONCILIATION_DOMAINS.map((domain) => [domain, false]),
-  ) as Record<RequiredReconciliationDomain, boolean>;
+    RECONCILIATION_HYDRATION_DOMAINS.map((domain) => [domain, false]),
+  ) as Record<ReconciliationHydrationDomain, boolean>;
 }
 
 export function createReconciliationCoordinatorState<
@@ -371,7 +373,7 @@ function markTargetsDirty<TAuthoritative, TLiveEvent>(
 
 function isHydrated<TAuthoritative, TLiveEvent>(
   state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
-  domains: readonly RequiredReconciliationDomain[],
+  domains: readonly ReconciliationHydrationDomain[],
 ) {
   return domains.every((domain) => state.hydratedDomains[domain]);
 }

--- a/apps/app/src/lib/reconciliation/index.ts
+++ b/apps/app/src/lib/reconciliation/index.ts
@@ -1,3 +1,4 @@
 export * from "./contracts";
 export * from "./coordinator";
 export * from "./reducers";
+export * from "./versions";

--- a/apps/app/src/lib/reconciliation/reducers.ts
+++ b/apps/app/src/lib/reconciliation/reducers.ts
@@ -1,7 +1,6 @@
 import { getReconciliationScopeKey } from "./contracts";
 import type {
   ActiveFirstPageResult,
-  BookmarkSyncPage,
   EntityDiff,
   OrganizationSnapshot,
   ReconciliationCursor,
@@ -18,20 +17,12 @@ export type ReconciledScope = {
   membershipRevision: number;
 };
 
-type PendingBookmarkBucket = {
-  version: string;
-  nextPageIndex: number;
-  diffs: Array<EntityDiff<ApplicationBookmark>>;
-};
-
 export type ReconciliationDataState = {
   organization: OrganizationSnapshot | null;
   navigation: NavigationSnapshot | null;
   feedItems: Record<string, ApplicationFeedItem>;
   bookmarks: Record<string, ApplicationBookmark>;
   scopes: Record<string, ReconciledScope>;
-  bookmarkBucketVersions: Record<number, string>;
-  pendingBookmarkBuckets: Record<number, PendingBookmarkBucket>;
 };
 
 export type ReconciliationDataEvent =
@@ -41,8 +32,7 @@ export type ReconciliationDataEvent =
       type: "apply-active-first-page";
       page: ActiveFirstPageResult;
       currentMembershipRevision: number;
-    }
-  | { type: "apply-bookmark-sync-page"; page: BookmarkSyncPage };
+    };
 
 export type ReconciliationDataTransition = {
   state: ReconciliationDataState;
@@ -58,8 +48,6 @@ export function createReconciliationDataState(
     feedItems: {},
     bookmarks: {},
     scopes: {},
-    bookmarkBucketVersions: {},
-    pendingBookmarkBuckets: {},
     ...initial,
   };
 }
@@ -109,56 +97,6 @@ function applyActiveFirstPage(
   };
 }
 
-function applyBookmarkSyncPage(
-  state: ReconciliationDataState,
-  page: BookmarkSyncPage,
-): ReconciliationDataTransition {
-  const current = state.pendingBookmarkBuckets[page.bucket];
-  if (page.pageIndex !== 0 && !current) return { state, applied: false };
-  if (
-    page.pageIndex !== 0 &&
-    current &&
-    (current.version !== page.version ||
-      current.nextPageIndex !== page.pageIndex)
-  ) {
-    return { state, applied: false };
-  }
-  const pending: PendingBookmarkBucket = {
-    version: page.version,
-    nextPageIndex: page.pageIndex + 1,
-    diffs: [
-      ...(page.pageIndex === 0 ? [] : (current?.diffs ?? [])),
-      ...page.diffs,
-    ],
-  };
-  if (!page.completesBucket) {
-    return {
-      applied: true,
-      state: {
-        ...state,
-        pendingBookmarkBuckets: {
-          ...state.pendingBookmarkBuckets,
-          [page.bucket]: pending,
-        },
-      },
-    };
-  }
-  const pendingBookmarkBuckets = { ...state.pendingBookmarkBuckets };
-  delete pendingBookmarkBuckets[page.bucket];
-  return {
-    applied: true,
-    state: {
-      ...state,
-      bookmarks: applyEntityDiffs(state.bookmarks, pending.diffs),
-      bookmarkBucketVersions: {
-        ...state.bookmarkBucketVersions,
-        [page.bucket]: page.version,
-      },
-      pendingBookmarkBuckets,
-    },
-  };
-}
-
 export function reduceReconciliationData(
   state: ReconciliationDataState,
   event: ReconciliationDataEvent,
@@ -180,7 +118,5 @@ export function reduceReconciliationData(
         event.page,
         event.currentMembershipRevision,
       );
-    case "apply-bookmark-sync-page":
-      return applyBookmarkSyncPage(state, event.page);
   }
 }

--- a/apps/app/src/lib/reconciliation/versions.ts
+++ b/apps/app/src/lib/reconciliation/versions.ts
@@ -1,0 +1,20 @@
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import { bookmarkManifestValue } from "~/lib/data/bookmarks/manifest";
+
+export function getFeedItemReconciliationVersion(item: ApplicationFeedItem) {
+  return [
+    item.contentHash ?? "",
+    item.updatedAt.toISOString(),
+    item.isWatchedUpdatedAt?.toISOString() ?? "",
+    item.isWatchLaterUpdatedAt?.toISOString() ?? "",
+    item.progress,
+    item.duration,
+  ].join("|");
+}
+
+export function getBookmarkReconciliationVersion(
+  bookmark: ApplicationBookmark,
+) {
+  return bookmarkManifestValue(bookmark);
+}

--- a/apps/app/src/server/api/routers/initialRouter.ts
+++ b/apps/app/src/server/api/routers/initialRouter.ts
@@ -96,6 +96,18 @@ import {
   MAX_BULK_MUTATION_ITEMS,
 } from "~/lib/schemas/bulk";
 import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
+import { reconciliationInputSchema } from "~/server/reconciliation/input";
+import { reconcileApplicationState as streamApplicationReconciliation } from "~/server/reconciliation";
+
+export const reconcileApplicationState = protectedProcedure
+  .input(reconciliationInputSchema)
+  .handler(async function* ({ context, input }) {
+    yield* streamApplicationReconciliation({
+      database: context.db,
+      userId: context.user.id,
+      request: input,
+    });
+  });
 
 export type PaginationCursor = {
   placement?: number;

--- a/apps/app/src/server/api/routers/mixedContentRouter.ts
+++ b/apps/app/src/server/api/routers/mixedContentRouter.ts
@@ -27,6 +27,7 @@ const clientIdSchema = z
 
 const scopeSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("view"), viewId: z.number().int() }),
+  z.object({ type: z.literal("feed"), feedId: z.number().int() }),
   z.object({ type: z.literal("tag"), tagId: z.number().int() }),
 ]);
 

--- a/apps/app/src/server/mixed-content/projection.ts
+++ b/apps/app/src/server/mixed-content/projection.ts
@@ -8,6 +8,7 @@ import {
   queryFeedCandidates,
 } from "./projection/candidates";
 import { loadScopeData } from "./projection/scope";
+import type { ScopeData } from "./projection/scope";
 import type { ContentStatusFilter } from "~/lib/content-status";
 import type { db as defaultDatabase } from "~/server/db";
 import type { ApplicationFeedItem, DatabaseBookmark } from "~/server/db/schema";
@@ -16,7 +17,9 @@ import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
 type MixedContentDatabase = typeof defaultDatabase;
 
 export type MixedContentScope =
-  { type: "view"; viewId: number } | { type: "tag"; tagId: number };
+  | { type: "view"; viewId: number }
+  | { type: "feed"; feedId: number }
+  | { type: "tag"; tagId: number };
 
 export type MixedContentEntityKind = "bookmark" | "feed-item";
 
@@ -64,6 +67,20 @@ export async function queryMixedContentPage(input: {
     throw new Error("Mixed-content page limit must be between 1 and 500");
   }
   const scopeData = await loadScopeData(input);
+  return queryResolvedMixedContentPage({ ...input, scopeData });
+}
+
+export async function queryResolvedMixedContentPage(input: {
+  database: MixedContentDatabase;
+  userId: string;
+  scope: MixedContentScope;
+  scopeData: ScopeData;
+  contentStatus: ContentStatusFilter;
+  sectionPlacement?: number | null;
+  cursor?: MixedContentCursor;
+  limit: number;
+}): Promise<MixedContentPage> {
+  const { scopeData } = input;
   if (!scopeData.valid) {
     return {
       references: [],

--- a/apps/app/src/server/mixed-content/projection/candidates.ts
+++ b/apps/app/src/server/mixed-content/projection/candidates.ts
@@ -3,11 +3,9 @@ import {
   asc,
   desc,
   eq,
-  exists,
   getTableColumns,
   gt,
   lt,
-  not,
   or,
   sql,
 } from "drizzle-orm";
@@ -222,21 +220,6 @@ export async function queryFeedCandidates(input: {
   const placement = input.hasSections
     ? feedSectionPlacement((input.scope as { viewId: number }).viewId)
     : sql<number>`CAST(0 AS INTEGER)`;
-  const normalizedFeedUrl = sql<string>`COALESCE(
-    ${feedItems.normalizedUrl},
-    ${feedItems.url}
-  )`;
-  const canonicalBookmark = exists(
-    input.database
-      .select({ value: sql<number>`1` })
-      .from(bookmarks)
-      .where(
-        and(
-          eq(bookmarks.userId, input.userId),
-          eq(bookmarks.canonicalUrl, normalizedFeedUrl),
-        ),
-      ),
-  );
   const rows = await input.database
     .select({
       item: applicationFeedItemColumns,
@@ -254,7 +237,6 @@ export async function queryFeedCandidates(input: {
         input.sectionPlacement === undefined || !input.hasSections
           ? undefined
           : eq(placement, input.sectionPlacement),
-        not(canonicalBookmark),
         cursorCondition({
           cursor: input.cursor,
           placement,

--- a/apps/app/src/server/mixed-content/projection/scope.ts
+++ b/apps/app/src/server/mixed-content/projection/scope.ts
@@ -41,6 +41,20 @@ export async function loadScopeData(input: {
   scope: MixedContentScope;
 }): Promise<ScopeData> {
   const { database, userId, scope } = input;
+  if (scope.type === "feed") {
+    const feed = await database
+      .select({ id: feeds.id })
+      .from(feeds)
+      .where(and(eq(feeds.id, scope.feedId), eq(feeds.userId, userId)))
+      .limit(1);
+    return {
+      valid: feed.length === 1,
+      targetView: null,
+      categoryIds: [],
+      directFeedIds: [],
+      sections: [],
+    };
+  }
   if (scope.type === "tag") {
     const tag = await database
       .select({ id: contentCategories.id })
@@ -202,6 +216,7 @@ export function feedScopeCondition(input: {
   scopeData: ScopeData;
 }) {
   const { database, userId, scope, scopeData } = input;
+  if (scope.type === "feed") return eq(feeds.id, scope.feedId);
   if (scope.type === "tag") {
     return exists(
       database
@@ -262,6 +277,7 @@ export function bookmarkScopeCondition(input: {
   scopeData: ScopeData;
 }) {
   const { database, userId, scope, scopeData } = input;
+  if (scope.type === "feed") return sql`0`;
   if (scope.type === "tag") {
     return exists(
       database

--- a/apps/app/src/server/navigation/snapshot.ts
+++ b/apps/app/src/server/navigation/snapshot.ts
@@ -105,24 +105,6 @@ function availabilityRecord(rows: AvailabilityRow[]) {
   ) as Record<number, NavigationAvailability>;
 }
 
-function canonicalBookmarkExists(database: NavigationDatabase, userId: string) {
-  const normalizedFeedUrl = sql<string>`COALESCE(
-    ${feedItems.normalizedUrl},
-    ${feedItems.url}
-  )`;
-  return exists(
-    database
-      .select({ value: sql<number>`1` })
-      .from(bookmarks)
-      .where(
-        and(
-          eq(bookmarks.userId, userId),
-          eq(bookmarks.canonicalUrl, normalizedFeedUrl),
-        ),
-      ),
-  );
-}
-
 function feedCompatibleWithView() {
   return or(
     and(
@@ -178,7 +160,6 @@ function feedExistsForViewFeed(input: {
             isRead: feedItems.isWatched,
             isLater: feedItems.isWatchLater,
           }),
-          not(canonicalBookmarkExists(input.database, input.userId)),
         ),
       ),
   );
@@ -242,7 +223,6 @@ function feedExistsForView(input: {
             isRead: feedItems.isWatched,
             isLater: feedItems.isWatchLater,
           }),
-          not(canonicalBookmarkExists(input.database, input.userId)),
         ),
       ),
   );
@@ -358,7 +338,6 @@ async function queryViewAvailability(input: {
                 isRead: feedItems.isWatched,
                 isLater: feedItems.isWatchLater,
               }),
-              not(canonicalBookmarkExists(input.database, input.userId)),
             ),
           ),
       ),
@@ -411,7 +390,6 @@ async function queryTagAvailability(input: {
               isRead: feedItems.isWatched,
               isLater: feedItems.isWatchLater,
             }),
-            not(canonicalBookmarkExists(input.database, input.userId)),
           ),
         ),
     );
@@ -576,7 +554,6 @@ async function queryUncategorizedViewFeedAvailability(input: {
               isRead: feedItems.isWatched,
               isLater: feedItems.isWatchLater,
             }),
-            not(canonicalBookmarkExists(input.database, input.userId)),
           ),
         ),
     );

--- a/apps/app/src/server/reconciliation/index.ts
+++ b/apps/app/src/server/reconciliation/index.ts
@@ -1,0 +1,432 @@
+import { loadOrganizationSnapshot } from "./organization";
+import type {
+  ActiveFirstPageResult,
+  EntityDiff,
+  OrganizationSnapshot,
+  ReconciliationChunk,
+  ReconciliationDomainFailure,
+  ReconciliationEntityManifestEntry,
+  ReconciliationInput,
+  ReconciliationPageManifest,
+  ReconciliationScope,
+  ReconciliationScopeInput,
+  ReconciliationScopeTarget,
+  ReconciliationStreamEvent,
+  RequiredReconciliationDomain,
+} from "~/lib/reconciliation";
+import type { db as defaultDatabase } from "~/server/db";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ScopeData } from "~/server/mixed-content/projection/scope";
+import type {
+  ApplicationBookmark,
+  MixedContentPage,
+} from "~/server/mixed-content/projection";
+import {
+  getBookmarkReconciliationVersion,
+  getFeedItemReconciliationVersion,
+  REQUIRED_RECONCILIATION_DOMAINS,
+} from "~/lib/reconciliation";
+import { env } from "~/env";
+import {
+  queryMixedContentPage,
+  queryResolvedMixedContentPage,
+} from "~/server/mixed-content/projection";
+import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
+import { getUserPlanLimits } from "~/server/subscriptions/helpers";
+import { ITEMS_PER_PAGE } from "~/server/api/constants";
+import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
+
+type ReconciliationDatabase = typeof defaultDatabase;
+
+type Outcome<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+function outcome<T>(promise: Promise<T>): Promise<Outcome<T>> {
+  return promise.then(
+    (value) => ({ ok: true, value }),
+    (error: unknown) => ({ ok: false, error }),
+  );
+}
+
+function message(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "Unknown reconciliation error";
+}
+
+function event(
+  reconciliationId: string,
+  chunk: ReconciliationChunk,
+): ReconciliationStreamEvent {
+  return { reconciliationId, chunk };
+}
+
+function failure(input: ReconciliationDomainFailure): ReconciliationChunk {
+  return { type: "domain-error", failure: input };
+}
+
+function scopeDataFromOrganization(
+  organization: OrganizationSnapshot,
+  scope: ReconciliationScope,
+): ScopeData {
+  if (scope.type === "feed") {
+    return {
+      valid: organization.feeds.some(({ id }) => id === scope.feedId),
+      targetView: null,
+      categoryIds: [],
+      directFeedIds: [],
+      sections: [],
+    };
+  }
+  if (scope.type === "tag") {
+    return {
+      valid: organization.tags.some(({ id }) => id === scope.tagId),
+      targetView: null,
+      categoryIds: [],
+      directFeedIds: [],
+      sections: [],
+    };
+  }
+  if (scope.viewId === UNCATEGORIZED_VIEW_ID) {
+    return {
+      valid: true,
+      targetView: null,
+      categoryIds: [],
+      directFeedIds: [],
+      sections: [],
+    };
+  }
+  const view = organization.views.find(({ id }) => id === scope.viewId);
+  return {
+    valid: view !== undefined,
+    targetView: view ?? null,
+    categoryIds: view?.categoryIds ?? [],
+    directFeedIds: view?.feedIds ?? [],
+    sections: view?.viewSections ?? [],
+  };
+}
+
+function entityDiffs<TEntity extends { id: string }>(input: {
+  entities: TEntity[];
+  manifest: ReconciliationEntityManifestEntry[];
+  version: (entity: TEntity) => string;
+}): Array<EntityDiff<TEntity>> {
+  const clientVersions = new Map(
+    input.manifest.map(({ id, version }) => [id, version]),
+  );
+  return input.entities.map((entity) =>
+    clientVersions.get(entity.id) === input.version(entity)
+      ? { status: "unchanged", id: entity.id }
+      : { status: "upsert", entity },
+  );
+}
+
+function activeFirstPage(input: {
+  scopeInput: ReconciliationScopeInput;
+  page: MixedContentPage;
+}): ActiveFirstPageResult {
+  return {
+    target: input.scopeInput.target,
+    membershipRevision: input.scopeInput.membershipRevision,
+    orderedRefs: input.page.references,
+    feedItemDiffs: entityDiffs<ApplicationFeedItem>({
+      entities: input.page.feedItems,
+      manifest: input.scopeInput.pageManifest.feedItems,
+      version: getFeedItemReconciliationVersion,
+    }),
+    bookmarkDiffs: entityDiffs<ApplicationBookmark>({
+      entities: input.page.bookmarks,
+      manifest: input.scopeInput.pageManifest.bookmarks,
+      version: getBookmarkReconciliationVersion,
+    }),
+    cursor: input.page.cursor,
+    hasMore: input.page.hasMore,
+  };
+}
+
+function emptyPageManifest(): ReconciliationPageManifest {
+  return {
+    feedItems: [],
+    bookmarks: [],
+  };
+}
+
+function resolveFullScope(
+  request: Extract<ReconciliationInput, { type: "full" }>,
+  organization: OrganizationSnapshot,
+): ReconciliationScopeInput | null {
+  if (request.selection.type === "selected") {
+    const target: ReconciliationScopeTarget = {
+      type: "scope",
+      scope: request.selection.scope,
+      contentStatus: request.selection.contentStatus,
+    };
+    return scopeDataFromOrganization(organization, target.scope).valid
+      ? {
+          target,
+          pageManifest: request.selection.pageManifest,
+          membershipRevision: request.selection.membershipRevision,
+        }
+      : null;
+  }
+  const view = organization.views[0];
+  if (!view) return null;
+  return {
+    target: {
+      type: "scope",
+      scope: { type: "view", viewId: view.id },
+      contentStatus: request.selection.contentStatus,
+    },
+    pageManifest: emptyPageManifest(),
+    membershipRevision: request.selection.membershipRevision,
+  };
+}
+
+async function resolveAutomaticRssOwner(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+}) {
+  const limits = await getUserPlanLimits(input.database, input.userId);
+  return env.BACKGROUND_REFRESH_ENABLED &&
+    limits.backgroundRefreshIntervalMs !== null
+    ? ("background-task" as const)
+    : ("client" as const);
+}
+
+async function* reconcileFull(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+  request: Extract<ReconciliationInput, { type: "full" }>;
+}): AsyncGenerator<ReconciliationStreamEvent> {
+  const { database, userId, request } = input;
+  const organizationPromise = outcome(
+    loadOrganizationSnapshot({ database, userId }),
+  );
+  const navigationPromise = outcome(
+    queryNavigationSnapshot({ database, userId }),
+  );
+  const ownerPromise = outcome(resolveAutomaticRssOwner({ database, userId }));
+
+  const organization = await organizationPromise;
+  if (!organization.ok) {
+    yield event(
+      request.reconciliationId,
+      failure({
+        phase: "load-organization",
+        domain: "organization",
+        message: message(organization.error),
+      }),
+    );
+    return;
+  }
+  yield event(request.reconciliationId, {
+    type: "organization-snapshot",
+    snapshot: organization.value,
+  });
+  yield event(request.reconciliationId, {
+    type: "domain-complete",
+    domain: "organization",
+  });
+
+  const scopeInput = resolveFullScope(request, organization.value);
+  if (!scopeInput) {
+    const selectedTarget =
+      request.selection.type === "selected"
+        ? {
+            type: "scope" as const,
+            scope: request.selection.scope,
+            contentStatus: request.selection.contentStatus,
+          }
+        : undefined;
+    yield event(
+      request.reconciliationId,
+      failure({
+        phase: "resolve-selection",
+        domain: "active-scope",
+        target: selectedTarget,
+        message: "The selected reconciliation scope is unavailable",
+      }),
+    );
+    return;
+  }
+
+  const page = await outcome(
+    queryResolvedMixedContentPage({
+      database,
+      userId,
+      scope: scopeInput.target.scope,
+      scopeData: scopeDataFromOrganization(
+        organization.value,
+        scopeInput.target.scope,
+      ),
+      contentStatus: scopeInput.target.contentStatus,
+      limit: ITEMS_PER_PAGE,
+    }),
+  );
+  if (!page.ok) {
+    yield event(
+      request.reconciliationId,
+      failure({
+        phase: "load-active-scope",
+        domain: "active-scope",
+        target: scopeInput.target,
+        message: message(page.error),
+      }),
+    );
+    return;
+  }
+  yield event(request.reconciliationId, {
+    type: "active-first-page",
+    page: activeFirstPage({ scopeInput, page: page.value }),
+  });
+  yield event(request.reconciliationId, {
+    type: "domain-complete",
+    domain: "active-scope",
+    target: scopeInput.target,
+  });
+
+  const owner = await ownerPromise;
+  yield event(request.reconciliationId, {
+    type: "automatic-rss-owner",
+    owner: owner.ok ? owner.value : "client",
+  });
+
+  const navigation = await navigationPromise;
+  if (!navigation.ok) {
+    yield event(
+      request.reconciliationId,
+      failure({
+        phase: "load-navigation",
+        domain: "navigation",
+        message: message(navigation.error),
+      }),
+    );
+    return;
+  }
+  yield event(request.reconciliationId, {
+    type: "navigation-snapshot",
+    snapshot: navigation.value,
+  });
+  yield event(request.reconciliationId, {
+    type: "domain-complete",
+    domain: "navigation",
+  });
+  yield event(request.reconciliationId, {
+    type: "epoch-complete",
+    requiredDomains: [...REQUIRED_RECONCILIATION_DOMAINS],
+  });
+}
+
+async function* reconcileTargeted(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+  request: Extract<ReconciliationInput, { type: "targeted" }>;
+}): AsyncGenerator<ReconciliationStreamEvent> {
+  const { database, userId, request } = input;
+  const navigationRequested = request.targets.some(
+    ({ target }) => target.type === "navigation",
+  );
+  const completedDomains = new Set<RequiredReconciliationDomain>();
+
+  for (const target of request.targets) {
+    if (target.target.type === "navigation") continue;
+    if (target.target.type === "organization") {
+      const organization = await outcome(
+        loadOrganizationSnapshot({ database, userId }),
+      );
+      if (!organization.ok) {
+        yield event(
+          request.reconciliationId,
+          failure({
+            phase: "load-organization",
+            domain: "organization",
+            message: message(organization.error),
+          }),
+        );
+        return;
+      }
+      yield event(request.reconciliationId, {
+        type: "organization-snapshot",
+        snapshot: organization.value,
+      });
+      yield event(request.reconciliationId, {
+        type: "domain-complete",
+        domain: "organization",
+      });
+      completedDomains.add("organization");
+      continue;
+    }
+    if (!("pageManifest" in target)) continue;
+
+    const page = await outcome(
+      queryMixedContentPage({
+        database,
+        userId,
+        scope: target.target.scope,
+        contentStatus: target.target.contentStatus,
+        limit: ITEMS_PER_PAGE,
+      }),
+    );
+    if (!page.ok) {
+      yield event(
+        request.reconciliationId,
+        failure({
+          phase: "load-active-scope",
+          domain: "active-scope",
+          target: target.target,
+          message: message(page.error),
+        }),
+      );
+      return;
+    }
+    yield event(request.reconciliationId, {
+      type: "active-first-page",
+      page: activeFirstPage({ scopeInput: target, page: page.value }),
+    });
+    yield event(request.reconciliationId, {
+      type: "domain-complete",
+      domain: "active-scope",
+      target: target.target,
+    });
+    completedDomains.add("active-scope");
+  }
+
+  if (navigationRequested) {
+    const navigation = await outcome(
+      queryNavigationSnapshot({ database, userId }),
+    );
+    if (!navigation.ok) {
+      yield event(
+        request.reconciliationId,
+        failure({
+          phase: "load-navigation",
+          domain: "navigation",
+          message: message(navigation.error),
+        }),
+      );
+      return;
+    }
+    yield event(request.reconciliationId, {
+      type: "navigation-snapshot",
+      snapshot: navigation.value,
+    });
+    yield event(request.reconciliationId, {
+      type: "domain-complete",
+      domain: "navigation",
+    });
+    completedDomains.add("navigation");
+  }
+  yield event(request.reconciliationId, {
+    type: "epoch-complete",
+    requiredDomains: [...completedDomains],
+  });
+}
+
+export function reconcileApplicationState(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+  request: ReconciliationInput;
+}): AsyncGenerator<ReconciliationStreamEvent> {
+  return input.request.type === "full"
+    ? reconcileFull({ ...input, request: input.request })
+    : reconcileTargeted({ ...input, request: input.request });
+}

--- a/apps/app/src/server/reconciliation/input.ts
+++ b/apps/app/src/server/reconciliation/input.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { ITEMS_PER_PAGE } from "~/server/api/constants";
+import { contentStatusFilterSchema } from "~/lib/content-status";
+
+export const MAX_RECONCILIATION_TARGETS = 16;
+export const RECONCILIATION_REQUEST_BUDGET_BYTES = 128 * 1_024;
+
+const reconciliationIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
+const entityIdSchema = z.string().min(1).max(256);
+
+const scopeSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("view"), viewId: z.number().int() }),
+  z.object({ type: z.literal("feed"), feedId: z.number().int() }),
+  z.object({ type: z.literal("tag"), tagId: z.number().int() }),
+]);
+
+const scopeTargetSchema = z.object({
+  type: z.literal("scope"),
+  scope: scopeSchema,
+  contentStatus: contentStatusFilterSchema,
+});
+
+const entityManifestSchema = z
+  .array(
+    z.object({
+      id: entityIdSchema,
+      version: z.string().max(512),
+    }),
+  )
+  .max(ITEMS_PER_PAGE);
+
+const pageManifestSchema = z.object({
+  feedItems: entityManifestSchema,
+  bookmarks: entityManifestSchema,
+});
+
+const scopeInputSchema = z.object({
+  target: scopeTargetSchema,
+  pageManifest: pageManifestSchema,
+  membershipRevision: z.number().int().nonnegative(),
+});
+
+const selectionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("cold"),
+    contentStatus: contentStatusFilterSchema,
+    membershipRevision: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal("selected"),
+    scope: scopeSchema,
+    contentStatus: contentStatusFilterSchema,
+    pageManifest: pageManifestSchema,
+    membershipRevision: z.number().int().nonnegative(),
+  }),
+]);
+
+const targetSchema = z.union([
+  z.object({ target: z.object({ type: z.literal("organization") }) }),
+  z.object({ target: z.object({ type: z.literal("navigation") }) }),
+  scopeInputSchema,
+]);
+
+export const reconciliationInputSchema = z
+  .discriminatedUnion("type", [
+    z.object({
+      type: z.literal("full"),
+      reconciliationId: reconciliationIdSchema,
+      selection: selectionSchema,
+    }),
+    z.object({
+      type: z.literal("targeted"),
+      reconciliationId: reconciliationIdSchema,
+      targets: z.array(targetSchema).max(MAX_RECONCILIATION_TARGETS),
+    }),
+  ])
+  .refine(
+    (input) =>
+      new TextEncoder().encode(JSON.stringify(input)).byteLength <=
+      RECONCILIATION_REQUEST_BUDGET_BYTES,
+    "Reconciliation request exceeds the request budget",
+  );

--- a/apps/app/src/server/reconciliation/organization.ts
+++ b/apps/app/src/server/reconciliation/organization.ts
@@ -1,0 +1,219 @@
+import { asc, eq, inArray } from "drizzle-orm";
+import type { OrganizationSnapshot } from "~/lib/reconciliation";
+import type {
+  ApplicationFeed,
+  ApplicationView,
+  DatabaseContentCategory,
+  DatabaseFeedCategory,
+  DatabaseViewCategory,
+  DatabaseViewFeed,
+  DatabaseViewSection,
+} from "~/server/db/schema";
+import type { db as defaultDatabase } from "~/server/db";
+import { isFeedCompatibleWithContentFilter } from "~/lib/data/feed-items/filters";
+import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
+import { sortViewsByPlacement } from "~/lib/data/views/utils";
+import { parseArrayOfSchema } from "~/lib/schemas/utils";
+import { buildUncategorizedView } from "~/server/api/utils/buildUncategorizedView";
+import {
+  contentCategories,
+  feedCategories,
+  feeds,
+  feedsSchema,
+  viewCategories,
+  viewFeeds,
+  views,
+  viewSections,
+} from "~/server/db/schema";
+
+type ReconciliationDatabase = typeof defaultDatabase;
+
+type OrganizationRows = {
+  views: Array<typeof views.$inferSelect>;
+  feeds: Array<typeof feeds.$inferSelect>;
+  tags: DatabaseContentCategory[];
+  feedTags: DatabaseFeedCategory[];
+  viewTags: DatabaseViewCategory[];
+  directViewFeeds: DatabaseViewFeed[];
+  viewSections: DatabaseViewSection[];
+};
+
+type CustomViewMembership = {
+  view: ApplicationView;
+  feedIds: Set<number>;
+  categoryIds: Set<number>;
+};
+
+function buildFeedTagsByFeed(feedTags: DatabaseFeedCategory[]) {
+  const result = new Map<number, number[]>();
+  for (const assignment of feedTags) {
+    result.set(assignment.feedId, [
+      ...(result.get(assignment.feedId) ?? []),
+      assignment.categoryId,
+    ]);
+  }
+  return result;
+}
+
+function buildApplicationViews(userId: string, rows: OrganizationRows) {
+  const customViews: ApplicationView[] = rows.views.map((view) => ({
+    ...view,
+    isDefault: false,
+    categoryIds: rows.viewTags.flatMap((assignment) =>
+      assignment.viewId === view.id && assignment.categoryId !== null
+        ? [assignment.categoryId]
+        : [],
+    ),
+    feedIds: rows.directViewFeeds.flatMap((assignment) =>
+      assignment.viewId === view.id ? [assignment.feedId] : [],
+    ),
+    viewSections: rows.viewSections
+      .filter((section) => section.viewId === view.id)
+      .map((section) => ({
+        ...section,
+        itemType: section.itemType as "tag" | "feed",
+      })),
+  }));
+  return {
+    customViews,
+    allViews: sortViewsByPlacement([
+      ...customViews,
+      buildUncategorizedView(userId, rows.tags, customViews),
+    ]),
+  };
+}
+
+function effectiveFeedIds(input: {
+  view: ApplicationView;
+  applicationFeeds: ApplicationFeed[];
+  feedTagsByFeed: Map<number, number[]>;
+  customMemberships: CustomViewMembership[];
+}) {
+  const { view, applicationFeeds, feedTagsByFeed, customMemberships } = input;
+  const customDirectFeedIds = new Set(
+    customMemberships.flatMap(({ view: candidate }) => candidate.feedIds),
+  );
+  const matching = new Set<number>(
+    view.id === UNCATEGORIZED_VIEW_ID ? [] : view.feedIds,
+  );
+
+  for (const feed of applicationFeeds) {
+    if (matching.has(feed.id)) continue;
+    if (!isFeedCompatibleWithContentFilter(feed.platform, view.contentFilter)) {
+      continue;
+    }
+    const tagIds = feedTagsByFeed.get(feed.id) ?? [];
+    const tagIdSet = new Set(tagIds);
+    if (view.id === UNCATEGORIZED_VIEW_ID) {
+      if (customDirectFeedIds.has(feed.id)) continue;
+      const belongsToCompatibleCustomView = customMemberships.some(
+        (membership) =>
+          isFeedCompatibleWithContentFilter(
+            feed.platform,
+            membership.view.contentFilter,
+          ) &&
+          (membership.feedIds.has(feed.id) ||
+            tagIds.some((id) => membership.categoryIds.has(id))),
+      );
+      if (!belongsToCompatibleCustomView) matching.add(feed.id);
+      continue;
+    }
+    if (
+      (view.feedIds.length === 0 && view.categoryIds.length === 0) ||
+      view.categoryIds.some((id) => tagIdSet.has(id))
+    ) {
+      matching.add(feed.id);
+    }
+  }
+  return [...matching];
+}
+
+async function loadOrganizationRows(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+}): Promise<OrganizationRows> {
+  const [viewRows, feedRows, tags] = await Promise.all([
+    input.database
+      .select()
+      .from(views)
+      .where(eq(views.userId, input.userId))
+      .orderBy(asc(views.placement)),
+    input.database.query.feeds.findMany({
+      where: eq(feeds.userId, input.userId),
+    }),
+    input.database
+      .select()
+      .from(contentCategories)
+      .where(eq(contentCategories.userId, input.userId))
+      .orderBy(asc(contentCategories.name)),
+  ]);
+  const viewIds = viewRows.map(({ id }) => id);
+  const tagIds = tags.map(({ id }) => id);
+  const [feedTags, viewTags, directViewFeeds, sectionRows] = await Promise.all([
+    tagIds.length > 0
+      ? input.database
+          .select()
+          .from(feedCategories)
+          .where(inArray(feedCategories.categoryId, tagIds))
+      : Promise.resolve([]),
+    viewIds.length > 0
+      ? input.database
+          .select()
+          .from(viewCategories)
+          .where(inArray(viewCategories.viewId, viewIds))
+      : Promise.resolve([]),
+    viewIds.length > 0
+      ? input.database
+          .select()
+          .from(viewFeeds)
+          .where(inArray(viewFeeds.viewId, viewIds))
+      : Promise.resolve([]),
+    viewIds.length > 0
+      ? input.database
+          .select()
+          .from(viewSections)
+          .where(inArray(viewSections.viewId, viewIds))
+          .orderBy(asc(viewSections.placement))
+      : Promise.resolve([]),
+  ]);
+  return {
+    views: viewRows,
+    feeds: feedRows,
+    tags,
+    feedTags,
+    viewTags,
+    directViewFeeds,
+    viewSections: sectionRows,
+  };
+}
+
+export async function loadOrganizationSnapshot(input: {
+  database: ReconciliationDatabase;
+  userId: string;
+}): Promise<OrganizationSnapshot> {
+  const rows = await loadOrganizationRows(input);
+  const { customViews, allViews } = buildApplicationViews(input.userId, rows);
+  const applicationFeeds = parseArrayOfSchema(rows.feeds, feedsSchema);
+  const feedTagsByFeed = buildFeedTagsByFeed(rows.feedTags);
+  const customMemberships = customViews.map((view) => ({
+    view,
+    feedIds: new Set(view.feedIds),
+    categoryIds: new Set(view.categoryIds),
+  }));
+  return {
+    views: allViews,
+    feeds: applicationFeeds,
+    tags: rows.tags,
+    feedTags: rows.feedTags,
+    directViewFeeds: rows.directViewFeeds,
+    effectiveViewFeeds: allViews.map((view) => ({
+      viewId: view.id,
+      feedIds: effectiveFeedIds({
+        view,
+        applicationFeeds,
+        feedTagsByFeed,
+        customMemberships,
+      }),
+    })),
+  };
+}

--- a/apps/app/src/server/rss/fetchFeeds.ts
+++ b/apps/app/src/server/rss/fetchFeeds.ts
@@ -181,7 +181,7 @@ async function insertFeedItems(
         normalizedUrl = normalizedBookmarkUrlOverride(item.url);
       } catch {
         // Invalid item URLs retain their existing Feed behavior but cannot
-        // participate in Bookmark canonical suppression.
+        // keep the normalized URL stable for identity and cache matching.
       }
       return {
         feedId,

--- a/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
+++ b/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
@@ -117,7 +117,6 @@ function loadScope(
     contentStatus,
     page: page(references),
     replacesScope: true,
-    feedItems: feedItemsStore.getState().feedItemsDict,
   });
 }
 

--- a/apps/app/tests/unit/bookmarks/mixed-content-projection.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-projection.test.ts
@@ -228,7 +228,7 @@ describe("mixed-content projection", () => {
     ]);
   });
 
-  it("suppresses every canonical Feed item before mixed membership while preserving Feed-only access and independent deletion", async () => {
+  it("keeps matching Bookmarks and Feed items as independent mixed rows", async () => {
     await seedFeed(1);
     await seedFeed(2);
     await seedView(10, "Feed view");
@@ -252,10 +252,14 @@ describe("mixed-content projection", () => {
       feedId: 1,
       url: "https://example.com/other",
     });
-    await seedBookmark({ id: "bookmark-match", canonicalUrl });
+    await seedBookmark({
+      id: "bookmark-match",
+      canonicalUrl,
+      isSaved: false,
+    });
     await database
       .insert(bookmarkViews)
-      .values({ bookmarkId: "bookmark-match", viewId: 11 });
+      .values({ bookmarkId: "bookmark-match", viewId: 10 });
 
     const mixedFeedView = await queryMixedContentPage({
       database,
@@ -266,7 +270,15 @@ describe("mixed-content projection", () => {
     });
     expect(
       mixedFeedView.references.map((reference) => reference.entityId),
-    ).toEqual(["feed-other"]);
+    ).toEqual(
+      expect.arrayContaining([
+        "bookmark-match",
+        "feed-match-one",
+        "feed-match-two",
+        "feed-other",
+      ]),
+    );
+    expect(mixedFeedView.references).toHaveLength(4);
 
     const feedOnlyItems = await database
       .select()
@@ -279,6 +291,18 @@ describe("mixed-content projection", () => {
 
     await database.delete(feeds).where(eq(feeds.id, 1));
     expect(await database.select().from(bookmarks)).toHaveLength(1);
+
+    const beforeBookmarkDeletion = await queryMixedContentPage({
+      database,
+      userId: "user-one",
+      scope: { type: "view", viewId: 10 },
+      contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+      limit: 20,
+    });
+    expect(
+      beforeBookmarkDeletion.references.map((reference) => reference.entityId),
+    ).toEqual(expect.arrayContaining(["bookmark-match", "feed-match-two"]));
+
     await database.delete(bookmarks).where(eq(bookmarks.id, "bookmark-match"));
 
     const restored = await queryMixedContentPage({

--- a/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-sync.test.ts
@@ -367,7 +367,6 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
             : [],
         ),
         replacesScope: true,
-        feedItems: feedItemsStore.getState().feedItemsDict,
       });
     }
 
@@ -400,7 +399,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     ).toEqual([reference("feed-item", vertical.id)]);
   });
 
-  it("suppresses a reprojected Feed item against the global cached Bookmark index", () => {
+  it("keeps a reprojected Feed item when it matches a cached Bookmark", () => {
     const cached = bookmark({
       id: "global-collision",
       canonicalUrl: "https://example.com/collision",
@@ -417,7 +416,6 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
       page: page([reference("feed-item", original.id)]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
 
     const colliding = {
@@ -438,7 +436,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
 
     expect(
       mixedContentStore.getState().scopes["view:10:inbox:unread"]?.references,
-    ).toEqual([]);
+    ).toEqual([reference("feed-item", colliding.id)]);
   });
 
   it("reprojects cached Feed items immediately after a View filter edit", () => {
@@ -458,7 +456,6 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
       page: page([reference("feed-item", horizontal.id)]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
 
     const shortsView = { ...view(), contentFilter: 4 as const };
@@ -467,7 +464,6 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     mixedContentStore.getState().reprojectFeedItems({
       itemIds: Object.keys(feedItems),
       feedItems,
-      bookmarks: bookmarksStore.getState().snapshot(),
       views: [shortsView],
       feedCategories: [],
     });
@@ -477,7 +473,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     ).toEqual([reference("feed-item", vertical.id)]);
   });
 
-  it("suppresses matching Feed items immediately, moves Bookmark content status, restores on deletion, and reports scopes for refill", () => {
+  it("moves Bookmark content status without changing matching Feed rows", () => {
     const matchingOne = feedItem(
       "feed-match-one",
       "https://example.com/article#fragment",
@@ -500,21 +496,18 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
         reference("feed-item", other.id),
       ]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       contentStatus: { saveStatus: "inbox", archiveStatus: "archived" },
       page: page([]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
       page: page([]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
 
     const saved = bookmark();
@@ -524,7 +517,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
         chunk: { type: "bookmark-upsert", bookmark: saved },
       },
     ]);
-    expect(affectedOnSave).toHaveLength(2);
+    expect(affectedOnSave).toHaveLength(1);
     expect(
       mixedContentStore.getState().scopes[
         getMixedScopeKey(scope, {
@@ -532,7 +525,11 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
           archiveStatus: "unread",
         })
       ]?.references,
-    ).toEqual([reference("feed-item", other.id)]);
+    ).toEqual([
+      reference("feed-item", other.id),
+      reference("feed-item", matchingTwo.id),
+      reference("feed-item", matchingOne.id),
+    ]);
     expect(feedItemsStore.getState().feedItemsDict[matchingOne.id]).toEqual(
       matchingOne,
     );
@@ -563,7 +560,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
         },
       },
     ]);
-    expect(affectedOnDelete).toHaveLength(2);
+    expect(affectedOnDelete).toHaveLength(1);
     expect(
       mixedContentStore.getState().scopes[
         getMixedScopeKey(scope, {
@@ -724,7 +721,6 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
       page: page([reference("bookmark", cached.id)]),
       replacesScope: true,
-      feedItems: {},
     });
     const moved = bookmark({
       ...cached,
@@ -752,7 +748,7 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
     ).toEqual([]);
   });
 
-  it("restores a suppressed Feed item when authoritative bucket sync deletes its Bookmark", () => {
+  it("removes only the Bookmark when authoritative bucket sync deletes it", () => {
     const url = "https://example.com/collision";
     const item = feedItem("collision-feed", url);
     const cached = bookmark({ id: "collision-bookmark", canonicalUrl: url });
@@ -762,13 +758,23 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
       page: page([reference("feed-item", item.id)]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     processPublishedChunks([
       {
         source: "bookmark",
         chunk: { type: "bookmark-upsert", bookmark: cached },
       },
+    ]);
+    expect(
+      mixedContentStore.getState().scopes[
+        getMixedScopeKey(
+          { type: "view", viewId: 10 },
+          { saveStatus: "saved", archiveStatus: "unread" },
+        )
+      ]?.references,
+    ).toEqual([
+      reference("bookmark", cached.id),
+      reference("feed-item", item.id),
     ]);
     const [syncPage] = buildBookmarkSyncPages({
       bucket: getBookmarkSyncBucket(cached.id),
@@ -804,14 +810,12 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
       page: page(references),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       contentStatus: { saveStatus: "inbox", archiveStatus: "archived" },
       page: page([]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     orpcMocks.setBookmarkBulkReadValue.mockResolvedValue([]);
     orpcMocks.setFeedBulkWatchedValue.mockImplementation(
@@ -893,14 +897,12 @@ describe("Bookmark synchronization and local mixed reprojection", () => {
       contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
       page: page(references),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     mixedContentStore.getState().applyPage({
       scope,
       contentStatus: { saveStatus: "inbox", archiveStatus: "archived" },
       page: page([]),
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
     orpcMocks.setBookmarkBulkReadValue.mockRejectedValueOnce(
       new Error("write failed"),

--- a/apps/app/tests/unit/data/mixed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/mixed-page-retention.test.ts
@@ -46,7 +46,6 @@ function applyPages(count: number) {
         hasMore: true,
       },
       replacesScope: pageIndex === 0,
-      feedItems: {},
     });
   }
 }

--- a/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
+++ b/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
@@ -108,7 +108,6 @@ describe("optimistic feed item mutations", () => {
         hasMore: false,
       },
       replacesScope: true,
-      feedItems: feedItemsStore.getState().feedItemsDict,
     });
 
     applyOptimisticWatchLaterValue(item.id, true);

--- a/apps/app/tests/unit/navigation/navigation-snapshot.test.ts
+++ b/apps/app/tests/unit/navigation/navigation-snapshot.test.ts
@@ -79,6 +79,58 @@ beforeEach(async () => {
 afterEach(() => cleanup());
 
 describe("navigation snapshot", () => {
+  it("keeps Feed availability when a matching Bookmark has different status", async () => {
+    await seedFeed(1);
+    await database.insert(views).values({
+      id: 20,
+      userId: "navigation-user",
+      name: "Independent rows",
+      contentFilter: 3,
+      daysWindow: 0,
+      layout: "list",
+    });
+    await database.insert(viewFeeds).values({ viewId: 20, feedId: 1 });
+    await database.insert(feedItems).values({
+      id: "matching-feed-item",
+      feedId: 1,
+      contentId: "matching-feed-item",
+      contentType: "text",
+      title: "Matching Feed item",
+      author: "Author",
+      url: "https://items.example/shared",
+      normalizedUrl: "https://items.example/shared",
+      postedAt: NOW,
+      createdAt: NOW,
+      updatedAt: NOW,
+      isWatched: false,
+      isWatchLater: false,
+    });
+    await database.insert(bookmarks).values({
+      id: "matching-bookmark",
+      userId: "navigation-user",
+      sourceUrl: "https://items.example/shared",
+      canonicalUrl: "https://items.example/shared",
+      title: "Matching Bookmark",
+      contentType: "text",
+      isSaved: true,
+      isRead: true,
+      createdAt: NOW,
+      savedUpdatedAt: NOW,
+      readUpdatedAt: NOW,
+      progressUpdatedAt: NOW,
+      updatedAt: NOW,
+    });
+
+    const snapshot = await queryNavigationSnapshot({
+      database,
+      userId: "navigation-user",
+      now: NOW,
+    });
+
+    expect(snapshot.views[20]?.inbox.unread).toBe(true);
+    expect(snapshot.viewFeeds[20]?.[1]?.inbox.unread).toBe(true);
+  });
+
   it("reports complete View, Tag, global Feed, and per-View Feed availability without loading content pages", async () => {
     await Promise.all([
       seedFeed(1),

--- a/apps/app/tests/unit/performance/bookmark-server-bounds.test.ts
+++ b/apps/app/tests/unit/performance/bookmark-server-bounds.test.ts
@@ -8,6 +8,7 @@ import { updateBookmarksReadState } from "~/server/bookmarks/service";
 import { loadExtensionBookmarkWorkspace } from "~/server/bookmarks/extensionWorkspace";
 import { queryMixedContentPage } from "~/server/mixed-content/projection";
 import { loadApplicationBookmark } from "~/server/mixed-content/sync";
+import { reconcileApplicationState } from "~/server/reconciliation";
 import { UNCATEGORIZED_SECTION_PLACEMENT } from "~/lib/views/sections";
 import {
   bookmarks,
@@ -18,6 +19,7 @@ import {
   feedItems,
   feeds,
   user,
+  viewFeeds,
   views,
   viewSections,
 } from "~/server/db/schema";
@@ -74,6 +76,83 @@ function bookmarkRows(count: number, userId = "bounds-user") {
 }
 
 describe("Bookmark server performance bounds", () => {
+  it("keeps a full reconciliation to one active page as content grows", async () => {
+    await session.database.insert(views).values({
+      id: 10,
+      userId: "bounds-user",
+      name: "Everything",
+      contentFilter: 7,
+      placement: 1,
+    });
+    await session.database.insert(feeds).values({
+      id: 30,
+      userId: "bounds-user",
+      name: "Feed",
+      url: "https://example.com/feed.xml",
+      platform: "website",
+    });
+    await session.database.insert(viewFeeds).values({ viewId: 10, feedId: 30 });
+    await session.database.insert(feedItems).values(
+      Array.from({ length: 1_000 }, (_, index) => ({
+        id: `reconciliation-feed-${index.toString().padStart(4, "0")}`,
+        feedId: 30,
+        contentId: `reconciliation-content-${index}`,
+        title: `Item ${index}`,
+        author: "Author",
+        url: `https://example.com/reconciliation-feed-${index}`,
+        postedAt: new Date(NOW.getTime() - index),
+        createdAt: NOW,
+        updatedAt: NOW,
+      })),
+    );
+    const seededBookmarks = bookmarkRows(500).map((bookmark) => ({
+      ...bookmark,
+      isSaved: false,
+    }));
+    await session.database.insert(bookmarks).values(seededBookmarks);
+    await session.database
+      .insert(bookmarkViews)
+      .values(
+        seededBookmarks.map(({ id }) => ({ bookmarkId: id, viewId: 10 })),
+      );
+
+    session.instrumentation.reset();
+    const events = [];
+    for await (const event of reconcileApplicationState({
+      database: session.database,
+      userId: "bounds-user",
+      request: {
+        type: "full",
+        reconciliationId: "bounded-full",
+        selection: {
+          type: "cold",
+          contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+          membershipRevision: 0,
+        },
+      },
+    })) {
+      events.push(event);
+    }
+    const evidence = session.instrumentation.snapshot();
+    const active = events.find(
+      ({ chunk }) => chunk.type === "active-first-page",
+    );
+    if (active?.chunk.type !== "active-first-page") {
+      throw new Error("Expected active reconciliation page");
+    }
+
+    expect(active.chunk.page.orderedRefs).toHaveLength(30);
+    expect(
+      active.chunk.page.feedItemDiffs.length +
+        active.chunk.page.bookmarkDiffs.length,
+    ).toBe(30);
+    expect(evidence.statementCount).toBeLessThanOrEqual(24);
+    expect(evidence.materializedRows).toBeLessThanOrEqual(180);
+    expect(Buffer.byteLength(JSON.stringify(events))).toBeLessThanOrEqual(
+      256 * 1_024,
+    );
+  });
+
   it("returns the extension editor workspace without reloading its published Bookmark", async () => {
     const [row] = bookmarkRows(1);
     await session.database.insert(bookmarks).values(row!);

--- a/apps/app/tests/unit/reconciliation/reconciliation-rpc.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation-rpc.test.ts
@@ -1,0 +1,111 @@
+import { createRouterClient } from "@orpc/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBookmarkTestDatabase } from "../bookmarks/database";
+import type { ORPCContext } from "~/server/orpc/base";
+import { user, views } from "~/server/db/schema";
+import { orpcRouter } from "~/server/orpc/router";
+import { MAX_RECONCILIATION_TARGETS } from "~/server/reconciliation/input";
+
+const testState = vi.hoisted((): { database: unknown } => ({
+  database: undefined,
+}));
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return testState.database;
+  },
+}));
+vi.mock("~/server/auth", () => ({ auth: {} }));
+vi.mock("~/env", () => ({
+  env: {
+    BACKGROUND_REFRESH_ENABLED: false,
+    DATABASE_URL: "file::memory:",
+    KV_STORE: "none",
+    PUBLIC_BASE_URL: "http://localhost:3000",
+    TRUSTED_ORIGINS: [],
+  },
+}));
+
+type TestDatabase = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["database"];
+type Cleanup = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["cleanup"];
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+
+let database: TestDatabase;
+let cleanup: Cleanup;
+
+beforeEach(async () => {
+  ({ database, cleanup } = await createBookmarkTestDatabase());
+  testState.database = database;
+  await database.insert(user).values({
+    id: "rpc-user",
+    name: "RPC user",
+    email: "rpc@example.com",
+    emailVerified: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  await database.insert(views).values({
+    id: 10,
+    userId: "rpc-user",
+    name: "Reading",
+    contentFilter: 3,
+    placement: 1,
+  });
+});
+
+afterEach(() => cleanup());
+
+function api() {
+  return createRouterClient(orpcRouter, {
+    context: {
+      headers: new Headers(),
+      session: { id: "rpc-session" },
+      user: { id: "rpc-user" },
+      db: database,
+    } as ORPCContext,
+  });
+}
+
+describe("reconciliation RPC", () => {
+  it("streams the deep reconciliation interface through the authenticated transport", async () => {
+    const stream = await api().initial.reconcileApplicationState({
+      type: "full",
+      reconciliationId: "rpc-cold",
+      selection: {
+        type: "cold",
+        contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        membershipRevision: 0,
+      },
+    });
+    const chunkTypes: string[] = [];
+    for await (const event of stream) chunkTypes.push(event.chunk.type);
+
+    expect(chunkTypes).toEqual([
+      "organization-snapshot",
+      "domain-complete",
+      "active-first-page",
+      "domain-complete",
+      "automatic-rss-owner",
+      "navigation-snapshot",
+      "domain-complete",
+      "epoch-complete",
+    ]);
+  });
+
+  it("rejects an oversized targeted request before server work begins", async () => {
+    await expect(
+      api().initial.reconcileApplicationState({
+        type: "targeted",
+        reconciliationId: "too-many-targets",
+        targets: Array.from({ length: MAX_RECONCILIATION_TARGETS + 1 }, () => ({
+          target: { type: "navigation" as const },
+        })),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/app/tests/unit/reconciliation/reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { ApplicationFeedItem } from "~/server/db/schema";
-import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 import type {
   ActiveFirstPageResult,
   OrganizationSnapshot,
   ReconciliationCommand,
   ReconciliationCoordinatorEvent,
   ReconciliationCoordinatorState,
+  ReconciliationHydrationDomain,
   ReconciliationRequestIntent,
   ReconciliationScopeTarget,
   ReconciliationTarget,
@@ -36,7 +36,6 @@ const OTHER_SCOPE = {
 
 const ORGANIZATION = { type: "organization" } as const;
 const NAVIGATION = { type: "navigation" } as const;
-const BOOKMARKS = { type: "bookmarks" } as const;
 
 function feedItem(
   id: string,
@@ -69,19 +68,6 @@ function feedItem(
   };
 }
 
-function bookmark(
-  id: string,
-  overrides: Partial<ApplicationBookmark> = {},
-): ApplicationBookmark {
-  return {
-    id,
-    title: id,
-    sourceUrl: `https://example.com/${id}`,
-    canonicalUrl: `https://example.com/${id}`,
-    ...overrides,
-  } as ApplicationBookmark;
-}
-
 function firstPage(
   membershipRevision: number,
   overrides: Partial<ActiveFirstPageResult> = {},
@@ -105,6 +91,7 @@ function organizationSnapshot(name: string): OrganizationSnapshot {
     tags: [],
     feedTags: [],
     directViewFeeds: [],
+    effectiveViewFeeds: [],
   };
 }
 
@@ -180,39 +167,6 @@ describe("reconciliation data reducers", () => {
     });
     expect(result).toEqual({ state, applied: false });
   });
-
-  it("applies a bounded Bookmark bucket only after its final page", () => {
-    const oldBookmark = bookmark("old");
-    const newBookmark = bookmark("new");
-    let state = createReconciliationDataState({
-      bookmarks: { old: oldBookmark },
-    });
-
-    ({ state } = reduceReconciliationData(state, {
-      type: "apply-bookmark-sync-page",
-      page: {
-        bucket: 3,
-        version: "next",
-        pageIndex: 0,
-        diffs: [{ status: "delete", id: "old" }],
-        completesBucket: false,
-      },
-    }));
-    expect(state.bookmarks.old).toBe(oldBookmark);
-
-    ({ state } = reduceReconciliationData(state, {
-      type: "apply-bookmark-sync-page",
-      page: {
-        bucket: 3,
-        version: "next",
-        pageIndex: 1,
-        diffs: [{ status: "upsert", entity: newBookmark }],
-        completesBucket: true,
-      },
-    }));
-    expect(state.bookmarks).toEqual({ new: newBookmark });
-    expect(state.bookmarkBucketVersions[3]).toBe("next");
-  });
 });
 
 type TestCoordinator = ReconciliationCoordinatorState<string, string>;
@@ -242,7 +196,7 @@ function hydrateAll(send: (event: TestEvent) => TestCommand[]) {
     "active-scope",
     "navigation",
     "bookmarks",
-  ] satisfies RequiredReconciliationDomain[]) {
+  ] satisfies ReconciliationHydrationDomain[]) {
     send({ type: "hydration-complete", domain });
   }
 }
@@ -258,7 +212,7 @@ function startedRequest(commands: TestCommand[]) {
 }
 
 function requiredTargets(): ReconciliationTarget[] {
-  return [ORGANIZATION, ACTIVE_SCOPE, NAVIGATION, BOOKMARKS];
+  return [ORGANIZATION, ACTIVE_SCOPE, NAVIGATION];
 }
 
 function hydrationFor(target: ReconciliationTarget) {
@@ -309,7 +263,6 @@ describe("reconciliation coordinator", () => {
     expect(harness.state.domains.organization.appliedAt).toBe(2);
     expect(harness.state.domains["active-scope"].appliedAt).toBe(3);
     expect(harness.state.domains.navigation.appliedAt).toBe(4);
-    expect(harness.state.domains.bookmarks.appliedAt).toBe(5);
   });
 
   it("preserves applied domains and withholds parity after partial failure", () => {
@@ -324,7 +277,7 @@ describe("reconciliation coordinator", () => {
       }),
     );
 
-    for (const target of [ORGANIZATION, ACTIVE_SCOPE, BOOKMARKS]) {
+    for (const target of [ORGANIZATION, ACTIVE_SCOPE]) {
       harness.send({
         type: "authoritative-received",
         reconciliationId: request.reconciliationId,
@@ -411,7 +364,7 @@ describe("reconciliation coordinator", () => {
       { type: "targeted", targets: [OTHER_SCOPE] },
       { type: "targeted", targets: [NAVIGATION] },
       { type: "full", selectedScope: ACTIVE_SCOPE },
-      { type: "targeted", targets: [BOOKMARKS] },
+      { type: "targeted", targets: [ORGANIZATION] },
     ] satisfies ReconciliationRequestIntent[]) {
       expect(harness.send({ type: "request-reconciliation", intent })).toEqual(
         [],

--- a/apps/app/tests/unit/reconciliation/server-reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/server-reconciliation.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBookmarkTestDatabase } from "../bookmarks/database";
+import type { ReconciliationInput } from "~/lib/reconciliation";
+import { getFeedItemReconciliationVersion } from "~/lib/reconciliation";
+import {
+  bookmarks,
+  bookmarkViews,
+  feedItems,
+  feeds,
+  user,
+  viewFeeds,
+  views,
+} from "~/server/db/schema";
+import { reconcileApplicationState } from "~/server/reconciliation";
+
+type TestDatabase = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["database"];
+type Cleanup = Awaited<
+  ReturnType<typeof createBookmarkTestDatabase>
+>["cleanup"];
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+
+let database: TestDatabase;
+let cleanup: Cleanup;
+
+beforeEach(async () => {
+  ({ database, cleanup } = await createBookmarkTestDatabase());
+  await database.insert(user).values({
+    id: "reconciliation-user",
+    name: "Reconciliation user",
+    email: "reconciliation@example.com",
+    emailVerified: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+});
+
+afterEach(() => cleanup());
+
+async function collect(request: ReconciliationInput) {
+  const events = [];
+  for await (const event of reconcileApplicationState({
+    database,
+    userId: "reconciliation-user",
+    request,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("server reconciliation", () => {
+  it("returns authoritative membership while omitting an unchanged entity body", async () => {
+    await database.insert(views).values({
+      id: 10,
+      userId: "reconciliation-user",
+      name: "Reading",
+      contentFilter: 3,
+      placement: 1,
+    });
+    await database.insert(feeds).values({
+      id: 20,
+      userId: "reconciliation-user",
+      name: "Reading feed",
+      url: "https://example.com/feed.xml",
+      platform: "website",
+    });
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 20 });
+    await database.insert(feedItems).values({
+      id: "unchanged-feed-item",
+      feedId: 20,
+      contentId: "unchanged-feed-item",
+      title: "Feed item",
+      author: "Author",
+      url: "https://example.com/unchanged",
+      postedAt: NOW,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const initial = await collect({
+      type: "full",
+      reconciliationId: "manifest-source",
+      selection: {
+        type: "cold",
+        contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        membershipRevision: 0,
+      },
+    });
+    const initialPage = initial.find(
+      ({ chunk }) => chunk.type === "active-first-page",
+    );
+    if (initialPage?.chunk.type !== "active-first-page") {
+      throw new Error("Expected source page");
+    }
+    const entityDiff = initialPage.chunk.page.feedItemDiffs[0];
+    if (entityDiff?.status !== "upsert") {
+      throw new Error("Expected source entity");
+    }
+
+    const events = await collect({
+      type: "full",
+      reconciliationId: "manifest-match",
+      selection: {
+        type: "selected",
+        scope: { type: "view", viewId: 10 },
+        contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        pageManifest: {
+          feedItems: [
+            {
+              id: entityDiff.entity.id,
+              version: getFeedItemReconciliationVersion(entityDiff.entity),
+            },
+          ],
+          bookmarks: [],
+        },
+        membershipRevision: 7,
+      },
+    });
+    const activePage = events.find(
+      ({ chunk }) => chunk.type === "active-first-page",
+    );
+    if (activePage?.chunk.type !== "active-first-page") {
+      throw new Error("Expected reconciled page");
+    }
+
+    expect(activePage.chunk.page.orderedRefs).toHaveLength(1);
+    expect(activePage.chunk.page.feedItemDiffs).toEqual([
+      { status: "unchanged", id: "unchanged-feed-item" },
+    ]);
+    expect(activePage.chunk.page.membershipRevision).toBe(7);
+  });
+
+  it("resolves a cold View and streams one complete page with independent matching rows", async () => {
+    await database.insert(views).values({
+      id: 10,
+      userId: "reconciliation-user",
+      name: "Reading",
+      contentFilter: 3,
+      placement: 1,
+    });
+    await database.insert(feeds).values({
+      id: 20,
+      userId: "reconciliation-user",
+      name: "Reading feed",
+      url: "https://example.com/feed.xml",
+      platform: "website",
+    });
+    await database.insert(viewFeeds).values({ viewId: 10, feedId: 20 });
+    await database.insert(feedItems).values({
+      id: "matching-feed-item",
+      feedId: 20,
+      contentId: "matching-feed-item",
+      title: "Feed item",
+      author: "Author",
+      url: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      postedAt: NOW,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await database.insert(bookmarks).values({
+      id: "matching-bookmark",
+      userId: "reconciliation-user",
+      sourceUrl: "https://example.com/article",
+      effectiveUrl: "https://example.com/article",
+      canonicalUrl: "https://example.com/article",
+      isSaved: false,
+      savedUpdatedAt: NOW,
+      readUpdatedAt: NOW,
+      progressUpdatedAt: NOW,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await database
+      .insert(bookmarkViews)
+      .values({ bookmarkId: "matching-bookmark", viewId: 10 });
+
+    const events = await collect({
+      type: "full",
+      reconciliationId: "cold-1",
+      selection: {
+        type: "cold",
+        contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        membershipRevision: 4,
+      },
+    });
+
+    expect(events.map(({ chunk }) => chunk.type)).toEqual([
+      "organization-snapshot",
+      "domain-complete",
+      "active-first-page",
+      "domain-complete",
+      "automatic-rss-owner",
+      "navigation-snapshot",
+      "domain-complete",
+      "epoch-complete",
+    ]);
+    expect(events.every((event) => event.reconciliationId === "cold-1")).toBe(
+      true,
+    );
+
+    const organization = events.find(
+      ({ chunk }) => chunk.type === "organization-snapshot",
+    );
+    if (organization?.chunk.type !== "organization-snapshot") {
+      throw new Error("Expected organization snapshot");
+    }
+    expect(organization.chunk.snapshot.directViewFeeds).toEqual([
+      { viewId: 10, feedId: 20 },
+    ]);
+    expect(organization.chunk.snapshot.effectiveViewFeeds).toContainEqual({
+      viewId: 10,
+      feedIds: [20],
+    });
+
+    const activePage = events.find(
+      ({ chunk }) => chunk.type === "active-first-page",
+    );
+    expect(activePage?.chunk).toMatchObject({
+      type: "active-first-page",
+      page: {
+        target: {
+          type: "scope",
+          scope: { type: "view", viewId: 10 },
+          contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        },
+        membershipRevision: 4,
+      },
+    });
+    if (activePage?.chunk.type !== "active-first-page") {
+      throw new Error("Expected active page");
+    }
+    expect(
+      activePage.chunk.page.orderedRefs.map(({ entityId }) => entityId),
+    ).toEqual(
+      expect.arrayContaining(["matching-bookmark", "matching-feed-item"]),
+    );
+    expect(activePage.chunk.page.orderedRefs).toHaveLength(2);
+
+    const completed = events.at(-1);
+    expect(completed?.chunk).toEqual({
+      type: "epoch-complete",
+      requiredDomains: ["organization", "active-scope", "navigation"],
+    });
+  });
+
+  it("terminates an unavailable explicit selection with structured scope context", async () => {
+    const events = await collect({
+      type: "full",
+      reconciliationId: "stale-selection",
+      selection: {
+        type: "selected",
+        scope: { type: "view", viewId: 404 },
+        contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        pageManifest: {
+          feedItems: [],
+          bookmarks: [],
+        },
+        membershipRevision: 2,
+      },
+    });
+
+    expect(events.map(({ chunk }) => chunk.type)).toEqual([
+      "organization-snapshot",
+      "domain-complete",
+      "domain-error",
+    ]);
+    expect(events.at(-1)?.chunk).toEqual({
+      type: "domain-error",
+      failure: {
+        phase: "resolve-selection",
+        domain: "active-scope",
+        target: {
+          type: "scope",
+          scope: { type: "view", viewId: 404 },
+          contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+        },
+        message: "The selected reconciliation scope is unavailable",
+      },
+    });
+  });
+});


### PR DESCRIPTION
- Add a bounded streamed reconciliation module and authenticated transport for cold startup, warm reconnects, and targeted repair.
- Reconcile organization, one authoritative mixed-content page, navigation availability, and automatic RSS ownership without running ingestion.
- Treat Bookmarks and Feed items as independent page-retained rows and remove canonical suppression from server and client projection paths.
- Add compact entity manifests, structured terminal domain failures, transport coverage, and fixed server bounds.