### PR TITLE
Cut startup over to reconciliation

### DIFF
--- a/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
+++ b/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
@@ -40,10 +40,7 @@ import {
   useHasInitialData,
 } from "~/lib/data/store";
 import { useFeedItemNavigation } from "~/lib/hooks/useFeedItemNavigation";
-import { useLazyCategoryFilter } from "~/lib/hooks/useLazyCategoryFilter";
-import { useLazyFeedFilter } from "~/lib/hooks/useLazyFeedFilter";
 import { useShortcut } from "~/lib/hooks/useShortcut";
-import { useValidateViewItems } from "~/lib/hooks/useValidateViewItems";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
 import { showUndoToast } from "~/lib/undo";
 import { VIEW_LAYOUT } from "~/server/db/constants";
@@ -325,10 +322,6 @@ function ContentStatusSectionList({
 }
 
 export function RenderViewItems() {
-  useLazyFeedFilter();
-  useLazyCategoryFilter();
-  useValidateViewItems();
-
   const { feeds, hasFetchedFeeds } = useFeeds();
   const { hasFetchedFeedCategories } = useFeedCategories();
 

--- a/apps/app/src/lib/data/InitialClientQueries.tsx
+++ b/apps/app/src/lib/data/InitialClientQueries.tsx
@@ -1,54 +1,40 @@
 "use client";
 
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import {
   categoryFilterAtom,
+  contentStatusFilterAtom,
   feedFilterAtom,
-  UNSELECTED_VIEW_ID,
   viewFilterIdAtom,
   viewsAtom,
 } from "./atoms";
 
-import { useStoresHydrated } from "./hydration";
-import { loadingActor } from "./loading-machine";
 import { useDataSubscription } from "./useDataSubscription";
-import { useUpdateViewFilter } from "./views";
 import { useViewsFetchStatus, useViews as useViewsStore } from "./views/store";
+import {
+  dataReconciliation,
+  getCurrentReconciliationTarget,
+} from "./reconciliation";
 import type { PropsWithChildren } from "react";
 
 export function InitialClientQueries({ children }: PropsWithChildren) {
-  const { requestInitialData } = useDataSubscription();
-  const hasRequestedInitialData = useRef(false);
-  const hydrated = useStoresHydrated();
+  useDataSubscription();
 
   // Sync views store with viewsAtom for compatibility
   const viewsFromStore = useViewsStore();
   const viewsFetchStatus = useViewsFetchStatus();
   const setViewsAtom = useSetAtom(viewsAtom);
-  const updateViewFilter = useUpdateViewFilter();
 
-  // Read content-status atoms for auto-selection logic
   const viewFilterId = useAtomValue(viewFilterIdAtom);
   const feedFilter = useAtomValue(feedFilterAtom);
   const categoryFilter = useAtomValue(categoryFilterAtom);
+  const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
 
-  // Request initial data once stores have hydrated from IDB.
-  // Gating on hydration ensures cached data is loaded first, preventing
-  // fresh SSE data from being overwritten by a late hydration merge.
-  // Build per-view manifests so the server can diff against the client's
-  // cached items and only send what changed.
   useEffect(() => {
-    if (!hasRequestedInitialData.current && hydrated) {
-      hasRequestedInitialData.current = true;
-
-      // Enter loading state immediately so the UI reflects it before
-      // the first SSE chunk arrives (avoids a brief idle flash).
-      loadingActor.send({ type: "INITIAL_LOAD_START" });
-
-      void requestInitialData();
-    }
-  }, [requestInitialData, hydrated]);
+    dataReconciliation.start();
+    return () => dataReconciliation.stop();
+  }, []);
 
   // Keep viewsAtom always in sync with store
   useEffect(() => {
@@ -57,26 +43,10 @@ export function InitialClientQueries({ children }: PropsWithChildren) {
     }
   }, [viewsFetchStatus, viewsFromStore, setViewsAtom]);
 
-  // Auto-select first view when nothing is selected
   useEffect(() => {
-    const nothingSelected =
-      viewFilterId === UNSELECTED_VIEW_ID &&
-      feedFilter === -1 &&
-      categoryFilter === -1;
-
-    if (nothingSelected && viewsFromStore.length > 0) {
-      const firstView = viewsFromStore[0];
-      if (firstView) {
-        updateViewFilter(firstView.id, viewsFromStore);
-      }
-    }
-  }, [
-    viewFilterId,
-    feedFilter,
-    categoryFilter,
-    viewsFromStore,
-    updateViewFilter,
-  ]);
+    const target = getCurrentReconciliationTarget();
+    if (target) dataReconciliation.activateScope(target);
+  }, [viewFilterId, feedFilter, categoryFilter, contentStatusFilter]);
 
   return children;
 }

--- a/apps/app/src/lib/data/feed-items/index.ts
+++ b/apps/app/src/lib/data/feed-items/index.ts
@@ -282,13 +282,14 @@ export const useFilteredContentOrder = () => {
   }, [bookmarkRevision]);
 
   return useMemo(() => {
-    if (feedFilter >= 0) return feedItemsOrder;
     const scope =
-      categoryFilter >= 0
-        ? ({ type: "tag", tagId: categoryFilter } as const)
-        : viewFilter
-          ? ({ type: "view", viewId: viewFilter.id } as const)
-          : null;
+      feedFilter >= 0
+        ? ({ type: "feed", feedId: feedFilter } as const)
+        : categoryFilter >= 0
+          ? ({ type: "tag", tagId: categoryFilter } as const)
+          : viewFilter
+            ? ({ type: "view", viewId: viewFilter.id } as const)
+            : null;
     if (!scope) return feedItemsOrder;
     const loadedScope =
       mixedScopes[getMixedScopeKey(scope, contentStatusFilter)];

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -65,6 +65,11 @@ type MixedContentStore = {
     page: MixedContentPage;
     replacesScope: boolean;
   }) => void;
+  reconcileFirstPage: (input: {
+    scope: MixedContentScope;
+    contentStatus: ContentStatusFilter;
+    page: MixedContentPage;
+  }) => { firstPageChanged: boolean };
   reprojectUpsert: (input: {
     bookmark: ApplicationBookmark;
     previousBookmark: ApplicationBookmark | undefined;
@@ -168,6 +173,40 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           projectionIndexes,
           projectionIndexesComplete: true,
         });
+      },
+      reconcileFirstPage: ({ scope, contentStatus, page }) => {
+        const key = getMixedScopeKey(scope, contentStatus);
+        const current = get();
+        const existing = current.scopes[key];
+        const rootPage = existing?.pages.find(
+          (candidate) => candidate.requestCursorKey === "root",
+        );
+        const referencesByKey = new Map(
+          existing?.references.map((reference) => [
+            mixedReferenceKey(reference),
+            reference,
+          ]),
+        );
+        const retainedFirstPage = rootPage?.value.referenceKeys.flatMap(
+          (referenceKey) => {
+            const reference = referencesByKey.get(referenceKey);
+            return reference ? [reference] : [];
+          },
+        );
+        const firstPageChanged =
+          !retainedFirstPage ||
+          !referencesEqual(retainedFirstPage, page.references);
+
+        if (firstPageChanged || !existing || existing.pages.length <= 1) {
+          get().applyPage({
+            scope,
+            contentStatus,
+            page,
+            replacesScope: true,
+          });
+        }
+
+        return { firstPageChanged };
       },
       reprojectUpsert: ({ bookmark, previousBookmark, views }) => {
         if (!isBookmarkProjectionChange(previousBookmark, bookmark)) return [];

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -1,0 +1,415 @@
+import { getDefaultStore } from "jotai";
+import { unstable_batchedUpdates } from "react-dom";
+import { bookmarksStore } from "./bookmarks/store";
+import { contentCategoriesStore } from "./content-categories/store";
+import { feedCategoriesStore } from "./feed-categories/store";
+import { getFeedItemMembershipRevision } from "./feed-items/membershipRevision";
+import { feedsStore } from "./feeds/store";
+import { loadingActor } from "./loading-machine";
+import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
+import { navigationSnapshotStore } from "./navigation/store";
+import { applyPublishedChunks } from "./subscriptionCoordinator";
+import { feedItemsStore } from "./store";
+import { viewFeedsStore } from "./view-feeds/store";
+import { viewsStore } from "./views/store";
+import {
+  categoryFilterAtom,
+  contentStatusFilterAtom,
+  dateFilterAtom,
+  feedFilterAtom,
+  UNSELECTED_VIEW_ID,
+  viewFilterIdAtom,
+} from "./atoms";
+import type {
+  ActiveFirstPageResult,
+  ReconciliationEntityManifestEntry,
+  ReconciliationHydrationDomain,
+  ReconciliationInput,
+  ReconciliationPageManifest,
+  ReconciliationRequestDescriptor,
+  ReconciliationScopeTarget,
+} from "~/lib/reconciliation";
+import type { PublishedChunk } from "~/server/api/publisher";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import { orpcRouterClient } from "~/lib/orpc";
+import {
+  createReconciliationRuntime,
+  getBookmarkReconciliationVersion,
+  getFeedItemReconciliationVersion,
+  getReconciliationTargetKey,
+} from "~/lib/reconciliation";
+import { DEFAULT_CONTENT_STATUS_FILTER } from "~/lib/content-status";
+
+type PersistedStore = {
+  persist: {
+    hasHydrated: () => boolean;
+    onFinishHydration: (listener: () => void) => () => void;
+  };
+};
+
+function asPersistedStore(store: unknown) {
+  return store as PersistedStore;
+}
+
+function reconciliationSessionId() {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `reconciliation-${Date.now()}-${Math.random()}`;
+}
+
+function currentSelection(): ReconciliationScopeTarget | null {
+  const atoms = getDefaultStore();
+  const contentStatus = atoms.get(contentStatusFilterAtom);
+  const feedId = atoms.get(feedFilterAtom);
+  if (feedId >= 0) {
+    return {
+      type: "scope",
+      scope: { type: "feed", feedId },
+      contentStatus,
+    };
+  }
+  const tagId = atoms.get(categoryFilterAtom);
+  if (tagId >= 0) {
+    return {
+      type: "scope",
+      scope: { type: "tag", tagId },
+      contentStatus,
+    };
+  }
+  const viewId = atoms.get(viewFilterIdAtom);
+  return viewId === UNSELECTED_VIEW_ID
+    ? null
+    : {
+        type: "scope",
+        scope: { type: "view", viewId },
+        contentStatus,
+      };
+}
+
+function firstPageManifest(
+  target: ReconciliationScopeTarget,
+): ReconciliationPageManifest {
+  const scope =
+    mixedContentStore.getState().scopes[
+      getMixedScopeKey(target.scope, target.contentStatus)
+    ];
+  const rootPage = scope?.pages.find(
+    (candidate) => candidate.requestCursorKey === "root",
+  );
+  if (!scope || !rootPage) return { feedItems: [], bookmarks: [] };
+
+  const referencesByKey = new Map(
+    scope.references.map((reference) => [
+      `${reference.entityKind}:${reference.entityId}`,
+      reference,
+    ]),
+  );
+  const feedItems: ReconciliationEntityManifestEntry[] = [];
+  const bookmarks: ReconciliationEntityManifestEntry[] = [];
+  for (const referenceKey of rootPage.value.referenceKeys) {
+    const reference = referencesByKey.get(referenceKey);
+    if (!reference) continue;
+    if (reference.entityKind === "feed-item") {
+      const item = feedItemsStore.getState().feedItemsDict[reference.entityId];
+      if (item) {
+        feedItems.push({
+          id: item.id,
+          version: getFeedItemReconciliationVersion(item),
+        });
+      }
+      continue;
+    }
+    const bookmark = bookmarksStore.getState().getBookmark(reference.entityId);
+    if (bookmark) {
+      bookmarks.push({
+        id: bookmark.id,
+        version: getBookmarkReconciliationVersion(bookmark),
+      });
+    }
+  }
+  return { feedItems, bookmarks };
+}
+
+function buildInput(
+  request: ReconciliationRequestDescriptor,
+): ReconciliationInput {
+  if (request.intent.type === "full") {
+    if ("coldContentStatus" in request.intent) {
+      return {
+        type: "full",
+        reconciliationId: request.reconciliationId,
+        selection: {
+          type: "cold",
+          contentStatus: request.intent.coldContentStatus,
+          membershipRevision: getFeedItemMembershipRevision(),
+        },
+      };
+    }
+    const { selectedScope } = request.intent;
+    return {
+      type: "full",
+      reconciliationId: request.reconciliationId,
+      selection: {
+        type: "selected",
+        scope: selectedScope.scope,
+        contentStatus: selectedScope.contentStatus,
+        pageManifest: firstPageManifest(selectedScope),
+        membershipRevision: getFeedItemMembershipRevision(),
+      },
+    };
+  }
+
+  return {
+    type: "targeted",
+    reconciliationId: request.reconciliationId,
+    targets: request.intent.targets.map((target) => {
+      if (target.type === "scope") {
+        return {
+          target,
+          pageManifest: firstPageManifest(target),
+          membershipRevision: getFeedItemMembershipRevision(),
+        };
+      }
+      return target.type === "organization"
+        ? { target: { type: "organization" as const } }
+        : { target: { type: "navigation" as const } };
+    }),
+  };
+}
+
+function removeFeedItem(id: string) {
+  const state = feedItemsStore.getState();
+  if (!state.feedItemsDict[id]) return;
+  const feedItemsDict = { ...state.feedItemsDict };
+  delete feedItemsDict[id];
+  feedItemsStore.setState({
+    feedItemsDict,
+    feedItemsOrder: state.feedItemsOrder.filter(
+      (candidate) => candidate !== id,
+    ),
+    scopeFeedItemIds: Object.fromEntries(
+      Object.entries(state.scopeFeedItemIds).map(([scopeKey, ids]) => [
+        scopeKey,
+        ids.filter((candidate) => candidate !== id),
+      ]),
+    ),
+    feedItemProjectionRevision: state.feedItemProjectionRevision + 1,
+  });
+}
+
+function applyActiveFirstPage(page: ActiveFirstPageResult) {
+  if (page.membershipRevision !== getFeedItemMembershipRevision()) return false;
+
+  const feedItemUpserts: ApplicationFeedItem[] = [];
+  for (const diff of page.feedItemDiffs) {
+    if (diff.status === "upsert") feedItemUpserts.push(diff.entity);
+    if (diff.status === "delete") removeFeedItem(diff.id);
+  }
+  const bookmarkUpserts = page.bookmarkDiffs.flatMap((diff) =>
+    diff.status === "upsert" ? [diff.entity] : [],
+  );
+  for (const diff of page.bookmarkDiffs) {
+    if (diff.status === "delete") bookmarksStore.getState().remove(diff.id);
+  }
+  feedItemsStore.getState().setFeedItems(feedItemUpserts);
+  bookmarksStore.getState().upsertMany(bookmarkUpserts);
+
+  const pageResult = mixedContentStore.getState().reconcileFirstPage({
+    scope: page.target.scope,
+    contentStatus: page.target.contentStatus,
+    page: {
+      references: page.orderedRefs,
+      feedItems: feedItemUpserts,
+      bookmarks: bookmarkUpserts,
+      cursor: page.cursor,
+      hasMore: page.hasMore,
+    },
+  });
+  if (pageResult.firstPageChanged) {
+    feedItemsStore.getState().retainFeedItemPage({
+      scopeKey: `mixed:${getMixedScopeKey(
+        page.target.scope,
+        page.target.contentStatus,
+      )}`,
+      itemIds: page.orderedRefs.flatMap((reference) =>
+        reference.entityKind === "feed-item" ? [reference.entityId] : [],
+      ),
+      requestCursor: null,
+      nextCursor: page.cursor,
+      replacesScope: true,
+    });
+  }
+  feedItemsStore.setState({ fetchFeedItemsLastFetchedAt: Date.now() });
+
+  const atoms = getDefaultStore();
+  if (
+    atoms.get(viewFilterIdAtom) === UNSELECTED_VIEW_ID &&
+    atoms.get(feedFilterAtom) < 0 &&
+    atoms.get(categoryFilterAtom) < 0 &&
+    page.target.scope.type === "view"
+  ) {
+    const view = viewsStore.getState().viewsDict[page.target.scope.viewId];
+    atoms.set(feedFilterAtom, -1);
+    atoms.set(categoryFilterAtom, -1);
+    if (view) atoms.set(dateFilterAtom, view.daysWindow);
+    atoms.set(viewFilterIdAtom, page.target.scope.viewId);
+  }
+  return true;
+}
+
+function performanceMark(name: string, reconciliationId?: string) {
+  if (typeof performance === "undefined") return;
+  performance.mark(name);
+  if (reconciliationId) performance.mark(`${name}:${reconciliationId}`);
+}
+
+const runtime = createReconciliationRuntime<PublishedChunk[]>({
+  sessionId: reconciliationSessionId,
+  now: () =>
+    typeof performance === "undefined" ? Date.now() : performance.now(),
+  buildInput,
+  openStream: async (input, signal) =>
+    orpcRouterClient.initial.reconcileApplicationState(input, { signal }),
+  applyAuthoritative: (payload) => {
+    switch (payload.type) {
+      case "organization":
+        unstable_batchedUpdates(() => {
+          viewsStore.getState().set(payload.snapshot.views);
+          viewsStore.setState({ fetchStatus: "success" });
+          feedsStore.getState().set(payload.snapshot.feeds);
+          feedsStore.setState({ fetchStatus: "success" });
+          contentCategoriesStore.getState().set(payload.snapshot.tags);
+          contentCategoriesStore.setState({ fetchStatus: "success" });
+          feedCategoriesStore.getState().set(payload.snapshot.feedTags);
+          feedCategoriesStore.setState({ fetchStatus: "success" });
+          viewFeedsStore.getState().set(payload.snapshot.directViewFeeds);
+          viewFeedsStore.setState({ fetchStatus: "success" });
+          feedItemsStore.setState({
+            hasInitialData: true,
+            viewFeedIds: Object.fromEntries(
+              payload.snapshot.effectiveViewFeeds.map(({ viewId, feedIds }) => [
+                viewId,
+                feedIds,
+              ]),
+            ),
+          });
+        });
+        performanceMark("serial:reconciliation-organization-applied");
+        return true;
+      case "active-scope": {
+        const applied = applyActiveFirstPage(payload.page);
+        if (applied) {
+          performanceMark("serial:reconciliation-active-scope-applied");
+        }
+        return applied;
+      }
+      case "navigation":
+        navigationSnapshotStore.getState().set(payload.snapshot);
+        performanceMark("serial:reconciliation-navigation-applied");
+        return true;
+    }
+  },
+  applyLiveEvent: (payloads) => {
+    const result = applyPublishedChunks(payloads, {
+      refreshNavigation: false,
+    });
+    const activeTarget = currentSelection();
+    const activeScopeKey = activeTarget
+      ? getMixedScopeKey(activeTarget.scope, activeTarget.contentStatus)
+      : null;
+    const activeScopeChanged = result.affectedScopes.some(
+      (scope) =>
+        activeScopeKey === getMixedScopeKey(scope.scope, scope.contentStatus),
+    );
+    return [
+      ...(activeTarget && activeScopeChanged ? [activeTarget] : []),
+      ...(result.navigationSnapshotChanged
+        ? ([{ type: "navigation" }] as const)
+        : []),
+    ];
+  },
+  getCurrentSelection: currentSelection,
+  mark: performanceMark,
+  onParityApplied: () => loadingActor.send({ type: "INITIAL_DATA_COMPLETE" }),
+});
+
+const organizationStores = [
+  viewsStore,
+  feedsStore,
+  contentCategoriesStore,
+  feedCategoriesStore,
+  viewFeedsStore,
+].map(asPersistedStore);
+const activeScopeStores = [feedItemsStore, mixedContentStore].map(
+  asPersistedStore,
+);
+const bookmarkStores = [bookmarksStore].map(asPersistedStore);
+const allPersistedStores = [
+  ...organizationStores,
+  ...activeScopeStores,
+  ...bookmarkStores,
+];
+let hydrationCleanups: Array<() => void> = [];
+
+function observeHydration(stores: PersistedStore[], onHydrated: () => void) {
+  let emitted = false;
+  const check = () => {
+    if (emitted || !stores.every((store) => store.persist.hasHydrated()))
+      return;
+    emitted = true;
+    onHydrated();
+  };
+  const cleanups = stores.map((store) =>
+    store.persist.onFinishHydration(check),
+  );
+  check();
+  return () => cleanups.forEach((cleanup) => cleanup());
+}
+
+function observeDomainHydration(
+  domain: ReconciliationHydrationDomain,
+  stores: PersistedStore[],
+) {
+  return observeHydration(stores, () => runtime.hydrationComplete(domain));
+}
+
+export const dataReconciliation = {
+  start() {
+    if (hydrationCleanups.length > 0) return;
+    const atoms = getDefaultStore();
+    atoms.set(viewFilterIdAtom, UNSELECTED_VIEW_ID);
+    atoms.set(feedFilterAtom, -1);
+    atoms.set(categoryFilterAtom, -1);
+    atoms.set(contentStatusFilterAtom, DEFAULT_CONTENT_STATUS_FILTER);
+    atoms.set(dateFilterAtom, 0);
+    loadingActor.send({ type: "INITIAL_LOAD_START" });
+    runtime.hydrationComplete("navigation");
+    hydrationCleanups = [
+      observeDomainHydration("organization", organizationStores),
+      observeDomainHydration("active-scope", activeScopeStores),
+      observeDomainHydration("bookmarks", bookmarkStores),
+      observeHydration(allPersistedStores, () => runtime.cacheUsable()),
+    ];
+    runtime.start();
+  },
+  stop() {
+    hydrationCleanups.forEach((cleanup) => cleanup());
+    hydrationCleanups = [];
+    runtime.stop();
+  },
+  activateScope: runtime.activateScope,
+  receivePublishedChunks: runtime.receiveLiveEvent,
+  sseConnectionChanged: runtime.sseConnectionChanged,
+  getState: runtime.getState,
+  subscribe: runtime.subscribe,
+};
+
+export function getCurrentReconciliationTarget() {
+  return currentSelection();
+}
+
+export function getReconciliationTargetStatus(
+  target: ReconciliationScopeTarget,
+) {
+  return runtime.getState().targets[getReconciliationTargetKey(target)]?.status;
+}

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -69,7 +69,10 @@ function completeBookmarkSyncPages(payloads: PublishedChunk[]) {
   return completed;
 }
 
-export function processPublishedChunks(payloads: PublishedChunk[]) {
+export function applyPublishedChunks(
+  payloads: PublishedChunk[],
+  options: { refreshNavigation?: boolean } = {},
+) {
   const affectedScopes = new Map<string, LoadedMixedScope>();
   let navigationSnapshotChanged = payloads.some(
     ({ chunk }) =>
@@ -236,8 +239,18 @@ export function processPublishedChunks(payloads: PublishedChunk[]) {
       );
     }
   }
-  if (navigationSnapshotChanged) {
+  if (navigationSnapshotChanged && options.refreshNavigation !== false) {
     void refreshNavigationSnapshotSafely();
   }
-  return [...affectedScopes.values()];
+  return {
+    affectedScopes: [...affectedScopes.values()],
+    navigationSnapshotChanged,
+  };
+}
+
+export function processPublishedChunks(
+  payloads: PublishedChunk[],
+  options: { refreshNavigation?: boolean } = {},
+) {
+  return applyPublishedChunks(payloads, options).affectedScopes;
 }

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -6,11 +6,10 @@ import { orpcRouterClient } from "../orpc";
 import { getDataSubscriptionClientId } from "./clientChannel";
 import { combineAbortSignals } from "./combineAbortSignals";
 import { loadingActor } from "./loading-machine";
-import { bookmarksStore } from "./bookmarks/store";
-import { processPublishedChunks } from "./subscriptionCoordinator";
 import { shouldAlwaysKeepSSEConnectionAlive } from "./atoms";
 import { getFeedItemMembershipRevision } from "./feed-items/membershipRevision";
 import { setDataSubscriptionConnected } from "./subscriptionConnection";
+import { dataReconciliation } from "./reconciliation";
 import type { PublishedChunk } from "~/server/api/publisher";
 import type { ContentStatusFilter } from "~/lib/content-status";
 import type {
@@ -65,16 +64,8 @@ export function useDataSubscription() {
     const chunks = chunkBufferRef.current;
     if (chunks.length === 0) return;
     chunkBufferRef.current = [];
-    const affectedScopes = processPublishedChunks(chunks);
-    for (const scope of affectedScopes) {
-      void orpcRouterClient.mixedContent.requestPage({
-        clientId,
-        scope: scope.scope,
-        contentStatus: scope.contentStatus,
-        cursor: null,
-      });
-    }
-  }, [clientId]);
+    dataReconciliation.receivePublishedChunks(chunks);
+  }, []);
 
   // Cleanup aborts the stream and removes both direct subscriptions. The
   // subscription loop also combines its connection signal with this abort.
@@ -87,7 +78,6 @@ export function useDataSubscription() {
     // Per-connection controller — aborted on visibility change to force
     // a reconnect without tearing down the entire subscription lifecycle.
     let connectionController: AbortController | null = null;
-    let visibilityReconnect = false;
     let paused = false;
 
     async function runSubscriptionLoop() {
@@ -116,20 +106,7 @@ export function useDataSubscription() {
             { signal: connectionSignal },
           );
           setDataSubscriptionConnected(true);
-
-          // After reconnecting due to page refocus, re-request data so
-          // the server sends fresh metadata, diffs, and triggers a
-          // refresh if the cooldown elapsed while the tab was hidden.
-          if (visibilityReconnect) {
-            visibilityReconnect = false;
-            void Promise.all([
-              orpcRouterClient.initial.requestInitialData({ clientId }),
-              orpcRouterClient.mixedContent.synchronize({
-                clientId,
-                bookmarkManifest: bookmarksStore.getState().manifest(),
-              }),
-            ]);
-          }
+          dataReconciliation.sseConnectionChanged(true);
 
           for await (const payload of iterator as AsyncIterable<PublishedChunk>) {
             if (conn.signal.aborted) break;
@@ -142,6 +119,7 @@ export function useDataSubscription() {
           }
         } catch (error) {
           setDataSubscriptionConnected(false);
+          dataReconciliation.sseConnectionChanged(false);
 
           if (controller.signal.aborted) break;
 
@@ -160,6 +138,7 @@ export function useDataSubscription() {
           );
         } finally {
           setDataSubscriptionConnected(false);
+          dataReconciliation.sseConnectionChanged(false);
           cleanupConnectionSignal();
         }
       }
@@ -184,7 +163,6 @@ export function useDataSubscription() {
         (document.visibilityState === "hidden" && shouldStayAlive)
       ) {
         paused = false;
-        visibilityReconnect = true;
         // If the loop is waiting on the paused promise, the
         // visibilitychange listener inside it will resolve it.
         // If it's in a backoff sleep, the next iteration will
@@ -219,6 +197,7 @@ export function useDataSubscription() {
       unsubscribeAtom();
       controller.abort();
       setDataSubscriptionConnected(false);
+      dataReconciliation.sseConnectionChanged(false);
       // Cancel any pending RAF flush
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);
@@ -226,22 +205,11 @@ export function useDataSubscription() {
       }
       // Flush remaining chunks synchronously on unmount
       if (chunkBufferRef.current.length > 0) {
-        processPublishedChunks(chunkBufferRef.current);
+        dataReconciliation.receivePublishedChunks(chunkBufferRef.current);
         chunkBufferRef.current = [];
       }
     };
   }, [clientId, flushBuffer]);
-
-  // Request methods that trigger data fetching via the publisher
-  const requestInitialData = useCallback(() => {
-    return Promise.all([
-      orpcRouterClient.initial.requestInitialData({ clientId }),
-      orpcRouterClient.mixedContent.synchronize({
-        clientId,
-        bookmarkManifest: bookmarksStore.getState().manifest(),
-      }),
-    ]);
-  }, [clientId]);
 
   const requestFullTextForItems = useCallback(
     (itemIds: string[]) => {
@@ -311,7 +279,6 @@ export function useDataSubscription() {
   );
 
   return {
-    requestInitialData,
     requestFullTextForItems,
     requestItemsByContentStatus,
     requestItemsByFeed,
@@ -324,16 +291,6 @@ export function useDataSubscription() {
  * This allows accessing request methods from anywhere in the app.
  */
 export const dataSubscriptionActions = {
-  requestInitialData: () => {
-    const clientId = getDataSubscriptionClientId();
-    return Promise.all([
-      orpcRouterClient.initial.requestInitialData({ clientId }),
-      orpcRouterClient.mixedContent.synchronize({
-        clientId,
-        bookmarkManifest: bookmarksStore.getState().manifest(),
-      }),
-    ]);
-  },
   requestMixedContentPage: (
     scope: Parameters<
       typeof orpcRouterClient.mixedContent.requestPage

--- a/apps/app/src/lib/hooks/useLoadMoreItems.ts
+++ b/apps/app/src/lib/hooks/useLoadMoreItems.ts
@@ -109,12 +109,14 @@ export function useLoadMoreItems() {
 
   const mixedScope = useMemo(
     () =>
-      activeFilterType === "category"
-        ? ({ type: "tag", tagId: categoryFilter } as const)
-        : activeFilterType === "view" && viewId !== undefined
-          ? ({ type: "view", viewId } as const)
-          : null,
-    [activeFilterType, categoryFilter, viewId],
+      activeFilterType === "feed"
+        ? ({ type: "feed", feedId: feedFilter } as const)
+        : activeFilterType === "category"
+          ? ({ type: "tag", tagId: categoryFilter } as const)
+          : activeFilterType === "view" && viewId !== undefined
+            ? ({ type: "view", viewId } as const)
+            : null,
+    [activeFilterType, feedFilter, categoryFilter, viewId],
   );
   const mixedScopeKey = mixedScope
     ? getMixedScopeKey(mixedScope, contentStatusFilter)

--- a/apps/app/src/lib/reconciliation/contracts.ts
+++ b/apps/app/src/lib/reconciliation/contracts.ts
@@ -181,6 +181,10 @@ export type ReconciliationRequestIntent =
       selectedScope: ReconciliationScopeTarget;
     }
   | {
+      type: "full";
+      coldContentStatus: ContentStatusFilter;
+    }
+  | {
       type: "targeted";
       targets: ReconciliationTarget[];
     };

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -287,7 +287,7 @@ function startRequest<TAuthoritative, TLiveEvent>(
   intent: ReconciliationRequestIntent,
 ): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
   const targets = uniqueTargets(requestTargets(intent));
-  const reconciliationId = `${state.sessionId}:${state.nextReconciliationSequence}`;
+  const reconciliationId = `${state.sessionId}-${state.nextReconciliationSequence}`;
   const capturedRevisions = Object.fromEntries(
     targets.map((target) => [
       getReconciliationTargetKey(target),

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -44,7 +44,8 @@ type ReconciliationRequestRecord = ReconciliationRequestDescriptor & {
 
 type FullEpoch = {
   reconciliationId: string;
-  selectedScope: ReconciliationScopeTarget;
+  intent: Extract<ReconciliationRequestIntent, { type: "full" }>;
+  selectedScope: ReconciliationScopeTarget | null;
   requiredTargetKeys: string[];
   completed: boolean;
   established: boolean;
@@ -150,6 +151,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       type: "request-settled";
       reconciliationId: string;
       at: number;
+      failed?: boolean;
       failedTargets?: ReconciliationTarget[];
     }
   | {
@@ -211,9 +213,10 @@ export function createReconciliationCoordinatorState<
 }
 
 function requestTargets(intent: ReconciliationRequestIntent) {
-  return intent.type === "full"
+  if (intent.type === "targeted") return intent.targets;
+  return "selectedScope" in intent
     ? getRequiredTargetsForFullReconciliation(intent.selectedScope)
-    : intent.targets;
+    : ([{ type: "organization" }, { type: "navigation" }] as const);
 }
 
 function uniqueTargets(targets: readonly ReconciliationTarget[]) {
@@ -313,7 +316,8 @@ function startRequest<TAuthoritative, TLiveEvent>(
       ...nextState,
       latestFullEpoch: {
         reconciliationId,
-        selectedScope: intent.selectedScope,
+        intent,
+        selectedScope: "selectedScope" in intent ? intent.selectedScope : null,
         requiredTargetKeys: targets.map(getReconciliationTargetKey),
         completed: false,
         established: false,
@@ -347,8 +351,60 @@ function repairIntentFor<TAuthoritative, TLiveEvent>(
 ): ReconciliationRequestIntent {
   const fullEpoch = state.latestFullEpoch;
   return fullEpoch && !fullEpoch.established
-    ? { type: "full", selectedScope: fullEpoch.selectedScope }
+    ? fullEpoch.intent
     : { type: "targeted", targets: uniqueTargets(targets) };
+}
+
+function bindColdFullScope<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  reconciliationId: string,
+  target: ReconciliationTarget,
+) {
+  if (target.type !== "scope") return state;
+  const request = state.requests[reconciliationId];
+  if (
+    request?.intent.type !== "full" ||
+    "selectedScope" in request.intent ||
+    request.targets.some(
+      (candidate) =>
+        getReconciliationTargetKey(candidate) ===
+        getReconciliationTargetKey(target),
+    )
+  ) {
+    return state;
+  }
+
+  const targetKey = getReconciliationTargetKey(target);
+  const currentTarget = targetState(state, target);
+  const boundRequest = {
+    ...request,
+    targets: [...request.targets, target],
+    capturedRevisions: {
+      ...request.capturedRevisions,
+      [targetKey]: currentTarget.revision,
+    },
+  };
+  let nextState = withTargetState(state, {
+    ...currentTarget,
+    status: "syncing",
+    requestedReconciliationId: reconciliationId,
+  });
+  nextState = {
+    ...nextState,
+    requests: { ...nextState.requests, [reconciliationId]: boundRequest },
+    latestFullEpoch:
+      nextState.latestFullEpoch?.reconciliationId === reconciliationId
+        ? {
+            ...nextState.latestFullEpoch,
+            selectedScope: target,
+            requiredTargetKeys: [
+              ...nextState.latestFullEpoch.requiredTargetKeys,
+              targetKey,
+            ],
+          }
+        : nextState.latestFullEpoch,
+  };
+  return markTargetsDirty(nextState, [target], false);
 }
 
 function markTargetsDirty<TAuthoritative, TLiveEvent>(
@@ -468,13 +524,18 @@ function fullEpochIsApplied<TAuthoritative, TLiveEvent>(
 ) {
   const fullEpoch = state.latestFullEpoch;
   if (!fullEpoch?.completed) return false;
-  return fullEpoch.requiredTargetKeys.every((targetKey) => {
-    const target = state.targets[targetKey];
-    return (
-      target?.status === "verified" &&
-      target.appliedReconciliationId === fullEpoch.reconciliationId
-    );
-  });
+  return (
+    REQUIRED_RECONCILIATION_DOMAINS.every(
+      (domain) => state.domains[domain].status === "verified",
+    ) &&
+    fullEpoch.requiredTargetKeys.every((targetKey) => {
+      const target = state.targets[targetKey];
+      return (
+        target?.status === "verified" &&
+        target.appliedReconciliationId === fullEpoch.reconciliationId
+      );
+    })
+  );
 }
 
 function withEstablishedFullParity<TAuthoritative, TLiveEvent>(
@@ -548,8 +609,12 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
       return flushBufferedApplications(hydratedState);
     }
     case "request-reconciliation":
-      return enqueueRequest(state, event.intent);
+      return enqueueRequest(
+        markTargetsDirty(state, requestTargets(event.intent), false),
+        event.intent,
+      );
     case "authoritative-received": {
+      state = bindColdFullScope(state, event.reconciliationId, event.target);
       if (
         !requestRevisionIsCurrent(state, event.reconciliationId, event.target)
       ) {
@@ -674,6 +739,7 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
       if (
         nextState.latestFullEpoch?.reconciliationId ===
           event.reconciliationId &&
+        event.failed !== true &&
         (!event.failedTargets || event.failedTargets.length === 0)
       ) {
         nextState = withEstablishedFullParity(

--- a/apps/app/src/lib/reconciliation/index.ts
+++ b/apps/app/src/lib/reconciliation/index.ts
@@ -1,4 +1,5 @@
 export * from "./contracts";
 export * from "./coordinator";
 export * from "./reducers";
+export * from "./runtime";
 export * from "./versions";

--- a/apps/app/src/lib/reconciliation/runtime.ts
+++ b/apps/app/src/lib/reconciliation/runtime.ts
@@ -1,0 +1,382 @@
+import {
+  createReconciliationCoordinatorState,
+  transitionReconciliation,
+} from "./coordinator";
+import { getReconciliationTargetKey } from "./contracts";
+import type {
+  ReconciliationCommand,
+  ReconciliationCoordinatorEvent,
+  ReconciliationCoordinatorState,
+  ReconciliationRequestDescriptor,
+} from "./coordinator";
+import type {
+  ActiveFirstPageResult,
+  OrganizationSnapshot,
+  ReconciliationHydrationDomain,
+  ReconciliationInput,
+  ReconciliationScopeTarget,
+  ReconciliationStreamEvent,
+  ReconciliationTarget,
+  RequiredReconciliationDomain,
+} from "./contracts";
+import type { NavigationSnapshot } from "~/server/navigation/snapshot";
+
+export type ReconciliationAuthoritativePayload =
+  | { type: "organization"; snapshot: OrganizationSnapshot }
+  | { type: "active-scope"; page: ActiveFirstPageResult }
+  | { type: "navigation"; snapshot: NavigationSnapshot };
+
+export type ReconciliationRuntimeDependencies<TLiveEvent> = {
+  sessionId: () => string;
+  now: () => number;
+  buildInput: (request: ReconciliationRequestDescriptor) => ReconciliationInput;
+  openStream: (
+    input: ReconciliationInput,
+    signal: AbortSignal,
+  ) => Promise<AsyncIterable<ReconciliationStreamEvent>>;
+  applyAuthoritative: (payload: ReconciliationAuthoritativePayload) => boolean;
+  applyLiveEvent: (payload: TLiveEvent) => ReconciliationTarget[] | void;
+  getCurrentSelection: () => ReconciliationScopeTarget | null;
+  mark?: (name: string, reconciliationId?: string) => void;
+  onParityApplied?: () => void;
+};
+
+export type ReconciliationRuntime<TLiveEvent> = ReturnType<
+  typeof createReconciliationRuntime<TLiveEvent>
+>;
+
+function failureTarget(
+  event: Extract<ReconciliationStreamEvent["chunk"], { type: "domain-error" }>,
+): ReconciliationTarget | undefined {
+  if (event.failure.target) return event.failure.target;
+  if (event.failure.domain === "organization") return { type: "organization" };
+  if (event.failure.domain === "navigation") return { type: "navigation" };
+  return undefined;
+}
+
+function hydrationFor(payload: ReconciliationAuthoritativePayload) {
+  switch (payload.type) {
+    case "organization":
+      return ["organization"] as ReconciliationHydrationDomain[];
+    case "active-scope":
+      return [
+        "organization",
+        "active-scope",
+        "bookmarks",
+      ] as ReconciliationHydrationDomain[];
+    case "navigation":
+      return ["organization", "navigation"] as ReconciliationHydrationDomain[];
+  }
+}
+
+export function createReconciliationRuntime<TLiveEvent>(
+  dependencies: ReconciliationRuntimeDependencies<TLiveEvent>,
+) {
+  type State = ReconciliationCoordinatorState<
+    ReconciliationAuthoritativePayload,
+    TLiveEvent
+  >;
+  type Event = ReconciliationCoordinatorEvent<
+    ReconciliationAuthoritativePayload,
+    TLiveEvent
+  >;
+  type Command = ReconciliationCommand<
+    ReconciliationAuthoritativePayload,
+    TLiveEvent
+  >;
+
+  let state: State = createReconciliationCoordinatorState(
+    dependencies.sessionId(),
+  );
+  let started = false;
+  let everConnected = false;
+  let reconnectRequired = false;
+  let completedBeforeFirstConnection = false;
+  let liveSequence = 0;
+  const listeners = new Set<() => void>();
+  const requestControllers = new Map<string, AbortController>();
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const execute = (commands: Command[]) => {
+    for (const command of commands) {
+      if (command.type === "start-reconciliation") {
+        dependencies.mark?.(
+          "serial:reconciliation-requested",
+          command.request.reconciliationId,
+        );
+        const controller = new AbortController();
+        requestControllers.set(command.request.reconciliationId, controller);
+        void runRequest(command.request, controller.signal);
+        continue;
+      }
+      if (command.type === "apply-live-event") {
+        const invalidatedTargets = dependencies.applyLiveEvent(command.payload);
+        if (invalidatedTargets && invalidatedTargets.length > 0) {
+          send({
+            type: "live-event-received",
+            eventId: `applied:${command.eventId}`,
+            targets: invalidatedTargets,
+            invalidates: invalidatedTargets,
+            requiresHydration: [],
+          });
+        }
+        continue;
+      }
+      const applied = dependencies.applyAuthoritative(command.payload);
+      if (applied) {
+        send({
+          type: "authoritative-applied",
+          reconciliationId: command.reconciliationId,
+          target: command.target,
+          at: dependencies.now(),
+        });
+      } else {
+        send({
+          type: "live-event-received",
+          eventId: `rejected-authority:${command.reconciliationId}`,
+          targets: [command.target],
+          invalidates: [command.target],
+          requiresHydration: [],
+        });
+      }
+    }
+  };
+
+  const send = (event: Event) => {
+    const previousParity = state.serverParityAppliedAt;
+    const transition = transitionReconciliation(state, event);
+    state = transition.state;
+    notify();
+    if (
+      previousParity !== state.serverParityAppliedAt &&
+      state.serverParityAppliedAt !== null
+    ) {
+      dependencies.mark?.(
+        "serial:server-parity-applied",
+        state.latestFullEpoch?.reconciliationId,
+      );
+      dependencies.onParityApplied?.();
+    }
+    execute(transition.commands);
+  };
+
+  const applyCompletedDomain = (
+    reconciliationId: string,
+    domain: RequiredReconciliationDomain,
+    pending: Partial<
+      Record<RequiredReconciliationDomain, ReconciliationAuthoritativePayload>
+    >,
+  ) => {
+    const payload = pending[domain];
+    if (!payload) return;
+    delete pending[domain];
+    const target: ReconciliationTarget =
+      payload.type === "active-scope"
+        ? payload.page.target
+        : { type: payload.type };
+    dependencies.mark?.(
+      `serial:reconciliation-${domain}-received`,
+      reconciliationId,
+    );
+    send({
+      type: "authoritative-received",
+      reconciliationId,
+      target,
+      requiresHydration: hydrationFor(payload),
+      payload,
+    });
+  };
+
+  async function runRequest(
+    request: ReconciliationRequestDescriptor,
+    signal: AbortSignal,
+  ) {
+    const pending: Partial<
+      Record<RequiredReconciliationDomain, ReconciliationAuthoritativePayload>
+    > = {};
+    let settled = false;
+    try {
+      const input = dependencies.buildInput(request);
+      const stream = await dependencies.openStream(input, signal);
+      for await (const event of stream) {
+        if (signal.aborted) return;
+        if (event.reconciliationId !== request.reconciliationId) continue;
+        const { chunk } = event;
+        switch (chunk.type) {
+          case "organization-snapshot":
+            pending.organization = {
+              type: "organization",
+              snapshot: chunk.snapshot,
+            };
+            break;
+          case "active-first-page":
+            pending["active-scope"] = {
+              type: "active-scope",
+              page: chunk.page,
+            };
+            break;
+          case "navigation-snapshot":
+            pending.navigation = {
+              type: "navigation",
+              snapshot: chunk.snapshot,
+            };
+            break;
+          case "domain-complete":
+            applyCompletedDomain(
+              request.reconciliationId,
+              chunk.domain,
+              pending,
+            );
+            break;
+          case "automatic-rss-owner":
+            send({
+              type: "automatic-rss-owner-resolved",
+              owner: chunk.owner,
+            });
+            break;
+          case "domain-error": {
+            const target = failureTarget(chunk);
+            if (!state.sseConnected && !everConnected) {
+              completedBeforeFirstConnection = true;
+            }
+            send({
+              type: "request-settled",
+              reconciliationId: request.reconciliationId,
+              at: dependencies.now(),
+              failed: true,
+              failedTargets: target ? [target] : undefined,
+            });
+            settled = true;
+            return;
+          }
+          case "epoch-complete":
+            if (!state.sseConnected && !everConnected) {
+              completedBeforeFirstConnection = true;
+            }
+            send({
+              type: "request-settled",
+              reconciliationId: request.reconciliationId,
+              at: dependencies.now(),
+            });
+            settled = true;
+            return;
+        }
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        console.error("Reconciliation request failed", error);
+      }
+    } finally {
+      requestControllers.delete(request.reconciliationId);
+      if (!settled && !signal.aborted) {
+        if (!state.sseConnected && !everConnected) {
+          completedBeforeFirstConnection = true;
+        }
+        const failedTargets = state.requests[request.reconciliationId]?.targets;
+        send({
+          type: "request-settled",
+          reconciliationId: request.reconciliationId,
+          at: dependencies.now(),
+          failed: true,
+          failedTargets,
+        });
+      }
+    }
+  }
+
+  const requestCurrentFull = () => {
+    const selectedScope = dependencies.getCurrentSelection();
+    send({
+      type: "request-reconciliation",
+      intent: selectedScope
+        ? { type: "full", selectedScope }
+        : {
+            type: "full",
+            coldContentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+          },
+    });
+  };
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      requestCurrentFull();
+    },
+    stop() {
+      for (const controller of requestControllers.values()) controller.abort();
+      requestControllers.clear();
+      started = false;
+      everConnected = false;
+      reconnectRequired = false;
+      completedBeforeFirstConnection = false;
+      state = createReconciliationCoordinatorState(dependencies.sessionId());
+      notify();
+    },
+    cacheUsable() {
+      send({ type: "cache-usable", at: dependencies.now() });
+      dependencies.mark?.("serial:cache-usable");
+    },
+    hydrationComplete(domain: ReconciliationHydrationDomain) {
+      send({ type: "hydration-complete", domain });
+    },
+    sseConnectionChanged(connected: boolean) {
+      const wasConnected = state.sseConnected;
+      send({ type: "sse-connection-changed", connected });
+      if (!connected) {
+        if (wasConnected) reconnectRequired = true;
+        return;
+      }
+      dependencies.mark?.("serial:subscription-connected");
+      if (
+        reconnectRequired ||
+        (!everConnected && completedBeforeFirstConnection)
+      ) {
+        reconnectRequired = false;
+        completedBeforeFirstConnection = false;
+        requestCurrentFull();
+      }
+      everConnected = true;
+    },
+    activateScope(target: ReconciliationScopeTarget) {
+      const targetState = state.targets[getReconciliationTargetKey(target)];
+      if (
+        targetState?.status === "verified" ||
+        targetState?.status === "syncing"
+      ) {
+        return;
+      }
+      send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [target] },
+      });
+    },
+    receiveLiveEvent(payload: TLiveEvent) {
+      const inFlightFull = state.inFlight?.intent.type === "full";
+      const selectedScope = dependencies.getCurrentSelection();
+      const invalidates = inFlightFull
+        ? ([
+            { type: "organization" },
+            ...(selectedScope ? [selectedScope] : []),
+            { type: "navigation" },
+          ] as ReconciliationTarget[])
+        : undefined;
+      send({
+        type: "live-event-received",
+        eventId: `live:${++liveSequence}`,
+        targets: selectedScope ? [selectedScope] : [],
+        requiresHydration: ["organization", "active-scope", "bookmarks"],
+        payload,
+        invalidates,
+      });
+    },
+    getState: () => state,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-mixed-sync.spec.ts
@@ -60,7 +60,7 @@ test.describe("Bookmark mixed-content synchronization", () => {
     if (testEmail) await cleanupUser(SELF_HOSTED_TURSO_PORT, testEmail);
   });
 
-  test("hydrates normalized Bookmarks without eagerly fetching mixed scopes", async ({
+  test("hydrates only the first View's Inbox scope on cold startup", async ({
     page,
   }) => {
     const { email, password, feedItemId } = await seedArticleData(
@@ -76,25 +76,28 @@ test.describe("Bookmark mixed-content synchronization", () => {
 
     await signIn({ page, email, password });
 
+    const mixedScopePrefix =
+      "serial-mixed-content-store-v2::normalized:v1::record:scopes:";
+    const initialScopeKey =
+      mixedScopePrefix + encodeURIComponent(`view:${viewId}:inbox:unread`);
     await expect
       .poll(
         async () => {
-          const bookmarkCache = (await persistedValue(
-            page,
-            `serial-bookmarks-store::normalized:v1::record:bookmarksDict:${encodeURIComponent(bookmarkId)}`,
-          )) as { captureHash?: string } | null;
-          return bookmarkCache?.captureHash;
+          const mixedScopeKeys = (await persistedKeys(page)).filter(
+            (key) =>
+              typeof key === "string" && key.startsWith(mixedScopePrefix),
+          );
+          return mixedScopeKeys;
         },
         { timeout: 30_000 },
       )
-      .toBe(`hash-${bookmarkId}`);
+      .toEqual([initialScopeKey]);
 
-    const mixedScopePrefix =
-      "serial-mixed-content-store-v2::normalized:v1::record:scopes:";
-    const mixedScopeKeys = (await persistedKeys(page)).filter(
-      (key) => typeof key === "string" && key.startsWith(mixedScopePrefix),
+    const bookmarkCache = await persistedValue(
+      page,
+      `serial-bookmarks-store::normalized:v1::record:bookmarksDict:${encodeURIComponent(bookmarkId)}`,
     );
-    expect(mixedScopeKeys).toEqual([]);
+    expect(bookmarkCache).toBeUndefined();
     expect(viewId).toBeGreaterThan(0);
   });
 

--- a/apps/app/tests/unit/data/mixed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/mixed-page-retention.test.ts
@@ -99,4 +99,52 @@ describe("mixed-content page retention", () => {
       scope?.references.some(({ entityId }) => entityId.startsWith("page-1-")),
     ).toBe(false);
   });
+
+  it("retains a provisional tail only when the authoritative first page is unchanged", () => {
+    applyPages(3);
+    const contentStatus = {
+      saveStatus: "inbox",
+      archiveStatus: "unread",
+    } as const;
+    const scopeKey = getMixedScopeKey(SCOPE, contentStatus);
+
+    expect(
+      mixedContentStore.getState().reconcileFirstPage({
+        scope: SCOPE,
+        contentStatus,
+        page: {
+          references: references(0),
+          bookmarks: [],
+          feedItems: [],
+          cursor: cursor(0),
+          hasMore: true,
+        },
+      }),
+    ).toEqual({ firstPageChanged: false });
+    expect(
+      mixedContentStore.getState().scopes[scopeKey]?.references,
+    ).toHaveLength(90);
+
+    const changedReferences = references(9);
+    expect(
+      mixedContentStore.getState().reconcileFirstPage({
+        scope: SCOPE,
+        contentStatus,
+        page: {
+          references: changedReferences,
+          bookmarks: [],
+          feedItems: [],
+          cursor: cursor(9),
+          hasMore: false,
+        },
+      }),
+    ).toEqual({ firstPageChanged: true });
+    expect(mixedContentStore.getState().scopes[scopeKey]?.references).toEqual(
+      [...changedReferences].reverse(),
+    );
+    expect(mixedContentStore.getState().scopes[scopeKey]?.pages).toHaveLength(
+      1,
+    );
+    expect(mixedContentStore.getState().scopes[scopeKey]?.hasMore).toBe(false);
+  });
 });

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ActiveFirstPageResult,
+  OrganizationSnapshot,
+  ReconciliationInput,
+  ReconciliationRequestDescriptor,
+  ReconciliationScopeTarget,
+  ReconciliationStreamEvent,
+} from "~/lib/reconciliation";
+import type { NavigationSnapshot } from "~/server/navigation/snapshot";
+import {
+  createReconciliationRuntime,
+  getReconciliationTargetKey,
+} from "~/lib/reconciliation";
+
+const ACTIVE_SCOPE: ReconciliationScopeTarget = {
+  type: "scope",
+  scope: { type: "view", viewId: 7 },
+  contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+};
+
+const ORGANIZATION: OrganizationSnapshot = {
+  views: [],
+  feeds: [],
+  tags: [],
+  feedTags: [],
+  directViewFeeds: [],
+  effectiveViewFeeds: [],
+};
+
+const PAGE: ActiveFirstPageResult = {
+  target: ACTIVE_SCOPE,
+  membershipRevision: 0,
+  orderedRefs: [],
+  feedItemDiffs: [],
+  bookmarkDiffs: [],
+  cursor: null,
+  hasMore: false,
+};
+
+const NAVIGATION: NavigationSnapshot = {
+  views: {},
+  feeds: {},
+  tags: {},
+  viewFeeds: {},
+};
+
+function completeEpoch(reconciliationId: string): ReconciliationStreamEvent[] {
+  return [
+    {
+      reconciliationId,
+      chunk: { type: "organization-snapshot", snapshot: ORGANIZATION },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "domain-complete", domain: "organization" },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "active-first-page", page: PAGE },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "domain-complete",
+        domain: "active-scope",
+        target: ACTIVE_SCOPE,
+      },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "navigation-snapshot", snapshot: NAVIGATION },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "domain-complete", domain: "navigation" },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "epoch-complete",
+        requiredDomains: ["organization", "active-scope", "navigation"],
+      },
+    },
+  ];
+}
+
+function harness(
+  events: (
+    request: ReconciliationRequestDescriptor,
+  ) => ReconciliationStreamEvent[],
+) {
+  const requests: ReconciliationRequestDescriptor[] = [];
+  const applications: string[] = [];
+  const liveApplications: string[][] = [];
+  let currentSelection: ReconciliationScopeTarget | null = null;
+  let now = 0;
+  const runtime = createReconciliationRuntime<string[]>({
+    sessionId: () => "runtime-session",
+    now: () => ++now,
+    buildInput: (request) => {
+      requests.push(request);
+      return {
+        type: "full",
+        reconciliationId: request.reconciliationId,
+        selection: {
+          type: "cold",
+          contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+          membershipRevision: 0,
+        },
+      } satisfies ReconciliationInput;
+    },
+    openStream: async (_input, signal) => ({
+      async *[Symbol.asyncIterator]() {
+        const request = requests.at(-1);
+        if (!request) throw new Error("Expected a request");
+        for (const event of events(request)) {
+          if (signal.aborted) return;
+          yield event;
+        }
+      },
+    }),
+    applyAuthoritative: (payload) => {
+      applications.push(payload.type);
+      return true;
+    },
+    applyLiveEvent: (payload) => {
+      liveApplications.push(payload);
+    },
+    getCurrentSelection: () => currentSelection,
+  });
+  return {
+    runtime,
+    requests,
+    applications,
+    liveApplications,
+    setSelection(selection: ReconciliationScopeTarget | null) {
+      currentSelection = selection;
+    },
+  };
+}
+
+function hydrate(runtime: ReturnType<typeof harness>["runtime"]) {
+  for (const domain of [
+    "organization",
+    "active-scope",
+    "bookmarks",
+    "navigation",
+  ] as const) {
+    runtime.hydrationComplete(domain);
+  }
+}
+
+describe("client reconciliation runtime", () => {
+  it("starts cold, buffers complete domains through hydration, and establishes parity", async () => {
+    const test = harness((request) => completeEpoch(request.reconciliationId));
+    test.runtime.start();
+
+    await vi.waitFor(() => expect(test.requests).toHaveLength(1));
+    expect(test.requests[0]?.intent).toEqual({
+      type: "full",
+      coldContentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+    });
+    expect(test.applications).toEqual([]);
+
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    hydrate(test.runtime);
+
+    await vi.waitFor(() =>
+      expect(test.applications).toEqual([
+        "organization",
+        "active-scope",
+        "navigation",
+      ]),
+    );
+    expect(test.runtime.getState().trustedUpToDate).toBe(true);
+    expect(
+      test.runtime.getState().targets[getReconciliationTargetKey(ACTIVE_SCOPE)]
+        ?.status,
+    ).toBe("verified");
+  });
+
+  it("runs one follow-up full request when the first SSE connection is late", async () => {
+    const test = harness((request) => completeEpoch(request.reconciliationId));
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.start();
+    await vi.waitFor(() =>
+      expect(test.runtime.getState().serverParityAppliedAt).not.toBeNull(),
+    );
+    expect(test.requests).toHaveLength(1);
+
+    test.setSelection(ACTIVE_SCOPE);
+    test.runtime.sseConnectionChanged(true);
+    await vi.waitFor(() => expect(test.requests).toHaveLength(2));
+    expect(test.requests[1]?.intent).toEqual({
+      type: "full",
+      selectedScope: ACTIVE_SCOPE,
+    });
+  });
+
+  it("does not request a verified scope again but full-reconciles after reconnect", async () => {
+    const test = harness((request) => completeEpoch(request.reconciliationId));
+    test.setSelection(ACTIVE_SCOPE);
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+    await vi.waitFor(() =>
+      expect(test.runtime.getState().trustedUpToDate).toBe(true),
+    );
+    expect(test.requests).toHaveLength(1);
+
+    test.runtime.activateScope(ACTIVE_SCOPE);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(test.requests).toHaveLength(1);
+
+    test.runtime.sseConnectionChanged(false);
+    test.runtime.sseConnectionChanged(true);
+    await vi.waitFor(() => expect(test.requests).toHaveLength(2));
+    expect(test.requests[1]?.intent).toEqual({
+      type: "full",
+      selectedScope: ACTIVE_SCOPE,
+    });
+  });
+
+  it("preserves completed domains and withholds parity after a terminal error", async () => {
+    const test = harness((request) => [
+      {
+        reconciliationId: request.reconciliationId,
+        chunk: { type: "organization-snapshot", snapshot: ORGANIZATION },
+      },
+      {
+        reconciliationId: request.reconciliationId,
+        chunk: { type: "domain-complete", domain: "organization" },
+      },
+      {
+        reconciliationId: request.reconciliationId,
+        chunk: {
+          type: "domain-error",
+          failure: {
+            phase: "load-active-scope",
+            domain: "active-scope",
+            target: ACTIVE_SCOPE,
+            message: "failed page",
+          },
+        },
+      },
+    ]);
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+
+    await vi.waitFor(() => expect(test.applications).toEqual(["organization"]));
+    expect(test.runtime.getState().domains.organization.status).toBe(
+      "verified",
+    );
+    expect(test.runtime.getState().domains["active-scope"].status).toBe(
+      "dirty",
+    );
+    expect(test.runtime.getState().serverParityAppliedAt).toBeNull();
+    expect(test.runtime.getState().trustedUpToDate).toBe(false);
+  });
+
+  it("buffers live events until their persisted domains hydrate", () => {
+    const test = harness(() => []);
+    test.runtime.receiveLiveEvent(["newer-live-state"]);
+    expect(test.liveApplications).toEqual([]);
+
+    test.runtime.hydrationComplete("organization");
+    test.runtime.hydrationComplete("active-scope");
+    expect(test.liveApplications).toEqual([]);
+    test.runtime.hydrationComplete("bookmarks");
+    expect(test.liveApplications).toEqual([["newer-live-state"]]);
+  });
+});

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   createReconciliationRuntime,
   getReconciliationTargetKey,
 } from "~/lib/reconciliation";
+import { reconciliationInputSchema } from "~/server/reconciliation/input";
 
 const ACTIVE_SCOPE: ReconciliationScopeTarget = {
   type: "scope",
@@ -152,6 +153,24 @@ function hydrate(runtime: ReturnType<typeof harness>["runtime"]) {
 }
 
 describe("client reconciliation runtime", () => {
+  it("generates reconciliation IDs accepted by the RPC transport", () => {
+    const test = harness(() => []);
+    test.runtime.start();
+    const request = test.runtime.getState().inFlight;
+    expect(request).not.toBeNull();
+    expect(
+      reconciliationInputSchema.safeParse({
+        type: "full",
+        reconciliationId: request?.reconciliationId,
+        selection: {
+          type: "cold",
+          contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+          membershipRevision: 0,
+        },
+      }).success,
+    ).toBe(true);
+  });
+
   it("starts cold, buffers complete domains through hydration, and establishes parity", async () => {
     const test = harness((request) => completeEpoch(request.reconciliationId));
     test.runtime.start();


### PR DESCRIPTION
- Route cold load, scope changes, late subscription connection, and reconnect through the finite reconciliation stream.
- Buffer authoritative and live events behind hydration and domain barriers while retaining unchanged mixed-page tails.
- Remove legacy automatic startup fetches and add reconciliation race and retention coverage.