### PR TITLE
Separate and gate RSS ingestion

### DIFF
--- a/apps/app/server/tasks/feeds/background-refresh.ts
+++ b/apps/app/server/tasks/feeds/background-refresh.ts
@@ -33,7 +33,7 @@ export default defineTask({
       hasSubscribers,
       publish: async (channel, chunk) => {
         await publisher.publish(channel, {
-          source: "initial",
+          source: "rss",
           chunk,
         });
       },

--- a/apps/app/src/lib/data/loading-machine.ts
+++ b/apps/app/src/lib/data/loading-machine.ts
@@ -290,6 +290,18 @@ export const loadingMachine = setup({
 
 export const loadingActor = createActor(loadingMachine).start();
 
+export function updateRefreshCooldown(nextRefreshAt: Date | null) {
+  const raw = nextRefreshAt?.getTime();
+  const millisecondsPerMinute = 60_000;
+  loadingActor.send({
+    type: "REFRESH_COOLDOWN_UPDATE",
+    nextRefreshAt:
+      raw === undefined
+        ? null
+        : Math.ceil(raw / millisecondsPerMinute) * millisecondsPerMinute,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Discriminated union consumed by UI components
 // ---------------------------------------------------------------------------

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -5,9 +5,10 @@ import { contentCategoriesStore } from "./content-categories/store";
 import { feedCategoriesStore } from "./feed-categories/store";
 import { getFeedItemMembershipRevision } from "./feed-items/membershipRevision";
 import { feedsStore } from "./feeds/store";
-import { loadingActor } from "./loading-machine";
+import { loadingActor, updateRefreshCooldown } from "./loading-machine";
 import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
 import { navigationSnapshotStore } from "./navigation/store";
+import { rssSummaryAffectsTarget } from "./rssRepair";
 import { applyPublishedChunks } from "./subscriptionCoordinator";
 import { feedItemsStore } from "./store";
 import { viewFeedsStore } from "./view-feeds/store";
@@ -28,9 +29,11 @@ import type {
   ReconciliationPageManifest,
   ReconciliationRequestDescriptor,
   ReconciliationScopeTarget,
+  ReconciliationTarget,
 } from "~/lib/reconciliation";
 import type { PublishedChunk } from "~/server/api/publisher";
 import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { RssAttemptSummary, RssTrigger } from "~/lib/rss";
 import { orpcRouterClient } from "~/lib/orpc";
 import {
   createReconciliationRuntime,
@@ -263,6 +266,59 @@ function performanceMark(name: string, reconciliationId?: string) {
   if (reconciliationId) performance.mark(`${name}:${reconciliationId}`);
 }
 
+function rssRepairMemberships() {
+  return {
+    viewFeedIds: feedItemsStore.getState().viewFeedIds,
+    feedCategories: feedCategoriesStore.getState().feedCategories,
+  };
+}
+
+function rssSummaryFrom(payloads: PublishedChunk[]) {
+  return payloads
+    .flatMap((payload) =>
+      payload.source === "rss" && payload.chunk.type === "rss-attempt-complete"
+        ? [payload.chunk]
+        : [],
+    )
+    .at(-1);
+}
+
+function retainedRssTargets(
+  summary: RssAttemptSummary,
+  activeTarget: ReconciliationScopeTarget | null,
+) {
+  const activeKey = activeTarget
+    ? getReconciliationTargetKey(activeTarget)
+    : null;
+  return Object.values(mixedContentStore.getState().scopes)
+    .map(
+      ({ scope, contentStatus }) =>
+        ({
+          type: "scope",
+          scope,
+          contentStatus,
+        }) satisfies ReconciliationScopeTarget,
+    )
+    .filter(
+      (target) =>
+        getReconciliationTargetKey(target) !== activeKey &&
+        rssSummaryAffectsTarget(summary, target, rssRepairMemberships()),
+    );
+}
+
+let manualFullPromise: Promise<void> | null = null;
+let resolveManualFull: (() => void) | null = null;
+let rejectManualFull: ((error: Error) => void) | null = null;
+let supersededManualFullId: string | null = null;
+
+async function requestDueSources(trigger: RssTrigger) {
+  const result = await orpcRouterClient.initial.fetchDueSources({ trigger });
+  if (result.status !== "background-managed") {
+    updateRefreshCooldown(new Date(result.nextRefreshAt));
+  }
+  return result;
+}
+
 const runtime = createReconciliationRuntime<PublishedChunk[]>({
   sessionId: reconciliationSessionId,
   now: () =>
@@ -314,6 +370,26 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
       refreshNavigation: false,
     });
     const activeTarget = currentSelection();
+    const summary = rssSummaryFrom(payloads);
+    const onlyRssPayloads = payloads.every(({ source }) => source === "rss");
+    if (onlyRssPayloads && !summary) return;
+    if (summary) {
+      const repairTargets: ReconciliationTarget[] = [];
+      if (summary.affectedFeeds.length > 0) {
+        repairTargets.push({ type: "navigation" });
+        if (
+          activeTarget &&
+          rssSummaryAffectsTarget(summary, activeTarget, rssRepairMemberships())
+        ) {
+          repairTargets.push(activeTarget);
+        }
+      }
+      return {
+        repairTargets,
+        dirtyTargets: retainedRssTargets(summary, activeTarget),
+        repairIntent: { type: "targeted", targets: repairTargets } as const,
+      };
+    }
     const activeScopeKey = activeTarget
       ? getMixedScopeKey(activeTarget.scope, activeTarget.contentStatus)
       : null;
@@ -329,8 +405,26 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
     ];
   },
   getCurrentSelection: currentSelection,
+  deferLiveEventInvalidation: (payloads) =>
+    payloads.every(({ source }) => source === "rss"),
   mark: performanceMark,
-  onParityApplied: () => loadingActor.send({ type: "INITIAL_DATA_COMPLETE" }),
+  onParityApplied: ({ automaticRssOwner, reconciliationId }) => {
+    loadingActor.send({ type: "INITIAL_DATA_COMPLETE" });
+    if (resolveManualFull) {
+      if (reconciliationId !== supersededManualFullId) resolveManualFull();
+      return;
+    }
+    if (automaticRssOwner === "client") {
+      void requestDueSources("automatic").catch((error: unknown) => {
+        console.error("Automatic RSS attempt failed", error);
+      });
+    }
+  },
+  onFullReconciliationFailed: ({ reconciliationId }) => {
+    if (reconciliationId !== supersededManualFullId) {
+      rejectManualFull?.(new Error("Manual reconciliation failed"));
+    }
+  },
 });
 
 const organizationStores = [
@@ -398,7 +492,39 @@ export const dataReconciliation = {
     runtime.stop();
   },
   activateScope: runtime.activateScope,
-  receivePublishedChunks: runtime.receiveLiveEvent,
+  requestManualFull() {
+    if (manualFullPromise) return manualFullPromise;
+    manualFullPromise = new Promise<void>((resolve, reject) => {
+      resolveManualFull = resolve;
+      rejectManualFull = reject;
+      const inFlight = runtime.getState().inFlight;
+      supersededManualFullId =
+        inFlight?.intent.type === "full" ? inFlight.reconciliationId : null;
+      runtime.requestFull();
+    }).finally(() => {
+      manualFullPromise = null;
+      resolveManualFull = null;
+      rejectManualFull = null;
+      supersededManualFullId = null;
+    });
+    return manualFullPromise;
+  },
+  requestDueSources,
+  receivePublishedChunks(payloads: PublishedChunk[]) {
+    let start = 0;
+    while (start < payloads.length) {
+      const rss = payloads[start]?.source === "rss";
+      let end = start + 1;
+      while (
+        end < payloads.length &&
+        (payloads[end]?.source === "rss") === rss
+      ) {
+        end++;
+      }
+      runtime.receiveLiveEvent(payloads.slice(start, end));
+      start = end;
+    }
+  },
   sseConnectionChanged: runtime.sseConnectionChanged,
   getState: runtime.getState,
   subscribe: runtime.subscribe,

--- a/apps/app/src/lib/data/rssRepair.ts
+++ b/apps/app/src/lib/data/rssRepair.ts
@@ -1,0 +1,37 @@
+import type { ReconciliationScopeTarget } from "~/lib/reconciliation";
+import type { RssAttemptSummary } from "~/lib/rss";
+import type { DatabaseFeedCategory } from "~/server/db/schema";
+import { buildContentStatusKey } from "~/lib/content-status";
+
+export type RssRepairMemberships = {
+  viewFeedIds: Record<number, number[]>;
+  feedCategories: DatabaseFeedCategory[];
+};
+
+export function rssSummaryAffectsTarget(
+  summary: RssAttemptSummary,
+  target: ReconciliationScopeTarget,
+  memberships: RssRepairMemberships,
+) {
+  const contentStatusKey = buildContentStatusKey(target.contentStatus);
+  const affectedFeedIds = new Set(
+    summary.affectedFeeds.flatMap((feed) =>
+      feed.contentStatusKeys.includes(contentStatusKey) ? [feed.feedId] : [],
+    ),
+  );
+  if (affectedFeedIds.size === 0) return false;
+  if (target.scope.type === "feed") {
+    return affectedFeedIds.has(target.scope.feedId);
+  }
+  if (target.scope.type === "tag") {
+    const tagId = target.scope.tagId;
+    return memberships.feedCategories.some(
+      (assignment) =>
+        assignment.categoryId === tagId &&
+        affectedFeedIds.has(assignment.feedId),
+    );
+  }
+  return (memberships.viewFeedIds[target.scope.viewId] ?? []).some((feedId) =>
+    affectedFeedIds.has(feedId),
+  );
+}

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -17,7 +17,7 @@ import { clearPendingFeedItemOverrides } from "./feed-items/pendingMutations";
 import { isFeedItemMembershipRevisionStale } from "./feed-items/membershipRevision";
 import { feedsStore } from "./feeds/store";
 import { createNormalizedIDBStorage } from "./normalized-idb-storage";
-import { loadingActor } from "./loading-machine";
+import { loadingActor, updateRefreshCooldown } from "./loading-machine";
 import {
   applyScopeMembershipUpdate,
   getChangedItemsFromDiff,
@@ -908,12 +908,12 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
         loadingActor.send({ type: "MANUAL_REFRESH_REQUEST" });
 
         try {
-          // Re-run the same flow as initial mount: metadata, diffs, RSS refresh.
-          // Rate limiting is handled server-side via checkUserRefreshEligibility —
-          // if the user is in cooldown, metadata+diffs still run but RSS is skipped.
-          await orpcRouterClient.initial.requestInitialData({
-            clientId: getDataSubscriptionClientId(),
-          });
+          const { dataReconciliation } = await import("./reconciliation");
+          await dataReconciliation.requestManualFull();
+          const result = await dataReconciliation.requestDueSources("manual");
+          if (result.status === "cooldown") {
+            loadingActor.send({ type: "RESET" });
+          }
         } catch (e) {
           // Exit loading state so the button re-enables on error
           loadingActor.send({ type: "RESET" });
@@ -1076,18 +1076,11 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                   feedStatusDict: {},
                 });
 
-                // Round up to the next whole minute so the button re-enables
-                // in sync with the background-refresh cron (runs every minute).
-                let cooldownMs: number | null = null;
-                if (initialChunk.nextRefreshAt) {
-                  const raw = new Date(initialChunk.nextRefreshAt).getTime();
-                  const MS_PER_MINUTE = 60_000;
-                  cooldownMs = Math.ceil(raw / MS_PER_MINUTE) * MS_PER_MINUTE;
-                }
-                loadingActor.send({
-                  type: "REFRESH_COOLDOWN_UPDATE",
-                  nextRefreshAt: cooldownMs,
-                });
+                updateRefreshCooldown(
+                  initialChunk.nextRefreshAt
+                    ? new Date(initialChunk.nextRefreshAt)
+                    : null,
+                );
 
                 loadingActor.send({
                   type: "BACKGROUND_REFRESH_START",
@@ -1544,6 +1537,36 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 
               case "error":
                 console.error("Initial data error:", initialChunk.message);
+                break;
+            }
+            break;
+          }
+
+          case "rss": {
+            switch (chunk.type) {
+              case "refresh-start":
+                set({ feedStatusDict: {} });
+                updateRefreshCooldown(new Date(chunk.nextRefreshAt));
+                loadingActor.send({
+                  type: "BACKGROUND_REFRESH_START",
+                  totalFeeds: chunk.totalFeeds,
+                });
+                break;
+              case "feed-status": {
+                set({
+                  feedStatusDict: {
+                    ...get().feedStatusDict,
+                    [chunk.feedId]: chunk.status,
+                  },
+                });
+                loadingActor.send({ type: "FEED_STATUS" });
+                break;
+              }
+              case "feed-items":
+                mergeFeedItems(chunk.feedItems);
+                break;
+              case "rss-attempt-complete":
+                loadingActor.send({ type: "BACKGROUND_REFRESH_COMPLETE" });
                 break;
             }
             break;

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -148,6 +148,10 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       repairIntent?: ReconciliationRequestIntent;
     }
   | {
+      type: "targets-dirtied";
+      targets: ReconciliationTarget[];
+    }
+  | {
       type: "request-settled";
       reconciliationId: string;
       at: number;
@@ -613,6 +617,11 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
         markTargetsDirty(state, requestTargets(event.intent), false),
         event.intent,
       );
+    case "targets-dirtied":
+      return {
+        state: withDerivedTrust(markTargetsDirty(state, event.targets, true)),
+        commands: [],
+      };
     case "authoritative-received": {
       state = bindColdFullScope(state, event.reconciliationId, event.target);
       if (

--- a/apps/app/src/lib/reconciliation/runtime.ts
+++ b/apps/app/src/lib/reconciliation/runtime.ts
@@ -14,6 +14,7 @@ import type {
   OrganizationSnapshot,
   ReconciliationHydrationDomain,
   ReconciliationInput,
+  ReconciliationRequestIntent,
   ReconciliationScopeTarget,
   ReconciliationStreamEvent,
   ReconciliationTarget,
@@ -35,10 +36,22 @@ export type ReconciliationRuntimeDependencies<TLiveEvent> = {
     signal: AbortSignal,
   ) => Promise<AsyncIterable<ReconciliationStreamEvent>>;
   applyAuthoritative: (payload: ReconciliationAuthoritativePayload) => boolean;
-  applyLiveEvent: (payload: TLiveEvent) => ReconciliationTarget[] | void;
+  applyLiveEvent: (payload: TLiveEvent) =>
+    | ReconciliationTarget[]
+    | {
+        repairTargets?: ReconciliationTarget[];
+        dirtyTargets?: ReconciliationTarget[];
+        repairIntent?: ReconciliationRequestIntent;
+      }
+    | void;
   getCurrentSelection: () => ReconciliationScopeTarget | null;
+  deferLiveEventInvalidation?: (payload: TLiveEvent) => boolean;
   mark?: (name: string, reconciliationId?: string) => void;
-  onParityApplied?: () => void;
+  onParityApplied?: (input: {
+    reconciliationId: string | undefined;
+    automaticRssOwner: ReconciliationCoordinatorState["automaticRssOwner"];
+  }) => void;
+  onFullReconciliationFailed?: (input: { reconciliationId: string }) => void;
 };
 
 export type ReconciliationRuntime<TLiveEvent> = ReturnType<
@@ -113,13 +126,26 @@ export function createReconciliationRuntime<TLiveEvent>(
         continue;
       }
       if (command.type === "apply-live-event") {
-        const invalidatedTargets = dependencies.applyLiveEvent(command.payload);
-        if (invalidatedTargets && invalidatedTargets.length > 0) {
+        const effects = dependencies.applyLiveEvent(command.payload);
+        const repairTargets = Array.isArray(effects)
+          ? effects
+          : effects?.repairTargets;
+        const dirtyTargets = Array.isArray(effects)
+          ? undefined
+          : effects?.dirtyTargets;
+        const repairIntent = Array.isArray(effects)
+          ? undefined
+          : effects?.repairIntent;
+        if (dirtyTargets && dirtyTargets.length > 0) {
+          send({ type: "targets-dirtied", targets: dirtyTargets });
+        }
+        if (repairTargets && repairTargets.length > 0) {
           send({
             type: "live-event-received",
             eventId: `applied:${command.eventId}`,
-            targets: invalidatedTargets,
-            invalidates: invalidatedTargets,
+            targets: repairTargets,
+            invalidates: repairTargets,
+            repairIntent,
             requiresHydration: [],
           });
         }
@@ -158,7 +184,10 @@ export function createReconciliationRuntime<TLiveEvent>(
         "serial:server-parity-applied",
         state.latestFullEpoch?.reconciliationId,
       );
-      dependencies.onParityApplied?.();
+      dependencies.onParityApplied?.({
+        reconciliationId: state.latestFullEpoch?.reconciliationId,
+        automaticRssOwner: state.automaticRssOwner,
+      });
     }
     execute(transition.commands);
   };
@@ -249,6 +278,11 @@ export function createReconciliationRuntime<TLiveEvent>(
               failed: true,
               failedTargets: target ? [target] : undefined,
             });
+            if (request.intent.type === "full") {
+              dependencies.onFullReconciliationFailed?.({
+                reconciliationId: request.reconciliationId,
+              });
+            }
             settled = true;
             return;
           }
@@ -283,6 +317,11 @@ export function createReconciliationRuntime<TLiveEvent>(
           failed: true,
           failedTargets,
         });
+        if (request.intent.type === "full") {
+          dependencies.onFullReconciliationFailed?.({
+            reconciliationId: request.reconciliationId,
+          });
+        }
       }
     }
   }
@@ -354,16 +393,18 @@ export function createReconciliationRuntime<TLiveEvent>(
         intent: { type: "targeted", targets: [target] },
       });
     },
+    requestFull: requestCurrentFull,
     receiveLiveEvent(payload: TLiveEvent) {
       const inFlightFull = state.inFlight?.intent.type === "full";
       const selectedScope = dependencies.getCurrentSelection();
-      const invalidates = inFlightFull
-        ? ([
-            { type: "organization" },
-            ...(selectedScope ? [selectedScope] : []),
-            { type: "navigation" },
-          ] as ReconciliationTarget[])
-        : undefined;
+      const invalidates =
+        !dependencies.deferLiveEventInvalidation?.(payload) && inFlightFull
+          ? ([
+              { type: "organization" },
+              ...(selectedScope ? [selectedScope] : []),
+              { type: "navigation" },
+            ] as ReconciliationTarget[])
+          : undefined;
       send({
         type: "live-event-received",
         eventId: `live:${++liveSequence}`,

--- a/apps/app/src/lib/rss.ts
+++ b/apps/app/src/lib/rss.ts
@@ -1,0 +1,43 @@
+import type { ContentStatusKey } from "./content-status";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+
+export type RssTrigger = "automatic" | "manual";
+export type RssFeedStatus = "success" | "empty" | "error" | "skipped";
+export type RssAttemptOutcome = "completed" | "partial" | "failed";
+
+export type RssAffectedFeed = {
+  feedId: number;
+  contentStatusKeys: ContentStatusKey[];
+};
+
+export type RssAttemptCounts = {
+  refreshedCount: number;
+  skippedCount: number;
+  emptyCount: number;
+  errorCount: number;
+  totalRowsWritten: number;
+};
+
+export type RssAttemptSummary = RssAttemptCounts & {
+  outcome: RssAttemptOutcome;
+  affectedFeeds: RssAffectedFeed[];
+  originFailureFeedIds: number[];
+};
+
+export type RssPublishedChunk =
+  | {
+      type: "refresh-start";
+      totalFeeds: number;
+      nextRefreshAt: Date;
+    }
+  | { type: "feed-status"; feedId: number; status: RssFeedStatus }
+  | { type: "feed-items"; feedId: number; feedItems: ApplicationFeedItem[] }
+  | ({ type: "rss-attempt-complete" } & RssAttemptSummary);
+
+export type FetchDueSourcesResult =
+  | { status: "background-managed" }
+  | { status: "cooldown"; nextRefreshAt: Date }
+  | ({
+      status: "completed" | "partial";
+      nextRefreshAt: Date;
+    } & RssAttemptSummary);

--- a/apps/app/src/server/api/publisher.ts
+++ b/apps/app/src/server/api/publisher.ts
@@ -10,6 +10,7 @@ import type {
   BookmarkSyncChunk,
   MixedContentChunk,
 } from "~/server/mixed-content/sync";
+import type { RssPublishedChunk } from "~/lib/rss";
 import { env } from "~/env";
 import { logError, logMessage } from "~/server/logger";
 
@@ -20,7 +21,8 @@ export type PublishedChunk =
   | { source: "feed"; chunk: GetItemsByFeedChunk }
   | { source: "category"; chunk: GetItemsByCategoryIdChunk }
   | { source: "bookmark"; chunk: BookmarkSyncChunk }
-  | { source: "mixed"; chunk: MixedContentChunk };
+  | { source: "mixed"; chunk: MixedContentChunk }
+  | { source: "rss"; chunk: RssPublishedChunk };
 
 const RESUME_RETENTION_SECONDS = 60 * 2;
 const REDIS_KEY_PREFIX = "serial:pub:";

--- a/apps/app/src/server/api/routers/initialRouter.ts
+++ b/apps/app/src/server/api/routers/initialRouter.ts
@@ -43,6 +43,7 @@ import type {
 } from "~/server/mixed-content/sync";
 import type { NavigationSnapshot } from "~/server/navigation/snapshot";
 import type { ContentStatusFilter } from "~/lib/content-status";
+import type { RssPublishedChunk } from "~/lib/rss";
 import {
   contentStatusFilterSchema,
   DEFAULT_CONTENT_STATUS_FILTER,
@@ -98,6 +99,7 @@ import {
 import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
 import { reconciliationInputSchema } from "~/server/reconciliation/input";
 import { reconcileApplicationState as streamApplicationReconciliation } from "~/server/reconciliation";
+import { fetchDueSources as runFetchDueSources } from "~/server/rss/fetchDueSources";
 
 export const reconcileApplicationState = protectedProcedure
   .input(reconciliationInputSchema)
@@ -108,6 +110,20 @@ export const reconcileApplicationState = protectedProcedure
       request: input,
     });
   });
+
+export const fetchDueSources = protectedProcedure
+  .input(z.object({ trigger: z.enum(["automatic", "manual"]) }))
+  .handler(async ({ context, input }) =>
+    runFetchDueSources({
+      database: context.db,
+      userId: context.user.id,
+      trigger: input.trigger,
+      channel: getUserChannel(context.user.id),
+      publish: async (channel, chunk) => {
+        await publisher.publish(channel, { source: "rss", chunk });
+      },
+    }),
+  );
 
 export type PaginationCursor = {
   placement?: number;
@@ -224,7 +240,8 @@ type RouterPublishedChunk =
   | { source: "feed"; chunk: GetItemsByFeedChunk }
   | { source: "category"; chunk: GetItemsByCategoryIdChunk }
   | { source: "bookmark"; chunk: BookmarkSyncChunk }
-  | { source: "mixed"; chunk: MixedContentChunk };
+  | { source: "mixed"; chunk: MixedContentChunk }
+  | { source: "rss"; chunk: RssPublishedChunk };
 
 type ChannelSubscription = {
   channel: string;

--- a/apps/app/src/server/reconciliation/index.ts
+++ b/apps/app/src/server/reconciliation/index.ts
@@ -26,13 +26,12 @@ import {
   getFeedItemReconciliationVersion,
   REQUIRED_RECONCILIATION_DOMAINS,
 } from "~/lib/reconciliation";
-import { env } from "~/env";
 import {
   queryMixedContentPage,
   queryResolvedMixedContentPage,
 } from "~/server/mixed-content/projection";
 import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
-import { getUserPlanLimits } from "~/server/subscriptions/helpers";
+import { resolveAutomaticRssOwner } from "~/server/rss/automaticOwnership";
 import { ITEMS_PER_PAGE } from "~/server/api/constants";
 import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
 
@@ -179,17 +178,6 @@ function resolveFullScope(
     pageManifest: emptyPageManifest(),
     membershipRevision: request.selection.membershipRevision,
   };
-}
-
-async function resolveAutomaticRssOwner(input: {
-  database: ReconciliationDatabase;
-  userId: string;
-}) {
-  const limits = await getUserPlanLimits(input.database, input.userId);
-  return env.BACKGROUND_REFRESH_ENABLED &&
-    limits.backgroundRefreshIntervalMs !== null
-    ? ("background-task" as const)
-    : ("client" as const);
 }
 
 async function* reconcileFull(input: {

--- a/apps/app/src/server/rss/automaticOwnership.ts
+++ b/apps/app/src/server/rss/automaticOwnership.ts
@@ -1,0 +1,41 @@
+import type { AutomaticRssOwner } from "~/lib/reconciliation";
+import type { db as Database } from "~/server/db";
+import type { PlanId } from "~/server/subscriptions/plans";
+import { env } from "~/env";
+import { getEffectivePlanConfig } from "~/server/subscriptions/plans";
+import { getUserPlanLimits } from "~/server/subscriptions/helpers";
+
+export function automaticRssOwnerFor(input: {
+  backgroundRefreshEnabled: boolean;
+  backgroundRefreshIntervalMs: number | null;
+}): AutomaticRssOwner {
+  return input.backgroundRefreshEnabled &&
+    input.backgroundRefreshIntervalMs !== null
+    ? "background-task"
+    : "client";
+}
+
+export function automaticRssOwnerForPlan(input: {
+  backgroundRefreshEnabled: boolean;
+  planId: PlanId;
+  isAdmin?: boolean;
+}) {
+  const plan = getEffectivePlanConfig(input.planId, {
+    isAdmin: input.isAdmin,
+  });
+  return automaticRssOwnerFor({
+    backgroundRefreshEnabled: input.backgroundRefreshEnabled,
+    backgroundRefreshIntervalMs: plan.backgroundRefreshIntervalMs,
+  });
+}
+
+export async function resolveAutomaticRssOwner(input: {
+  database: typeof Database;
+  userId: string;
+}) {
+  const limits = await getUserPlanLimits(input.database, input.userId);
+  return automaticRssOwnerFor({
+    backgroundRefreshEnabled: env.BACKGROUND_REFRESH_ENABLED,
+    backgroundRefreshIntervalMs: limits.backgroundRefreshIntervalMs,
+  });
+}

--- a/apps/app/src/server/rss/backgroundRefresh.ts
+++ b/apps/app/src/server/rss/backgroundRefresh.ts
@@ -1,31 +1,28 @@
-import { and, asc, count, eq, gt, isNull, lte, or } from "drizzle-orm";
+import { and, asc, gt, isNull, lte, or } from "drizzle-orm";
 import { refreshUserFeeds } from "./refreshUserFeeds";
+import { addRefreshStats, emptyRefreshStats, rssAttemptSummary } from "./stats";
+import { countDueFeeds, getDueFeedPage, RSS_FEED_PAGE_SIZE } from "./dueFeeds";
+import { automaticRssOwnerForPlan } from "./automaticOwnership";
 import type { PlanId } from "~/server/subscriptions/plans";
 import type { DatabaseFeed } from "~/server/db/schema";
 import type { db as Database } from "~/server/db";
-import type { RefreshStats } from "./refreshUserFeeds";
-import type { NavigationSnapshot } from "~/server/navigation/snapshot";
+import type { RefreshStats } from "./stats";
+import type { RssAttemptOutcome, RssPublishedChunk } from "~/lib/rss";
 import {
   checkUserRefreshEligibilityForPlan,
   getUserPlanId,
 } from "~/server/subscriptions/helpers";
-import { feeds, user } from "~/server/db/schema";
+import { user } from "~/server/db/schema";
 import { workerPool } from "~/lib/workerPool";
-import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
 
 export const BACKGROUND_USER_PAGE_SIZE = 25;
-export const BACKGROUND_FEED_PAGE_SIZE = 50;
+export const BACKGROUND_FEED_PAGE_SIZE = RSS_FEED_PAGE_SIZE;
 export const BACKGROUND_PLAN_CONCURRENCY = 4;
 
 type UserCandidate = {
   id: string;
   role: string | null;
 };
-
-type RefreshLifecycleChunk =
-  | { type: "refresh-start"; totalFeeds: number; nextRefreshAt: Date }
-  | { type: "navigation-snapshot"; snapshot: NavigationSnapshot }
-  | { type: "refresh-complete" };
 
 type RefreshEligibility =
   | { eligible: true; nextRefreshAt: Date }
@@ -43,7 +40,7 @@ type BackgroundRefreshDependencies = {
     isAdmin: boolean;
   }) => Promise<RefreshEligibility>;
   getPlanId?: (userId: string) => Promise<PlanId>;
-  publish: (channel: string, chunk: RefreshLifecycleChunk) => Promise<void>;
+  publish: (channel: string, chunk: RssPublishedChunk) => Promise<void>;
   refreshFeedPage?: (input: {
     db: typeof Database;
     feedsList: DatabaseFeed[];
@@ -61,22 +58,6 @@ export type BackgroundRefreshMetrics = RefreshStats & {
   maximumFeedPageSize: number;
   planConcurrency: number;
 };
-
-const EMPTY_STATS: RefreshStats = {
-  refreshedCount: 0,
-  skippedCount: 0,
-  emptyCount: 0,
-  errorCount: 0,
-  totalRowsWritten: 0,
-};
-
-function addRefreshStats(target: RefreshStats, source: RefreshStats) {
-  target.refreshedCount += source.refreshedCount;
-  target.skippedCount += source.skippedCount;
-  target.emptyCount += source.emptyCount;
-  target.errorCount += source.errorCount;
-  target.totalRowsWritten += source.totalRowsWritten;
-}
 
 async function getDueUserPage(
   db: typeof Database,
@@ -114,46 +95,11 @@ async function getDueUserPage(
     .all();
 }
 
-async function countDueFeeds(db: typeof Database, userId: string, now: Date) {
-  const result = await db
-    .select({ value: count() })
-    .from(feeds)
-    .where(
-      and(
-        eq(feeds.userId, userId),
-        eq(feeds.isActive, true),
-        or(lte(feeds.nextFetchAt, now), isNull(feeds.nextFetchAt)),
-      ),
-    )
-    .get();
-  return result?.value ?? 0;
-}
-
-async function getDueFeedPage(
-  db: typeof Database,
-  input: { userId: string; afterFeedId?: number; now: Date },
-) {
-  return db
-    .select()
-    .from(feeds)
-    .where(
-      and(
-        eq(feeds.userId, input.userId),
-        eq(feeds.isActive, true),
-        or(lte(feeds.nextFetchAt, input.now), isNull(feeds.nextFetchAt)),
-        input.afterFeedId ? gt(feeds.id, input.afterFeedId) : undefined,
-      ),
-    )
-    .orderBy(asc(feeds.id))
-    .limit(BACKGROUND_FEED_PAGE_SIZE)
-    .all();
-}
-
 export async function runBackgroundFeedRefresh(
   dependencies: BackgroundRefreshDependencies,
 ): Promise<BackgroundRefreshMetrics> {
   const metrics: BackgroundRefreshMetrics = {
-    ...EMPTY_STATS,
+    ...emptyRefreshStats(),
     userPages: 0,
     feedPages: 0,
     usersClaimed: 0,
@@ -207,10 +153,20 @@ export async function runBackgroundFeedRefresh(
         );
 
     for await (const { candidate, planId } of planCandidates) {
-      if (dependencies.billingEnabled && planId === "free") continue;
+      if (
+        automaticRssOwnerForPlan({
+          backgroundRefreshEnabled: true,
+          planId,
+          isAdmin: candidate.role === "admin",
+        }) !== "background-task"
+      ) {
+        continue;
+      }
 
       const channel = `user:${candidate.id}`;
       let refreshStarted = false;
+      let outcome: RssAttemptOutcome = "completed";
+      const userStats = emptyRefreshStats();
       try {
         const dueFeedCount = await countDueFeeds(
           dependencies.db,
@@ -256,23 +212,21 @@ export async function runBackgroundFeedRefresh(
             feedsList: feedPage,
             channel,
           });
+          addRefreshStats(userStats, pageStats);
           addRefreshStats(metrics, pageStats);
         }
-
-        await dependencies.publish(channel, {
-          type: "navigation-snapshot",
-          snapshot: await queryNavigationSnapshot({
-            database: dependencies.db,
-            userId: candidate.id,
-          }),
-        });
+        outcome = userStats.errorCount > 0 ? "partial" : "completed";
       } catch (error) {
+        outcome = "failed";
         metrics.errorCount++;
         dependencies.onUserError?.(error, candidate.id);
       } finally {
         if (refreshStarted) {
           try {
-            await dependencies.publish(channel, { type: "refresh-complete" });
+            await dependencies.publish(channel, {
+              type: "rss-attempt-complete",
+              ...rssAttemptSummary(userStats, outcome),
+            });
           } catch (error) {
             metrics.errorCount++;
             dependencies.onUserError?.(error, candidate.id);

--- a/apps/app/src/server/rss/dueFeeds.ts
+++ b/apps/app/src/server/rss/dueFeeds.ts
@@ -1,0 +1,44 @@
+import { and, asc, count, eq, gt, isNull, lte, or } from "drizzle-orm";
+import type { db as Database } from "~/server/db";
+import { feeds } from "~/server/db/schema";
+
+export const RSS_FEED_PAGE_SIZE = 50;
+
+export async function countDueFeeds(
+  database: typeof Database,
+  userId: string,
+  now: Date,
+) {
+  const result = await database
+    .select({ value: count() })
+    .from(feeds)
+    .where(
+      and(
+        eq(feeds.userId, userId),
+        eq(feeds.isActive, true),
+        or(lte(feeds.nextFetchAt, now), isNull(feeds.nextFetchAt)),
+      ),
+    )
+    .get();
+  return result?.value ?? 0;
+}
+
+export async function getDueFeedPage(
+  database: typeof Database,
+  input: { userId: string; afterFeedId?: number; now: Date },
+) {
+  return database
+    .select()
+    .from(feeds)
+    .where(
+      and(
+        eq(feeds.userId, input.userId),
+        eq(feeds.isActive, true),
+        or(lte(feeds.nextFetchAt, input.now), isNull(feeds.nextFetchAt)),
+        input.afterFeedId ? gt(feeds.id, input.afterFeedId) : undefined,
+      ),
+    )
+    .orderBy(asc(feeds.id))
+    .limit(RSS_FEED_PAGE_SIZE)
+    .all();
+}

--- a/apps/app/src/server/rss/fetchDueSources.ts
+++ b/apps/app/src/server/rss/fetchDueSources.ts
@@ -1,0 +1,113 @@
+import { resolveAutomaticRssOwner } from "./automaticOwnership";
+import { countDueFeeds, getDueFeedPage } from "./dueFeeds";
+import { refreshUserFeeds } from "./refreshUserFeeds";
+import { addRefreshStats, emptyRefreshStats, rssAttemptSummary } from "./stats";
+import type { RefreshStats } from "./stats";
+import type { db as Database } from "~/server/db";
+import type { DatabaseFeed } from "~/server/db/schema";
+import type {
+  FetchDueSourcesResult,
+  RssPublishedChunk,
+  RssTrigger,
+} from "~/lib/rss";
+import { checkUserRefreshEligibility } from "~/server/subscriptions/helpers";
+
+type RefreshEligibility =
+  | { eligible: true; nextRefreshAt: Date }
+  | { eligible: false; nextRefreshAt: Date };
+
+type FetchDueSourcesDependencies = {
+  resolveOwner?: typeof resolveAutomaticRssOwner;
+  claimUser?: (
+    database: typeof Database,
+    userId: string,
+  ) => Promise<RefreshEligibility>;
+  countDue?: typeof countDueFeeds;
+  getDuePage?: typeof getDueFeedPage;
+  refreshFeedPage?: (input: {
+    db: typeof Database;
+    feedsList: DatabaseFeed[];
+    channel?: string;
+  }) => Promise<RefreshStats>;
+  now?: () => Date;
+};
+
+export async function fetchDueSources(input: {
+  database: typeof Database;
+  userId: string;
+  trigger: RssTrigger;
+  channel: string;
+  publish: (channel: string, chunk: RssPublishedChunk) => Promise<void>;
+  dependencies?: FetchDueSourcesDependencies;
+}): Promise<FetchDueSourcesResult> {
+  const dependencies = input.dependencies ?? {};
+  const resolveOwner = dependencies.resolveOwner ?? resolveAutomaticRssOwner;
+  if (
+    input.trigger === "automatic" &&
+    (await resolveOwner({
+      database: input.database,
+      userId: input.userId,
+    })) === "background-task"
+  ) {
+    return { status: "background-managed" };
+  }
+
+  const claimUser = dependencies.claimUser ?? checkUserRefreshEligibility;
+  const eligibility = await claimUser(input.database, input.userId);
+  if (!eligibility.eligible) {
+    return { status: "cooldown", nextRefreshAt: eligibility.nextRefreshAt };
+  }
+
+  const now = dependencies.now?.() ?? new Date();
+  const countDue = dependencies.countDue ?? countDueFeeds;
+  const getDuePage = dependencies.getDuePage ?? getDueFeedPage;
+  const refreshFeedPage = dependencies.refreshFeedPage ?? refreshUserFeeds;
+  const totalFeeds = await countDue(input.database, input.userId, now);
+  await input.publish(input.channel, {
+    type: "refresh-start",
+    totalFeeds,
+    nextRefreshAt: eligibility.nextRefreshAt,
+  });
+
+  const stats = emptyRefreshStats();
+  try {
+    let afterFeedId: number | undefined;
+    while (true) {
+      // Cursor pages preserve the background worker's bounded Feed loading.
+      // oxlint-disable-next-line react-doctor/async-await-in-loop
+      const feedPage = await getDuePage(input.database, {
+        userId: input.userId,
+        afterFeedId,
+        now,
+      });
+      if (feedPage.length === 0) break;
+      afterFeedId = feedPage.at(-1)?.id;
+      // Each page must finish before its cursor advances.
+      // oxlint-disable-next-line react-doctor/async-await-in-loop
+      const pageStats = await refreshFeedPage({
+        db: input.database,
+        feedsList: feedPage,
+        channel: input.channel,
+      });
+      addRefreshStats(stats, pageStats);
+    }
+  } catch (error) {
+    await input.publish(input.channel, {
+      type: "rss-attempt-complete",
+      ...rssAttemptSummary(stats, "failed"),
+    });
+    throw error;
+  }
+
+  const outcome = stats.errorCount > 0 ? "partial" : "completed";
+  const summary = rssAttemptSummary(stats, outcome);
+  await input.publish(input.channel, {
+    type: "rss-attempt-complete",
+    ...summary,
+  });
+  return {
+    status: outcome,
+    nextRefreshAt: eligibility.nextRefreshAt,
+    ...summary,
+  };
+}

--- a/apps/app/src/server/rss/refreshUserFeeds.ts
+++ b/apps/app/src/server/rss/refreshUserFeeds.ts
@@ -1,17 +1,13 @@
 import { publisher } from "../api/publisher";
 import { captureException } from "../logger";
 import { fetchAndInsertFeedData } from "./fetchFeeds";
-import type { GetByViewChunk } from "../api/routers/initialRouter";
+import { affectedFeedFromItems, emptyRefreshStats } from "./stats";
 import type { DatabaseFeed } from "../db/schema";
 import type { db as Database } from "../db";
+import type { RefreshStats } from "./stats";
+import type { RssPublishedChunk } from "~/lib/rss";
 
-export type RefreshStats = {
-  refreshedCount: number;
-  skippedCount: number;
-  emptyCount: number;
-  errorCount: number;
-  totalRowsWritten: number;
-};
+export type { RefreshStats } from "./stats";
 
 /**
  * Shared feed refresh logic used by both background-refresh tasks and
@@ -36,13 +32,7 @@ export async function refreshUserFeeds({
 }): Promise<RefreshStats> {
   const activeFeedsList = feedsList.filter((feed) => feed.isActive);
 
-  const stats: RefreshStats = {
-    refreshedCount: 0,
-    skippedCount: 0,
-    emptyCount: 0,
-    errorCount: 0,
-    totalRowsWritten: 0,
-  };
+  const stats = emptyRefreshStats();
 
   if (activeFeedsList.length === 0) {
     return stats;
@@ -50,9 +40,9 @@ export async function refreshUserFeeds({
 
   // Typed publish helper that no-ops when there is no channel
   const publish = channel
-    ? async (chunk: GetByViewChunk) => {
+    ? async (chunk: RssPublishedChunk) => {
         await publisher.publish(`${channel}`, {
-          source: "initial",
+          source: "rss",
           chunk,
         });
       }
@@ -85,6 +75,11 @@ export async function refreshUserFeeds({
       stats.refreshedCount++;
       if ("feedItems" in feedResult) {
         stats.totalRowsWritten += feedResult.feedItems.length;
+        const affectedFeed = affectedFeedFromItems(
+          feedResult.id,
+          feedResult.feedItems,
+        );
+        if (affectedFeed) stats.affectedFeeds.push(affectedFeed);
 
         if (feedResult.feedItems.length > 0) {
           await publish({
@@ -98,6 +93,7 @@ export async function refreshUserFeeds({
       stats.emptyCount++;
     } else if (feedResult.status === "error") {
       stats.errorCount++;
+      stats.originFailureFeedIds.push(feedResult.id);
       const feedName = feedNameMap.get(feedResult.id) ?? "unknown";
       const errMsg =
         "error" in feedResult

--- a/apps/app/src/server/rss/stats.ts
+++ b/apps/app/src/server/rss/stats.ts
@@ -1,0 +1,83 @@
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type {
+  RssAffectedFeed,
+  RssAttemptCounts,
+  RssAttemptOutcome,
+  RssAttemptSummary,
+} from "~/lib/rss";
+import { buildContentStatusKey } from "~/lib/content-status";
+
+export type RefreshStats = RssAttemptCounts & {
+  affectedFeeds: RssAffectedFeed[];
+  originFailureFeedIds: number[];
+};
+
+export function emptyRefreshStats(): RefreshStats {
+  return {
+    refreshedCount: 0,
+    skippedCount: 0,
+    emptyCount: 0,
+    errorCount: 0,
+    totalRowsWritten: 0,
+    affectedFeeds: [],
+    originFailureFeedIds: [],
+  };
+}
+
+export function affectedFeedFromItems(
+  feedId: number,
+  items: ApplicationFeedItem[],
+): RssAffectedFeed | null {
+  if (items.length === 0) return null;
+  return {
+    feedId,
+    contentStatusKeys: [
+      ...new Set(
+        items.map((item) =>
+          buildContentStatusKey({
+            saveStatus: item.isWatchLater ? "saved" : "inbox",
+            archiveStatus: item.isWatched ? "archived" : "unread",
+          }),
+        ),
+      ),
+    ],
+  };
+}
+
+export function addRefreshStats(target: RefreshStats, source: RefreshStats) {
+  target.refreshedCount += source.refreshedCount;
+  target.skippedCount += source.skippedCount;
+  target.emptyCount += source.emptyCount;
+  target.errorCount += source.errorCount;
+  target.totalRowsWritten += source.totalRowsWritten;
+  target.originFailureFeedIds = [
+    ...new Set([
+      ...target.originFailureFeedIds,
+      ...source.originFailureFeedIds,
+    ]),
+  ];
+
+  const affected = new Map(
+    target.affectedFeeds.map((feed) => [feed.feedId, feed]),
+  );
+  for (const feed of source.affectedFeeds) {
+    const current = affected.get(feed.feedId);
+    affected.set(feed.feedId, {
+      feedId: feed.feedId,
+      contentStatusKeys: [
+        ...new Set([
+          ...(current?.contentStatusKeys ?? []),
+          ...feed.contentStatusKeys,
+        ]),
+      ],
+    });
+  }
+  target.affectedFeeds = [...affected.values()];
+}
+
+export function rssAttemptSummary(
+  stats: RefreshStats,
+  outcome: RssAttemptOutcome = stats.errorCount > 0 ? "partial" : "completed",
+): RssAttemptSummary {
+  return { ...stats, outcome };
+}

--- a/apps/app/tests/unit/data/rss-repair.test.ts
+++ b/apps/app/tests/unit/data/rss-repair.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { ReconciliationScopeTarget } from "~/lib/reconciliation";
+import type { RssAttemptSummary } from "~/lib/rss";
+import { rssSummaryAffectsTarget } from "~/lib/data/rssRepair";
+
+const summary: RssAttemptSummary = {
+  outcome: "partial",
+  refreshedCount: 1,
+  skippedCount: 0,
+  emptyCount: 0,
+  errorCount: 1,
+  totalRowsWritten: 2,
+  affectedFeeds: [{ feedId: 7, contentStatusKeys: ["inbox:unread"] }],
+  originFailureFeedIds: [8],
+};
+
+const memberships = {
+  viewFeedIds: { 10: [7], 11: [8] },
+  feedCategories: [{ feedId: 7, categoryId: 20 }],
+};
+
+function target(
+  scope: ReconciliationScopeTarget["scope"],
+  contentStatus: ReconciliationScopeTarget["contentStatus"] = {
+    saveStatus: "inbox",
+    archiveStatus: "unread",
+  },
+): ReconciliationScopeTarget {
+  return { type: "scope", scope, contentStatus };
+}
+
+describe("RSS repair targeting", () => {
+  it("intersects committed Feed writes with actual organization membership", () => {
+    expect(
+      rssSummaryAffectsTarget(
+        summary,
+        target({ type: "feed", feedId: 7 }),
+        memberships,
+      ),
+    ).toBe(true);
+    expect(
+      rssSummaryAffectsTarget(
+        summary,
+        target({ type: "view", viewId: 10 }),
+        memberships,
+      ),
+    ).toBe(true);
+    expect(
+      rssSummaryAffectsTarget(
+        summary,
+        target({ type: "tag", tagId: 20 }),
+        memberships,
+      ),
+    ).toBe(true);
+    expect(
+      rssSummaryAffectsTarget(
+        summary,
+        target({ type: "view", viewId: 11 }),
+        memberships,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not repair a different Content status for the same Feed", () => {
+    expect(
+      rssSummaryAffectsTarget(
+        summary,
+        target(
+          { type: "feed", feedId: 7 },
+          { saveStatus: "saved", archiveStatus: "unread" },
+        ),
+        memberships,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -90,6 +90,14 @@ function harness(
   events: (
     request: ReconciliationRequestDescriptor,
   ) => ReconciliationStreamEvent[],
+  applyLiveEvent?: (payload: string[]) =>
+    | ReconciliationScopeTarget[]
+    | {
+        repairTargets?: ReconciliationScopeTarget[];
+        dirtyTargets?: ReconciliationScopeTarget[];
+        repairIntent?: ReconciliationRequestDescriptor["intent"];
+      }
+    | void,
 ) {
   const requests: ReconciliationRequestDescriptor[] = [];
   const applications: string[] = [];
@@ -127,6 +135,7 @@ function harness(
     },
     applyLiveEvent: (payload) => {
       liveApplications.push(payload);
+      return applyLiveEvent?.(payload);
     },
     getCurrentSelection: () => currentSelection,
   });
@@ -293,5 +302,63 @@ describe("client reconciliation runtime", () => {
     expect(test.liveApplications).toEqual([]);
     test.runtime.hydrationComplete("bookmarks");
     expect(test.liveApplications).toEqual([["newer-live-state"]]);
+  });
+
+  it("keeps RSS detail events repair-silent and schedules one summary repair", async () => {
+    const test = harness(
+      (request) =>
+        request.intent.type === "full"
+          ? completeEpoch(request.reconciliationId)
+          : [
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: { type: "active-first-page", page: PAGE },
+              },
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: {
+                  type: "domain-complete",
+                  domain: "active-scope",
+                  target: ACTIVE_SCOPE,
+                },
+              },
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: {
+                  type: "epoch-complete",
+                  requiredDomains: ["active-scope"],
+                },
+              },
+            ],
+      (payload) =>
+        payload.includes("rss-attempt-complete")
+          ? {
+              repairTargets: [ACTIVE_SCOPE],
+              repairIntent: {
+                type: "targeted",
+                targets: [ACTIVE_SCOPE],
+              },
+            }
+          : undefined,
+    );
+    test.setSelection(ACTIVE_SCOPE);
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+    await vi.waitFor(() =>
+      expect(test.runtime.getState().trustedUpToDate).toBe(true),
+    );
+
+    test.runtime.receiveLiveEvent(["feed-status", "feed-items"]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(test.requests).toHaveLength(1);
+
+    test.runtime.receiveLiveEvent(["rss-attempt-complete"]);
+    await vi.waitFor(() => expect(test.requests).toHaveLength(2));
+    expect(test.requests[1]?.intent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
   });
 });

--- a/apps/app/tests/unit/reconciliation/reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation.test.ts
@@ -470,4 +470,27 @@ describe("reconciliation coordinator", () => {
       },
     ]);
   });
+
+  it("marks an inactive target dirty without eagerly scheduling repair", () => {
+    const harness = coordinatorHarness();
+
+    expect(
+      harness.send({ type: "targets-dirtied", targets: [OTHER_SCOPE] }),
+    ).toEqual([]);
+    expect(harness.state.inFlight).toBeNull();
+    expect(
+      harness.state.targets[getReconciliationTargetKey(OTHER_SCOPE)]?.status,
+    ).toBe("dirty");
+
+    const request = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [OTHER_SCOPE] },
+      }),
+    );
+    expect(request.intent).toEqual({
+      type: "targeted",
+      targets: [OTHER_SCOPE],
+    });
+  });
 });

--- a/apps/app/tests/unit/rss/automatic-ownership.test.ts
+++ b/apps/app/tests/unit/rss/automatic-ownership.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { automaticRssOwnerFor } from "~/server/rss/automaticOwnership";
+
+describe("automatic RSS ownership", () => {
+  it.each([
+    {
+      name: "main-instance Free",
+      backgroundRefreshEnabled: true,
+      backgroundRefreshIntervalMs: null,
+      expected: "client",
+    },
+    {
+      name: "paid with the background task enabled",
+      backgroundRefreshEnabled: true,
+      backgroundRefreshIntervalMs: 60_000,
+      expected: "background-task",
+    },
+    {
+      name: "paid with the background task disabled",
+      backgroundRefreshEnabled: false,
+      backgroundRefreshIntervalMs: 60_000,
+      expected: "client",
+    },
+    {
+      name: "self-hosted with the background task enabled",
+      backgroundRefreshEnabled: true,
+      backgroundRefreshIntervalMs: 60_000,
+      expected: "background-task",
+    },
+    {
+      name: "self-hosted with the background task disabled",
+      backgroundRefreshEnabled: false,
+      backgroundRefreshIntervalMs: 60_000,
+      expected: "client",
+    },
+  ])("selects $expected for $name", (input) => {
+    expect(automaticRssOwnerFor(input)).toBe(input.expected);
+  });
+});

--- a/apps/app/tests/unit/rss/background-refresh.test.ts
+++ b/apps/app/tests/unit/rss/background-refresh.test.ts
@@ -22,6 +22,8 @@ const EMPTY_REFRESH_STATS: RefreshStats = {
   emptyCount: 0,
   errorCount: 0,
   totalRowsWritten: 0,
+  affectedFeeds: [],
+  originFailureFeedIds: [],
 };
 
 describe("runBackgroundFeedRefresh", () => {
@@ -89,9 +91,12 @@ describe("runBackgroundFeedRefresh", () => {
     ).toHaveLength(27);
     expect(
       publishedChunkTypes.filter((type) => type === "refresh-complete"),
-    ).toHaveLength(27);
+    ).toHaveLength(0);
     expect(
       publishedChunkTypes.filter((type) => type === "navigation-snapshot"),
+    ).toHaveLength(0);
+    expect(
+      publishedChunkTypes.filter((type) => type === "rss-attempt-complete"),
     ).toHaveLength(27);
   });
 

--- a/apps/app/tests/unit/rss/fetch-due-sources.test.ts
+++ b/apps/app/tests/unit/rss/fetch-due-sources.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { db as Database } from "~/server/db";
+import type { DatabaseFeed } from "~/server/db/schema";
+import type { RssPublishedChunk } from "~/lib/rss";
+import { emptyRefreshStats } from "~/server/rss/stats";
+import { fetchDueSources } from "~/server/rss/fetchDueSources";
+
+const database = {} as typeof Database;
+const nextRefreshAt = new Date("2026-08-10T12:05:00.000Z");
+
+function baseInput() {
+  const chunks: RssPublishedChunk[] = [];
+  return {
+    chunks,
+    input: {
+      database,
+      userId: "user-1",
+      trigger: "automatic" as const,
+      channel: "user:user-1",
+      publish: vi.fn((_channel: string, chunk: RssPublishedChunk) => {
+        chunks.push(chunk);
+        return Promise.resolve();
+      }),
+    },
+  };
+}
+
+describe("fetchDueSources", () => {
+  it("does not claim or publish when the background task owns automatic RSS", async () => {
+    const { input, chunks } = baseInput();
+    const claimUser = vi.fn();
+
+    await expect(
+      fetchDueSources({
+        ...input,
+        dependencies: {
+          resolveOwner: () => Promise.resolve("background-task"),
+          claimUser,
+        },
+      }),
+    ).resolves.toEqual({ status: "background-managed" });
+    expect(claimUser).not.toHaveBeenCalled();
+    expect(chunks).toEqual([]);
+  });
+
+  it("returns cooldown without emitting a losing lifecycle", async () => {
+    const { input, chunks } = baseInput();
+
+    await expect(
+      fetchDueSources({
+        ...input,
+        dependencies: {
+          resolveOwner: () => Promise.resolve("client"),
+          claimUser: () => Promise.resolve({ eligible: false, nextRefreshAt }),
+        },
+      }),
+    ).resolves.toEqual({ status: "cooldown", nextRefreshAt });
+    expect(chunks).toEqual([]);
+  });
+
+  it("emits one winner-owned summary and preserves partial committed writes", async () => {
+    const { input, chunks } = baseInput();
+    let page = 0;
+    const firstPageStats = {
+      ...emptyRefreshStats(),
+      refreshedCount: 1,
+      totalRowsWritten: 2,
+      affectedFeeds: [
+        { feedId: 7, contentStatusKeys: ["inbox:unread" as const] },
+      ],
+    };
+    const secondPageStats = {
+      ...emptyRefreshStats(),
+      errorCount: 1,
+      originFailureFeedIds: [8],
+    };
+    const refreshFeedPage = vi
+      .fn()
+      .mockResolvedValueOnce(firstPageStats)
+      .mockResolvedValueOnce(secondPageStats);
+
+    const result = await fetchDueSources({
+      ...input,
+      dependencies: {
+        resolveOwner: () => Promise.resolve("client"),
+        claimUser: () => Promise.resolve({ eligible: true, nextRefreshAt }),
+        countDue: () => Promise.resolve(2),
+        getDuePage: () =>
+          Promise.resolve(
+            page < 2 ? ([{ id: 7 + page++ }] as DatabaseFeed[]) : [],
+          ),
+        refreshFeedPage,
+      },
+    });
+
+    expect(result.status).toBe("partial");
+    expect(refreshFeedPage).toHaveBeenCalledTimes(2);
+    expect(chunks.map(({ type }) => type)).toEqual([
+      "refresh-start",
+      "rss-attempt-complete",
+    ]);
+    expect(chunks.at(-1)).toMatchObject({
+      type: "rss-attempt-complete",
+      outcome: "partial",
+      affectedFeeds: firstPageStats.affectedFeeds,
+      originFailureFeedIds: [8],
+    });
+  });
+
+  it("closes the winner lifecycle before surfacing an orchestration failure", async () => {
+    const { input, chunks } = baseInput();
+    let page = 0;
+
+    await expect(
+      fetchDueSources({
+        ...input,
+        dependencies: {
+          resolveOwner: () => Promise.resolve("client"),
+          claimUser: () => Promise.resolve({ eligible: true, nextRefreshAt }),
+          countDue: () => Promise.resolve(1),
+          getDuePage: () =>
+            Promise.resolve(
+              page++ === 0 ? ([{ id: 7 }] as DatabaseFeed[]) : [],
+            ),
+          refreshFeedPage: () => Promise.reject(new Error("database failed")),
+        },
+      }),
+    ).rejects.toThrow("database failed");
+    expect(chunks.at(-1)).toMatchObject({
+      type: "rss-attempt-complete",
+      outcome: "failed",
+    });
+  });
+});


### PR DESCRIPTION
- Separate RSS fetching from reconciliation behind shared automatic ownership.
- Consolidate refresh lifecycle and post-attempt targeted repair.
- Preserve manual refresh ordering and partial-origin behavior.