### PR TITLE
Implement targeted mutation repair and recovery

### DIFF
--- a/apps/app/src/app/api.extension.bookmarks.ts
+++ b/apps/app/src/app/api.extension.bookmarks.ts
@@ -31,6 +31,8 @@ import {
   extensionJsonResponse as jsonResponse,
   prepareExtensionJsonRequest,
 } from "~/server/http/extensionApi";
+import { ALL_CONTENT_STATUS_KEYS } from "~/lib/reconciliation";
+import { organizationInvalidationSummary } from "~/server/reconciliation/invalidation";
 
 export function preflightResponse() {
   return extensionPreflightResponse(["POST", "PATCH", "DELETE"]);
@@ -59,6 +61,7 @@ const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
           userId,
           id: removedBookmarkId,
           canonicalUrl: result.bookmark.canonicalUrl,
+          invalidation: null,
         }),
       ),
     );
@@ -66,6 +69,7 @@ const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
       database: db,
       userId,
       bookmarkId: result.bookmark.id,
+      contentStatusKeys: ALL_CONTENT_STATUS_KEYS,
     });
   },
   workspace: loadExtensionBookmarkWorkspace,
@@ -251,6 +255,7 @@ export async function mutateExtensionBookmark(
       database: db,
       userId: authenticatedUser.id,
       bookmarkId: mutation.bookmarkId,
+      invalidation: organizationInvalidationSummary(),
     });
     if (!bookmark) throw new BookmarkNotFoundError("Bookmark not found");
     return jsonResponse({
@@ -307,6 +312,7 @@ export async function removeExtensionBookmark(
       userId: authenticatedUser.id,
       id: deleted.id,
       canonicalUrl: deleted.canonicalUrl,
+      invalidation: organizationInvalidationSummary(),
     });
     return jsonResponse({ bookmarkId: deleted.id });
   } catch (error) {

--- a/apps/app/src/components/AddFeedDialog.tsx
+++ b/apps/app/src/components/AddFeedDialog.tsx
@@ -306,6 +306,7 @@ export function EditFeedDialog({
   const [selectedViewIds, setSelectedViewIds] = useState<number[]>([]);
   const [selectedOpenLocation, setSelectedOpenLocation] =
     useState<FeedOpenLocation>("serial");
+  const initializedFeedIdRef = useRef<number | null>(null);
 
   const isFormDisabled = !name;
 
@@ -332,7 +333,11 @@ export function EditFeedDialog({
   }
 
   useEffect(() => {
-    if (selectedFeedId == null) return;
+    if (selectedFeedId == null) {
+      initializedFeedIdRef.current = null;
+      return;
+    }
+    if (initializedFeedIdRef.current === selectedFeedId) return;
 
     const feed = feeds.find((v) => v.id === selectedFeedId);
     if (!feed) return;
@@ -350,6 +355,7 @@ export function EditFeedDialog({
     setSelectedCategories(_feedCategories);
     setSelectedViewIds(_feedViewIds);
     setSelectedOpenLocation(feed.openLocation);
+    initializedFeedIdRef.current = selectedFeedId;
   }, [feedCategories, viewFeeds, selectedFeedId, feeds]);
 
   const feed = feeds.find((v) => v.id === selectedFeedId);

--- a/apps/app/src/components/feed/RefetchItemsButton.tsx
+++ b/apps/app/src/components/feed/RefetchItemsButton.tsx
@@ -16,6 +16,7 @@ import {
   useNextRefreshAt,
 } from "~/lib/data/loading-machine";
 import { useFetchNewData } from "~/lib/data/store";
+import { useReconciliationDisplayStatus } from "~/lib/data/reconciliation";
 import { useShortcut } from "~/lib/hooks/useShortcut";
 
 function formatRelativeTime(targetMs: number, now: number): string {
@@ -34,6 +35,7 @@ export function RefetchItemsButton() {
   const fetchNewData = useFetchNewData();
   const loading = useLoadingMode();
   const nextRefreshAt = useNextRefreshAt();
+  const reconciliationStatus = useReconciliationDisplayStatus();
 
   // Track current time in state so the cooldown check is pure during render.
   // Only updated via the timeout callback (async) to satisfy the lint rule.
@@ -42,16 +44,24 @@ export function RefetchItemsButton() {
   const isMachineActive = useIsLoadingActive();
   const isRateLimited = nextRefreshAt !== null && nextRefreshAt > now;
 
-  const isRefreshing = isMachineActive;
+  const isReconciling = reconciliationStatus !== "idle";
+  const isRefreshing = isMachineActive || reconciliationStatus === "syncing";
   const isDisabled =
     isRefreshing ||
+    reconciliationStatus === "retrying" ||
     isRateLimited ||
     loading.mode === "initialLoad" ||
     loading.mode === "backgroundRefresh";
 
   // Show check icon when the user is up to date (cooldown active),
   // refresh icon when they can refresh again (cooldown expired/absent).
-  const showCheck = isRateLimited && !isMachineActive;
+  const showCheck = isRateLimited && !isMachineActive && !isReconciling;
+  const statusLabel =
+    reconciliationStatus === "syncing"
+      ? "Syncing"
+      : reconciliationStatus === "retrying"
+        ? "Retrying"
+        : "Refresh";
 
   // Tick `now` so the tooltip text updates live and the button re-enables
   // when the cooldown expires. Chained timeouts stop at expiry and use fewer
@@ -99,6 +109,7 @@ export function RefetchItemsButton() {
       onClick={onClick}
       disabled={isDisabled}
       shortcut="r"
+      aria-label={statusLabel}
     >
       {showCheck ? (
         <CheckIcon size={16} />
@@ -110,11 +121,11 @@ export function RefetchItemsButton() {
           })}
         />
       )}
-      <span className="hidden pl-1.5 md:block">Refresh</span>
+      <span className="hidden pl-1.5 md:block">{statusLabel}</span>
     </ButtonWithShortcut>
   );
 
-  if (isRateLimited) {
+  if (isReconciling || isRateLimited) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -122,10 +133,18 @@ export function RefetchItemsButton() {
           <span tabIndex={0}>{button}</span>
         </TooltipTrigger>
         <TooltipContent>
-          Refresh available in{" "}
-          <span className="font-mono">
-            {formatRelativeTime(nextRefreshAt, now)}
-          </span>
+          {reconciliationStatus === "syncing" ? (
+            "Checking for newer data"
+          ) : reconciliationStatus === "retrying" ? (
+            "Data may be stale. Retrying automatically"
+          ) : (
+            <>
+              Refresh available in{" "}
+              <span className="font-mono">
+                {formatRelativeTime(nextRefreshAt!, now)}
+              </span>
+            </>
+          )}
         </TooltipContent>
       </Tooltip>
     );

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -8,7 +8,6 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import { mixedContentStore } from "../mixed-content/store";
 import { viewsStore } from "../views/store";
-import { refreshNavigationSnapshotSafely } from "../navigation/store";
 import { bookmarksStore } from "./store";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 import { orpc } from "~/lib/orpc";
@@ -38,7 +37,7 @@ function removeProjectedBookmark(bookmark: ApplicationBookmark) {
 export function useSaveBookmarkMutation() {
   return useMutation(
     orpc.bookmark.save.mutationOptions({
-      onSuccess: async (result) => {
+      onSuccess: (result) => {
         const bookmark = result.bookmark as ApplicationBookmark;
         const previousBookmark = bookmarksStore
           .getState()
@@ -51,7 +50,6 @@ export function useSaveBookmarkMutation() {
           if (removedBookmark) removeProjectedBookmark(removedBookmark);
         }
         projectBookmark(bookmark, previousBookmark);
-        await refreshNavigationSnapshotSafely();
       },
     }),
   );
@@ -115,7 +113,7 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
         );
         return { previousBookmark, token };
       },
-      onSuccess: async (bookmark, input, context) => {
+      onSuccess: (bookmark, _input, context) => {
         const serverBookmark = bookmark as ApplicationBookmark;
         const currentBookmark = bookmarksStore
           .getState()
@@ -129,9 +127,6 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
               )
             : serverBookmark;
         projectBookmark(reconciled, currentBookmark);
-        if (input.isSaved !== undefined || input.isRead !== undefined) {
-          await refreshNavigationSnapshotSafely();
-        }
       },
       onError: (_error, _input, context) => {
         const optimisticBookmark = bookmarksStore
@@ -169,7 +164,7 @@ export function useSetBookmarkViewMutation() {
         );
         return { previousBookmark, token };
       },
-      onSuccess: async (bookmark, _input, context) => {
+      onSuccess: (bookmark, _input, context) => {
         const currentBookmark = context?.previousBookmark
           ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
           : undefined;
@@ -181,7 +176,6 @@ export function useSetBookmarkViewMutation() {
           );
           projectBookmark(applicationBookmark, currentBookmark);
         }
-        await refreshNavigationSnapshotSafely();
       },
       onError: (_error, _input, context) => {
         if (!context?.previousBookmark || !context.token) return;
@@ -219,7 +213,7 @@ export function useSetBookmarkTagMutation() {
         );
         return { previousBookmark, token };
       },
-      onSuccess: async (bookmark, _input, context) => {
+      onSuccess: (bookmark, _input, context) => {
         const currentBookmark = context?.previousBookmark
           ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
           : undefined;
@@ -231,7 +225,6 @@ export function useSetBookmarkTagMutation() {
           );
           projectBookmark(applicationBookmark, currentBookmark);
         }
-        await refreshNavigationSnapshotSafely();
       },
       onError: (_error, _input, context) => {
         if (!context?.previousBookmark || !context.token) return;
@@ -266,9 +259,6 @@ export function useDeleteBookmarkMutation() {
         if (context?.previousBookmark) {
           projectBookmark(context.previousBookmark, undefined);
         }
-      },
-      onSuccess: async () => {
-        await refreshNavigationSnapshotSafely();
       },
     }),
   );

--- a/apps/app/src/lib/data/feed-items/mutations.ts
+++ b/apps/app/src/lib/data/feed-items/mutations.ts
@@ -3,7 +3,6 @@ import { feedItemsStore, useFeedItemState } from "../store";
 import { feedCategoriesStore } from "../feed-categories/store";
 import { mixedContentStore } from "../mixed-content/store";
 import { viewsStore } from "../views/store";
-import { refreshNavigationSnapshotSafely } from "../navigation/store";
 import {
   clearPendingFeedItemOverride,
   setPendingWatchedOverride,
@@ -229,7 +228,6 @@ export async function setBulkWatchedValue({
       isWatched,
     });
     settleOptimisticWatchedValues(contexts, serverItems ?? []);
-    await refreshNavigationSnapshotSafely();
   } catch (error) {
     rollbackOptimisticWatchedValues(contexts);
     throw error;
@@ -242,9 +240,8 @@ export function useFeedItemsSetWatchedValueMutation(contentId: string) {
       onMutate: ({ isWatched }) => {
         return applyOptimisticWatchedValue(contentId, isWatched);
       },
-      onSuccess: async (serverValue, _variables, context) => {
+      onSuccess: (serverValue, _variables, context) => {
         resolveOptimisticWatchedValue(context, serverValue);
-        await refreshNavigationSnapshotSafely();
       },
       onError: (_error, _variables, context) => {
         rollbackOptimisticWatchedValue(context);
@@ -259,9 +256,8 @@ export function useFeedItemsSetWatchLaterValueMutation(contentId: string) {
       onMutate: ({ isWatchLater }) => {
         return applyOptimisticWatchLaterValue(contentId, isWatchLater);
       },
-      onSuccess: async (serverValue, _variables, context) => {
+      onSuccess: (serverValue, _variables, context) => {
         resolveOptimisticWatchLaterValue(context, serverValue);
-        await refreshNavigationSnapshotSafely();
       },
       onError: (_error, _variables, context) => {
         rollbackOptimisticWatchLaterValue(context);
@@ -289,9 +285,8 @@ export function useBulkSetWatchedValueMutation() {
       onMutate: ({ items, isWatched }) => {
         return applyOptimisticWatchedValues(items, isWatched);
       },
-      onSuccess: async (serverItems, _variables, contexts) => {
+      onSuccess: (serverItems, _variables, contexts) => {
         settleOptimisticWatchedValues(contexts ?? [], serverItems ?? []);
-        await refreshNavigationSnapshotSafely();
       },
       onError: (_error, _variables, contexts) => {
         rollbackOptimisticWatchedValues(contexts ?? []);

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -6,7 +6,6 @@ import {
   clearRetainedEntityPins,
   setRetainedEntityPins,
 } from "../page-retention";
-import { refreshNavigationSnapshotSafely } from "../navigation/store";
 import { mixedContentStore } from "./store";
 import type { MixedContentReference } from "~/server/mixed-content/projection";
 import { orpcRouterClient } from "~/lib/orpc";
@@ -75,7 +74,6 @@ export async function setMixedReadValue(input: {
           })
         : Promise.resolve(),
     ]);
-    await refreshNavigationSnapshotSafely();
   } catch (error) {
     for (const bookmark of previousBookmarks) {
       const optimisticBookmark = bookmarksStore

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -1,5 +1,6 @@
 import { getDefaultStore } from "jotai";
 import { unstable_batchedUpdates } from "react-dom";
+import { useSyncExternalStore } from "react";
 import { bookmarksStore } from "./bookmarks/store";
 import { contentCategoriesStore } from "./content-categories/store";
 import { feedCategoriesStore } from "./feed-categories/store";
@@ -37,6 +38,7 @@ import type { RssAttemptSummary, RssTrigger } from "~/lib/rss";
 import { orpcRouterClient } from "~/lib/orpc";
 import {
   createReconciliationRuntime,
+  expandInvalidationSummary,
   getBookmarkReconciliationVersion,
   getFeedItemReconciliationVersion,
   getReconciliationTargetKey,
@@ -306,6 +308,81 @@ function retainedRssTargets(
     );
 }
 
+function retainedScopeTargets(activeTarget: ReconciliationScopeTarget | null) {
+  const targets = Object.values(mixedContentStore.getState().scopes).map(
+    ({ scope, contentStatus }) =>
+      ({
+        type: "scope",
+        scope,
+        contentStatus,
+      }) satisfies ReconciliationScopeTarget,
+  );
+  if (activeTarget) targets.push(activeTarget);
+  return [
+    ...new Map(
+      targets.map((target) => [getReconciliationTargetKey(target), target]),
+    ).values(),
+  ];
+}
+
+function mutationInvalidationEffects(
+  payloads: PublishedChunk[],
+  activeTarget: ReconciliationScopeTarget | null,
+) {
+  const summaries = payloads.flatMap((payload) => {
+    if (payload.source === "invalidation") return [payload.chunk];
+    return payload.invalidation ? [payload.invalidation] : [];
+  });
+  if (summaries.length === 0) return null;
+
+  const retainedScopes = retainedScopeTargets(activeTarget);
+  const memberships = {
+    views: viewsStore.getState().views,
+    viewFeedIds: feedItemsStore.getState().viewFeedIds,
+    feedCategories: feedCategoriesStore.getState().feedCategories,
+  };
+  const repairTargets = new Map<string, ReconciliationTarget>();
+  const dirtyTargets = new Map<string, ReconciliationTarget>();
+  let unknown = false;
+
+  for (const summary of summaries) {
+    for (const domain of summary.domains) {
+      const target = { type: domain } satisfies ReconciliationTarget;
+      repairTargets.set(getReconciliationTargetKey(target), target);
+    }
+    const expanded = expandInvalidationSummary({
+      summary,
+      retainedScopes,
+      memberships,
+    });
+    unknown ||= expanded.scopeImpactUnknown;
+    for (const target of expanded.scopes) {
+      const key = getReconciliationTargetKey(target);
+      if (activeTarget && key === getReconciliationTargetKey(activeTarget)) {
+        repairTargets.set(key, target);
+      } else {
+        dirtyTargets.set(key, target);
+      }
+    }
+  }
+
+  const eagerTargets = [...repairTargets.values()];
+  return {
+    repairTargets: eagerTargets,
+    dirtyTargets: [...dirtyTargets.values()],
+    repairIntent: unknown
+      ? activeTarget
+        ? ({ type: "full", selectedScope: activeTarget } as const)
+        : ({
+            type: "full",
+            coldContentStatus: DEFAULT_CONTENT_STATUS_FILTER,
+          } as const)
+      : eagerTargets.length > 0
+        ? ({ type: "targeted", targets: eagerTargets } as const)
+        : undefined,
+  };
+}
+
 let manualFullPromise: Promise<void> | null = null;
 let resolveManualFull: (() => void) | null = null;
 let rejectManualFull: ((error: Error) => void) | null = null;
@@ -366,10 +443,14 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
     }
   },
   applyLiveEvent: (payloads) => {
-    const result = applyPublishedChunks(payloads, {
+    applyPublishedChunks(payloads, {
       refreshNavigation: false,
     });
     const activeTarget = currentSelection();
+    const invalidationEffects = mutationInvalidationEffects(
+      payloads,
+      activeTarget,
+    );
     const summary = rssSummaryFrom(payloads);
     const onlyRssPayloads = payloads.every(({ source }) => source === "rss");
     if (onlyRssPayloads && !summary) return;
@@ -390,23 +471,10 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
         repairIntent: { type: "targeted", targets: repairTargets } as const,
       };
     }
-    const activeScopeKey = activeTarget
-      ? getMixedScopeKey(activeTarget.scope, activeTarget.contentStatus)
-      : null;
-    const activeScopeChanged = result.affectedScopes.some(
-      (scope) =>
-        activeScopeKey === getMixedScopeKey(scope.scope, scope.contentStatus),
-    );
-    return [
-      ...(activeTarget && activeScopeChanged ? [activeTarget] : []),
-      ...(result.navigationSnapshotChanged
-        ? ([{ type: "navigation" }] as const)
-        : []),
-    ];
+    if (invalidationEffects) return invalidationEffects;
+    return;
   },
   getCurrentSelection: currentSelection,
-  deferLiveEventInvalidation: (payloads) =>
-    payloads.every(({ source }) => source === "rss"),
   mark: performanceMark,
   onParityApplied: ({ automaticRssOwner, reconciliationId }) => {
     loadingActor.send({ type: "INITIAL_DATA_COMPLETE" });
@@ -525,6 +593,7 @@ export const dataReconciliation = {
       start = end;
     }
   },
+  environmentChanged: runtime.environmentChanged,
   sseConnectionChanged: runtime.sseConnectionChanged,
   getState: runtime.getState,
   subscribe: runtime.subscribe,
@@ -538,4 +607,21 @@ export function getReconciliationTargetStatus(
   target: ReconciliationScopeTarget,
 ) {
   return runtime.getState().targets[getReconciliationTargetKey(target)]?.status;
+}
+
+export type ReconciliationDisplayStatus = "idle" | "syncing" | "retrying";
+
+function reconciliationDisplayStatus(): ReconciliationDisplayStatus {
+  const state = runtime.getState();
+  if (state.cacheUsableAt === null) return "idle";
+  if (state.inFlight) return "syncing";
+  return state.retryPending ? "retrying" : "idle";
+}
+
+export function useReconciliationDisplayStatus() {
+  return useSyncExternalStore(
+    dataReconciliation.subscribe,
+    reconciliationDisplayStatus,
+    () => "idle" as const,
+  );
 }

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -18,7 +18,13 @@ const pendingBookmarkSyncBuckets = new Map<
 function incomingFeedItemIds(payloads: PublishedChunk[]) {
   const ids = new Set<string>();
   for (const payload of payloads) {
-    if (payload.source === "bookmark" || payload.source === "mixed") continue;
+    if (
+      payload.source === "bookmark" ||
+      payload.source === "mixed" ||
+      payload.source === "invalidation"
+    ) {
+      continue;
+    }
     const chunk = payload.chunk;
     if ("feedItems" in chunk) {
       for (const item of chunk.feedItems) ids.add(item.id);
@@ -80,7 +86,10 @@ export function applyPublishedChunks(
       chunk.refreshNavigationSnapshot === true,
   );
   const feedPayloads = payloads.filter(
-    (payload) => payload.source !== "bookmark" && payload.source !== "mixed",
+    (payload) =>
+      payload.source !== "bookmark" &&
+      payload.source !== "mixed" &&
+      payload.source !== "invalidation",
   );
   if (feedPayloads.length > 0) {
     const incomingItemIds = incomingFeedItemIds(feedPayloads);
@@ -150,6 +159,7 @@ export function applyPublishedChunks(
   }
 
   for (const payload of payloads) {
+    if (payload.source === "invalidation") continue;
     if (payload.source === "mixed") {
       const { chunk } = payload;
       const scopeKey = getMixedScopeKey(chunk.scope, chunk.contentStatus);

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -179,8 +179,12 @@ export function useDataSubscription() {
 
     const handleVisibilityChange = () => {
       updateConnectionState();
+      dataReconciliation.environmentChanged();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    const handleNetworkChange = () => dataReconciliation.environmentChanged();
+    window.addEventListener("online", handleNetworkChange);
+    window.addEventListener("offline", handleNetworkChange);
 
     // Recompute connection logic when the keep-alive atom changes
     const unsubscribeAtom = getDefaultStore().sub(
@@ -194,6 +198,8 @@ export function useDataSubscription() {
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("online", handleNetworkChange);
+      window.removeEventListener("offline", handleNetworkChange);
       unsubscribeAtom();
       controller.abort();
       setDataSubscriptionConnected(false);

--- a/apps/app/src/lib/hooks/useFeedItemActions.ts
+++ b/apps/app/src/lib/hooks/useFeedItemActions.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { orpcRouterClient } from "../orpc";
-import { feedItemsStore, useFeedItemValue } from "../data/store";
+import { useFeedItemValue } from "../data/store";
 import {
   applyOptimisticWatchedValue,
   applyOptimisticWatchLaterValue,
@@ -13,17 +13,9 @@ import {
   rollbackOptimisticWatchedValue,
   rollbackOptimisticWatchLaterValue,
 } from "../data/feed-items/mutations";
-import { refreshNavigationAfterFeedItemChangeIfNeeded } from "../data/navigation/refreshOnLocalTransition";
 import { useFeeds as useFeedsArray } from "../data/feeds/store";
 import { saveHomeScrollPosition } from "~/lib/scroll";
 import { getDataSubscriptionClientId } from "~/lib/data/clientChannel";
-import { refreshNavigationSnapshotSafely } from "~/lib/data/navigation/store";
-import { isDataSubscriptionConnected } from "~/lib/data/subscriptionConnection";
-
-async function refreshNavigationWithoutSubscription() {
-  if (isDataSubscriptionConnected()) return;
-  await refreshNavigationSnapshotSafely();
-}
 
 export function useFeedItemActions(itemId: string) {
   const router = useRouter();
@@ -35,7 +27,6 @@ export function useFeedItemActions(itemId: string) {
     if (item.isWatched) return;
 
     const context = applyOptimisticWatchedValue(itemId, true);
-    const optimisticItem = feedItemsStore.getState().feedItemsDict[itemId];
     void orpcRouterClient.feedItem
       .setWatchedValue({
         id: itemId,
@@ -43,15 +34,8 @@ export function useFeedItemActions(itemId: string) {
         isWatched: true,
         clientId: getDataSubscriptionClientId(),
       })
-      .then(async (serverValue) => {
+      .then((serverValue) => {
         resolveOptimisticWatchedValue(context, serverValue);
-        if (optimisticItem) {
-          refreshNavigationAfterFeedItemChangeIfNeeded({
-            previousItem: item,
-            nextItem: optimisticItem,
-          });
-        }
-        await refreshNavigationWithoutSubscription();
       })
       .catch(() => rollbackOptimisticWatchedValue(context));
   }, [item, itemId]);
@@ -61,7 +45,6 @@ export function useFeedItemActions(itemId: string) {
 
     const newIsWatched = !item.isWatched;
     const context = applyOptimisticWatchedValue(itemId, newIsWatched);
-    const optimisticItem = feedItemsStore.getState().feedItemsDict[itemId];
     void orpcRouterClient.feedItem
       .setWatchedValue({
         id: itemId,
@@ -69,15 +52,8 @@ export function useFeedItemActions(itemId: string) {
         isWatched: newIsWatched,
         clientId: getDataSubscriptionClientId(),
       })
-      .then(async (serverValue) => {
+      .then((serverValue) => {
         resolveOptimisticWatchedValue(context, serverValue);
-        if (optimisticItem) {
-          refreshNavigationAfterFeedItemChangeIfNeeded({
-            previousItem: item,
-            nextItem: optimisticItem,
-          });
-        }
-        await refreshNavigationWithoutSubscription();
       })
       .catch(() => rollbackOptimisticWatchedValue(context));
 
@@ -88,7 +64,6 @@ export function useFeedItemActions(itemId: string) {
     if (!item) return;
 
     const context = applyOptimisticWatchLaterValue(itemId, !item.isWatchLater);
-    const optimisticItem = feedItemsStore.getState().feedItemsDict[itemId];
     void orpcRouterClient.feedItem
       .setWatchLaterValue({
         id: itemId,
@@ -96,15 +71,8 @@ export function useFeedItemActions(itemId: string) {
         isWatchLater: !item.isWatchLater,
         clientId: getDataSubscriptionClientId(),
       })
-      .then(async (serverValue) => {
+      .then((serverValue) => {
         resolveOptimisticWatchLaterValue(context, serverValue);
-        if (optimisticItem) {
-          refreshNavigationAfterFeedItemChangeIfNeeded({
-            previousItem: item,
-            nextItem: optimisticItem,
-          });
-        }
-        await refreshNavigationWithoutSubscription();
       })
       .catch(() => rollbackOptimisticWatchLaterValue(context));
   }, [item, itemId]);

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -87,9 +87,12 @@ export type ReconciliationCoordinatorState<
   hydratedDomains: Record<ReconciliationHydrationDomain, boolean>;
   bufferedApplications: Array<BufferedApplication<TAuthoritative, TLiveEvent>>;
   latestFullEpoch: FullEpoch | null;
+  activeScope: ReconciliationScopeTarget | null;
   cacheUsableAt: number | null;
   serverParityAppliedAt: number | null;
   sseConnected: boolean;
+  retryPending: boolean;
+  retryAt: number | null;
   automaticRssOwner: AutomaticRssOwner | null;
   trustedUpToDate: boolean;
 };
@@ -117,6 +120,12 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       type: "sse-connection-changed";
       connected: boolean;
     }
+  | {
+      type: "active-scope-changed";
+      target: ReconciliationScopeTarget;
+    }
+  | { type: "retry-scheduled"; at: number | null }
+  | { type: "retry-cleared" }
   | {
       type: "hydration-complete";
       domain: ReconciliationHydrationDomain;
@@ -208,9 +217,12 @@ export function createReconciliationCoordinatorState<
     hydratedDomains: initialHydrationState(),
     bufferedApplications: [],
     latestFullEpoch: null,
+    activeScope: null,
     cacheUsableAt: null,
     serverParityAppliedAt: null,
     sseConnected: false,
+    retryPending: false,
+    retryAt: null,
     automaticRssOwner: null,
     trustedUpToDate: false,
   };
@@ -266,6 +278,10 @@ function withTargetState<TAuthoritative, TLiveEvent>(
 ) {
   const targetKey = getReconciliationTargetKey(nextTarget.target);
   const domain = getTargetDomain(nextTarget.target);
+  const updatesActiveDomain =
+    nextTarget.target.type !== "scope" ||
+    (state.activeScope !== null &&
+      getReconciliationTargetKey(state.activeScope) === targetKey);
   return {
     ...state,
     targets: { ...state.targets, [targetKey]: nextTarget },
@@ -276,13 +292,15 @@ function withTargetState<TAuthoritative, TLiveEvent>(
             [getReconciliationScopeKey(nextTarget.target)]: nextTarget,
           }
         : state.scopes,
-    domains: {
-      ...state.domains,
-      [domain]: {
-        status: nextTarget.status,
-        appliedAt: nextTarget.appliedAt,
-      },
-    },
+    domains: updatesActiveDomain
+      ? {
+          ...state.domains,
+          [domain]: {
+            status: nextTarget.status,
+            appliedAt: nextTarget.appliedAt,
+          },
+        }
+      : state.domains,
   };
 }
 
@@ -301,6 +319,10 @@ function startRequest<TAuthoritative, TLiveEvent>(
   const descriptor = { reconciliationId, intent, capturedRevisions };
   let nextState: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent> = {
     ...state,
+    activeScope:
+      intent.type === "full" && "selectedScope" in intent
+        ? intent.selectedScope
+        : state.activeScope,
     nextReconciliationSequence: state.nextReconciliationSequence + 1,
     inFlight: descriptor,
     requests: {
@@ -350,13 +372,10 @@ function enqueueRequest<TAuthoritative, TLiveEvent>(
 }
 
 function repairIntentFor<TAuthoritative, TLiveEvent>(
-  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  _state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
   targets: ReconciliationTarget[],
 ): ReconciliationRequestIntent {
-  const fullEpoch = state.latestFullEpoch;
-  return fullEpoch && !fullEpoch.established
-    ? fullEpoch.intent
-    : { type: "targeted", targets: uniqueTargets(targets) };
+  return { type: "targeted", targets: uniqueTargets(targets) };
 }
 
 function bindColdFullScope<TAuthoritative, TLiveEvent>(
@@ -388,7 +407,11 @@ function bindColdFullScope<TAuthoritative, TLiveEvent>(
       [targetKey]: currentTarget.revision,
     },
   };
-  let nextState = withTargetState(state, {
+  let nextState: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent> = {
+    ...state,
+    activeScope: target,
+  };
+  nextState = withTargetState(nextState, {
     ...currentTarget,
     status: "syncing",
     requestedReconciliationId: reconciliationId,
@@ -534,10 +557,7 @@ function fullEpochIsApplied<TAuthoritative, TLiveEvent>(
     ) &&
     fullEpoch.requiredTargetKeys.every((targetKey) => {
       const target = state.targets[targetKey];
-      return (
-        target?.status === "verified" &&
-        target.appliedReconciliationId === fullEpoch.reconciliationId
-      );
+      return target?.status === "verified";
     })
   );
 }
@@ -557,15 +577,28 @@ function withEstablishedFullParity<TAuthoritative, TLiveEvent>(
 function deriveTrustedUpToDate<TAuthoritative, TLiveEvent>(
   state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
 ) {
+  const requiredTargetKeys = new Set([
+    getReconciliationTargetKey({ type: "organization" }),
+    getReconciliationTargetKey({ type: "navigation" }),
+    ...(state.activeScope
+      ? [getReconciliationTargetKey(state.activeScope)]
+      : []),
+  ]);
   const hasBufferedAuthoritative = state.bufferedApplications.some(
-    (application) => application.type === "authoritative",
+    (application) =>
+      application.type === "authoritative" &&
+      application.targetKeys.some((targetKey) =>
+        requiredTargetKeys.has(targetKey),
+      ),
   );
   return Boolean(
     state.cacheUsableAt !== null &&
     state.latestFullEpoch?.established &&
     state.serverParityAppliedAt !== null &&
     state.sseConnected &&
-    Object.keys(state.dirtyTargets).length === 0 &&
+    [...requiredTargetKeys].every(
+      (targetKey) => state.dirtyTargets[targetKey] === undefined,
+    ) &&
     !hasBufferedAuthoritative,
   );
 }
@@ -594,6 +627,33 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
         state: withDerivedTrust({
           ...state,
           sseConnected: event.connected,
+        }),
+        commands: [],
+      };
+    case "active-scope-changed": {
+      const target = targetState(state, event.target);
+      return {
+        state: withDerivedTrust(
+          withTargetState({ ...state, activeScope: event.target }, target),
+        ),
+        commands: [],
+      };
+    }
+    case "retry-scheduled":
+      return {
+        state: withDerivedTrust({
+          ...state,
+          retryPending: true,
+          retryAt: event.at,
+        }),
+        commands: [],
+      };
+    case "retry-cleared":
+      return {
+        state: withDerivedTrust({
+          ...state,
+          retryPending: false,
+          retryAt: null,
         }),
         commands: [],
       };
@@ -743,6 +803,13 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
     case "request-settled": {
       let nextState = state;
       if (event.failedTargets && event.failedTargets.length > 0) {
+        for (const target of event.failedTargets) {
+          nextState = bindColdFullScope(
+            nextState,
+            event.reconciliationId,
+            target,
+          );
+        }
         nextState = markTargetsDirty(nextState, event.failedTargets, false);
       }
       if (

--- a/apps/app/src/lib/reconciliation/index.ts
+++ b/apps/app/src/lib/reconciliation/index.ts
@@ -1,5 +1,6 @@
 export * from "./contracts";
 export * from "./coordinator";
+export * from "./invalidation";
 export * from "./reducers";
 export * from "./runtime";
 export * from "./versions";

--- a/apps/app/src/lib/reconciliation/invalidation.ts
+++ b/apps/app/src/lib/reconciliation/invalidation.ts
@@ -1,0 +1,218 @@
+import type {
+  ContentStatusFilter,
+  ContentStatusKey,
+} from "~/lib/content-status";
+import type {
+  ReconciliationScope,
+  ReconciliationScopeTarget,
+} from "./contracts";
+import {
+  buildContentStatusKey,
+  CONTENT_STATUS_FILTERS,
+} from "~/lib/content-status";
+import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
+
+export const ALL_CONTENT_STATUS_KEYS = CONTENT_STATUS_FILTERS.map(
+  buildContentStatusKey,
+);
+
+export type ReconciliationInvalidationDomain = "organization" | "navigation";
+
+export type ReconciliationScopeSelector =
+  | {
+      type: "scopes";
+      scopes: ReconciliationScope[];
+      contentStatusKeys: ContentStatusKey[];
+    }
+  | {
+      type: "feed-memberships";
+      feedIds: number[];
+      contentStatusKeys: ContentStatusKey[];
+    }
+  | {
+      type: "bookmark-memberships";
+      bookmarks: BookmarkInvalidationState[];
+      contentStatusKeys: ContentStatusKey[];
+    }
+  | {
+      type: "all-retained";
+      contentStatusKeys: ContentStatusKey[];
+    };
+
+export type ReconciliationInvalidationSummary = {
+  type: "reconciliation-invalidation";
+  domains: ReconciliationInvalidationDomain[];
+  scopeImpact:
+    | { type: "known"; selectors: ReconciliationScopeSelector[] }
+    | { type: "unknown" };
+};
+
+export type ReconciliationInvalidationMemberships = {
+  views: Array<{ id: number; categoryIds: number[]; feedIds: number[] }>;
+  viewFeedIds: Record<number, number[]>;
+  feedCategories: Array<{ feedId: number; categoryId: number }>;
+};
+
+export type BookmarkInvalidationState = {
+  isSaved: boolean;
+  isRead: boolean;
+  viewIds: number[];
+  tagIds: number[];
+};
+
+function unique<T>(values: T[]) {
+  return [...new Set(values)];
+}
+
+function sameScope(left: ReconciliationScope, right: ReconciliationScope) {
+  if (left.type !== right.type) return false;
+  if (left.type === "view" && right.type === "view") {
+    return left.viewId === right.viewId;
+  }
+  if (left.type === "feed" && right.type === "feed") {
+    return left.feedId === right.feedId;
+  }
+  return (
+    left.type === "tag" && right.type === "tag" && left.tagId === right.tagId
+  );
+}
+
+function selectorMatchesScope(
+  selector: ReconciliationScopeSelector,
+  target: ReconciliationScopeTarget,
+  memberships: ReconciliationInvalidationMemberships,
+) {
+  if (
+    !selector.contentStatusKeys.includes(
+      buildContentStatusKey(target.contentStatus),
+    )
+  ) {
+    return false;
+  }
+  if (selector.type === "all-retained") return true;
+  if (selector.type === "scopes") {
+    return selector.scopes.some((scope) => sameScope(scope, target.scope));
+  }
+  if (selector.type === "bookmark-memberships") {
+    if (target.scope.type === "feed") return false;
+    return selector.bookmarks.some((bookmark) => {
+      if (target.scope.type === "tag") {
+        return bookmark.tagIds.includes(target.scope.tagId);
+      }
+      if (target.scope.type !== "view") return false;
+      const targetViewId = target.scope.viewId;
+      const placedViewIds = new Set(bookmark.viewIds);
+      for (const view of memberships.views) {
+        if (view.categoryIds.some((tagId) => bookmark.tagIds.includes(tagId))) {
+          placedViewIds.add(view.id);
+        }
+      }
+      return targetViewId === UNCATEGORIZED_VIEW_ID
+        ? placedViewIds.size === 0
+        : placedViewIds.has(targetViewId);
+    });
+  }
+
+  const feedIds = new Set(selector.feedIds);
+  if (target.scope.type === "feed") {
+    return feedIds.has(target.scope.feedId);
+  }
+  if (target.scope.type === "tag") {
+    const targetTagId = target.scope.tagId;
+    return memberships.feedCategories.some(
+      ({ feedId, categoryId }) =>
+        categoryId === targetTagId && feedIds.has(feedId),
+    );
+  }
+  return (memberships.viewFeedIds[target.scope.viewId] ?? []).some((feedId) =>
+    feedIds.has(feedId),
+  );
+}
+
+export function expandInvalidationSummary(input: {
+  summary: ReconciliationInvalidationSummary;
+  retainedScopes: ReconciliationScopeTarget[];
+  memberships: ReconciliationInvalidationMemberships;
+}) {
+  if (input.summary.scopeImpact.type === "unknown") {
+    return { scopeImpactUnknown: true, scopes: [] };
+  }
+  return {
+    scopeImpactUnknown: false,
+    scopes: input.retainedScopes.filter((target) =>
+      input.summary.scopeImpact.type === "known"
+        ? input.summary.scopeImpact.selectors.some((selector) =>
+            selectorMatchesScope(selector, target, input.memberships),
+          )
+        : false,
+    ),
+  };
+}
+
+export function contentStatusKeyForEntity(input: {
+  isSaved: boolean;
+  isRead: boolean;
+}): ContentStatusKey {
+  return `${input.isSaved ? "saved" : "inbox"}:${input.isRead ? "archived" : "unread"}`;
+}
+
+export function buildBookmarkInvalidationSummary(input: {
+  before?: BookmarkInvalidationState | null;
+  after?: BookmarkInvalidationState | null;
+  states?: BookmarkInvalidationState[];
+  contentStatusKeys?: ContentStatusKey[];
+}): ReconciliationInvalidationSummary {
+  const states = [...(input.states ?? []), input.before, input.after].filter(
+    (state): state is BookmarkInvalidationState => Boolean(state),
+  );
+  const contentStatusKeys = unique(
+    input.contentStatusKeys ?? states.map(contentStatusKeyForEntity),
+  );
+  return {
+    type: "reconciliation-invalidation",
+    domains: ["navigation"],
+    scopeImpact: {
+      type: "known",
+      selectors: [
+        {
+          type: "bookmark-memberships",
+          bookmarks: states,
+          contentStatusKeys,
+        },
+      ],
+    },
+  };
+}
+
+export function buildFeedInvalidationSummary(input: {
+  feedIds: number[];
+  contentStatusKeys: ContentStatusKey[];
+}): ReconciliationInvalidationSummary {
+  return {
+    type: "reconciliation-invalidation",
+    domains: ["navigation"],
+    scopeImpact: {
+      type: "known",
+      selectors: [
+        {
+          type: "feed-memberships",
+          feedIds: unique(input.feedIds),
+          contentStatusKeys: unique(input.contentStatusKeys),
+        },
+      ],
+    },
+  };
+}
+
+export function contentStatusKeysAroundChange(input: {
+  saveStatuses: Array<ContentStatusFilter["saveStatus"]>;
+  archiveStatuses: Array<ContentStatusFilter["archiveStatus"]>;
+}): ContentStatusKey[] {
+  return unique(
+    input.saveStatuses.flatMap((saveStatus) =>
+      input.archiveStatuses.map<ContentStatusKey>(
+        (archiveStatus) => `${saveStatus}:${archiveStatus}`,
+      ),
+    ),
+  );
+}

--- a/apps/app/src/lib/reconciliation/runtime.ts
+++ b/apps/app/src/lib/reconciliation/runtime.ts
@@ -45,7 +45,8 @@ export type ReconciliationRuntimeDependencies<TLiveEvent> = {
       }
     | void;
   getCurrentSelection: () => ReconciliationScopeTarget | null;
-  deferLiveEventInvalidation?: (payload: TLiveEvent) => boolean;
+  isVisible?: () => boolean;
+  isOnline?: () => boolean;
   mark?: (name: string, reconciliationId?: string) => void;
   onParityApplied?: (input: {
     reconciliationId: string | undefined;
@@ -106,11 +107,112 @@ export function createReconciliationRuntime<TLiveEvent>(
   let reconnectRequired = false;
   let completedBeforeFirstConnection = false;
   let liveSequence = 0;
+  let retryDelayMs = 1_000;
+  let retryIntent: ReconciliationRequestIntent | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
   const listeners = new Set<() => void>();
   const requestControllers = new Map<string, AbortController>();
 
+  const canRetry = () =>
+    (dependencies.isVisible?.() ??
+      (typeof document === "undefined" ||
+        document.visibilityState !== "hidden")) &&
+    (dependencies.isOnline?.() ??
+      (typeof navigator === "undefined" || navigator.onLine !== false));
+
+  const clearRetryTimer = () => {
+    if (retryTimer !== null) clearTimeout(retryTimer);
+    retryTimer = null;
+  };
+
   const notify = () => {
     for (const listener of listeners) listener();
+  };
+
+  const mergeRetryIntent = (
+    current: ReconciliationRequestIntent | null,
+    incoming: ReconciliationRequestIntent,
+  ): ReconciliationRequestIntent => {
+    if (!current || incoming.type === "full") return incoming;
+    if (current.type === "full") return current;
+    return {
+      type: "targeted",
+      targets: [
+        ...new Map(
+          [...current.targets, ...incoming.targets].map((target) => [
+            getReconciliationTargetKey(target),
+            target,
+          ]),
+        ).values(),
+      ],
+    };
+  };
+
+  const scheduleRetry = (intent: ReconciliationRequestIntent) => {
+    retryIntent = mergeRetryIntent(retryIntent, intent);
+    clearRetryTimer();
+    if (!canRetry()) {
+      send({ type: "retry-scheduled", at: null });
+      return;
+    }
+    const delay = retryDelayMs;
+    send({ type: "retry-scheduled", at: dependencies.now() + delay });
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (!canRetry()) {
+        send({ type: "retry-scheduled", at: null });
+        return;
+      }
+      const pending = retryIntent;
+      retryIntent = null;
+      send({ type: "retry-cleared" });
+      if (pending) {
+        send({ type: "request-reconciliation", intent: pending });
+      }
+    }, delay);
+    retryDelayMs = Math.min(retryDelayMs * 2, 30_000);
+  };
+
+  const clearRetry = () => {
+    clearRetryTimer();
+    retryIntent = null;
+    retryDelayMs = 1_000;
+    send({ type: "retry-cleared" });
+  };
+
+  const successfulRequestCoversRetry = (
+    request: ReconciliationRequestDescriptor,
+  ) => {
+    if (!retryIntent) return true;
+    if (retryIntent.type === "full") return request.intent.type === "full";
+    const successfulTargetKeys = new Set(
+      (state.requests[request.reconciliationId]?.targets ?? []).map(
+        getReconciliationTargetKey,
+      ),
+    );
+    return retryIntent.targets.every((target) =>
+      successfulTargetKeys.has(getReconciliationTargetKey(target)),
+    );
+  };
+
+  const clearCoveredRetry = (request: ReconciliationRequestDescriptor) => {
+    if (successfulRequestCoversRetry(request)) clearRetry();
+  };
+
+  const retryIntentForFailure = (
+    failedTargets: ReconciliationTarget[] | undefined,
+    forceFull = false,
+  ): ReconciliationRequestIntent => {
+    if (forceFull || !failedTargets || failedTargets.length === 0) {
+      const selectedScope = dependencies.getCurrentSelection();
+      return selectedScope
+        ? { type: "full", selectedScope }
+        : {
+            type: "full",
+            coldContentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
+          };
+    }
+    return { type: "targeted", targets: failedTargets };
   };
 
   const execute = (commands: Command[]) => {
@@ -139,11 +241,11 @@ export function createReconciliationRuntime<TLiveEvent>(
         if (dirtyTargets && dirtyTargets.length > 0) {
           send({ type: "targets-dirtied", targets: dirtyTargets });
         }
-        if (repairTargets && repairTargets.length > 0) {
+        if ((repairTargets && repairTargets.length > 0) || repairIntent) {
           send({
             type: "live-event-received",
             eventId: `applied:${command.eventId}`,
-            targets: repairTargets,
+            targets: repairTargets ?? [],
             invalidates: repairTargets,
             repairIntent,
             requiresHydration: [],
@@ -278,6 +380,12 @@ export function createReconciliationRuntime<TLiveEvent>(
               failed: true,
               failedTargets: target ? [target] : undefined,
             });
+            scheduleRetry(
+              retryIntentForFailure(
+                target ? [target] : undefined,
+                chunk.failure.phase === "resolve-selection",
+              ),
+            );
             if (request.intent.type === "full") {
               dependencies.onFullReconciliationFailed?.({
                 reconciliationId: request.reconciliationId,
@@ -295,6 +403,7 @@ export function createReconciliationRuntime<TLiveEvent>(
               reconciliationId: request.reconciliationId,
               at: dependencies.now(),
             });
+            clearCoveredRetry(request);
             settled = true;
             return;
         }
@@ -317,6 +426,7 @@ export function createReconciliationRuntime<TLiveEvent>(
           failed: true,
           failedTargets,
         });
+        scheduleRetry(retryIntentForFailure(failedTargets));
         if (request.intent.type === "full") {
           dependencies.onFullReconciliationFailed?.({
             reconciliationId: request.reconciliationId,
@@ -327,6 +437,7 @@ export function createReconciliationRuntime<TLiveEvent>(
   }
 
   const requestCurrentFull = () => {
+    if (retryIntent) clearRetry();
     const selectedScope = dependencies.getCurrentSelection();
     send({
       type: "request-reconciliation",
@@ -348,6 +459,9 @@ export function createReconciliationRuntime<TLiveEvent>(
     stop() {
       for (const controller of requestControllers.values()) controller.abort();
       requestControllers.clear();
+      clearRetryTimer();
+      retryIntent = null;
+      retryDelayMs = 1_000;
       started = false;
       everConnected = false;
       reconnectRequired = false;
@@ -374,6 +488,7 @@ export function createReconciliationRuntime<TLiveEvent>(
         reconnectRequired ||
         (!everConnected && completedBeforeFirstConnection)
       ) {
+        clearRetry();
         reconnectRequired = false;
         completedBeforeFirstConnection = false;
         requestCurrentFull();
@@ -381,6 +496,7 @@ export function createReconciliationRuntime<TLiveEvent>(
       everConnected = true;
     },
     activateScope(target: ReconciliationScopeTarget) {
+      send({ type: "active-scope-changed", target });
       const targetState = state.targets[getReconciliationTargetKey(target)];
       if (
         targetState?.status === "verified" ||
@@ -394,24 +510,27 @@ export function createReconciliationRuntime<TLiveEvent>(
       });
     },
     requestFull: requestCurrentFull,
+    environmentChanged() {
+      if (!retryIntent) return;
+      if (!canRetry()) {
+        clearRetryTimer();
+        send({ type: "retry-scheduled", at: null });
+        return;
+      }
+      if (retryTimer !== null) return;
+      const pending = retryIntent;
+      retryIntent = null;
+      send({ type: "retry-cleared" });
+      send({ type: "request-reconciliation", intent: pending });
+    },
     receiveLiveEvent(payload: TLiveEvent) {
-      const inFlightFull = state.inFlight?.intent.type === "full";
       const selectedScope = dependencies.getCurrentSelection();
-      const invalidates =
-        !dependencies.deferLiveEventInvalidation?.(payload) && inFlightFull
-          ? ([
-              { type: "organization" },
-              ...(selectedScope ? [selectedScope] : []),
-              { type: "navigation" },
-            ] as ReconciliationTarget[])
-          : undefined;
       send({
         type: "live-event-received",
         eventId: `live:${++liveSequence}`,
         targets: selectedScope ? [selectedScope] : [],
         requiresHydration: ["organization", "active-scope", "bookmarks"],
         payload,
-        invalidates,
       });
     },
     getState: () => state,

--- a/apps/app/src/server/api/publisher.ts
+++ b/apps/app/src/server/api/publisher.ts
@@ -11,10 +11,11 @@ import type {
   MixedContentChunk,
 } from "~/server/mixed-content/sync";
 import type { RssPublishedChunk } from "~/lib/rss";
+import type { ReconciliationInvalidationSummary } from "~/lib/reconciliation";
 import { env } from "~/env";
 import { logError, logMessage } from "~/server/logger";
 
-export type PublishedChunk =
+type DataPublishedChunk =
   | { source: "initial"; chunk: GetByViewChunk }
   | { source: "revalidate"; chunk: RevalidateViewChunk }
   | { source: "content-status"; chunk: GetItemsByContentStatusChunk }
@@ -23,6 +24,15 @@ export type PublishedChunk =
   | { source: "bookmark"; chunk: BookmarkSyncChunk }
   | { source: "mixed"; chunk: MixedContentChunk }
   | { source: "rss"; chunk: RssPublishedChunk };
+
+export type PublishedChunk =
+  | (DataPublishedChunk & {
+      invalidation?: ReconciliationInvalidationSummary;
+    })
+  | {
+      source: "invalidation";
+      chunk: ReconciliationInvalidationSummary;
+    };
 
 const RESUME_RETENTION_SECONDS = 60 * 2;
 const REDIS_KEY_PREFIX = "serial:pub:";

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -138,6 +138,8 @@ export const updateState = protectedProcedure
       userId: context.user.id,
       bookmarkId: input.bookmarkId,
     });
+    // The invalidation summary needs the state from immediately before the mutation.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
     const bookmark = await updateBookmarkState({
       database: context.db,
       userId: context.user.id,
@@ -219,6 +221,8 @@ export const setBulkReadValue = protectedProcedure
       userId: context.user.id,
       bookmarkIds: input.bookmarkIds,
     });
+    // The invalidation summary needs the state from immediately before the mutation.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
     const updated = await updateBookmarksReadState({
       database: context.db,
       userId: context.user.id,
@@ -245,6 +249,8 @@ export const remove = protectedProcedure
       userId: context.user.id,
       bookmarkId: input.bookmarkId,
     });
+    // The deletion summary needs the state from immediately before the mutation.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
     const deleted = await deleteBookmark({
       database: context.db,
       userId: context.user.id,

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -16,6 +16,21 @@ import {
   publishBookmarkUpsertBatch,
 } from "~/server/mixed-content/sync";
 import { loadApplicationBookmarksById } from "~/server/mixed-content/projection";
+import { ALL_CONTENT_STATUS_KEYS } from "~/lib/reconciliation";
+
+async function loadBookmarkBeforeMutation(input: {
+  database: Parameters<typeof loadApplicationBookmarksById>[0]["database"];
+  userId: string;
+  bookmarkId: string;
+}) {
+  return (
+    await loadApplicationBookmarksById({
+      database: input.database,
+      userId: input.userId,
+      bookmarkIds: [input.bookmarkId],
+    })
+  )[0];
+}
 
 const bookmarkIdSchema = z.string().min(1);
 const bookmarkUrlSchema = z.string().superRefine((value, context) => {
@@ -37,6 +52,13 @@ export const save = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
+    const previousBookmark = input.bookmarkId
+      ? await loadBookmarkBeforeMutation({
+          database: context.db,
+          userId: context.user.id,
+          bookmarkId: input.bookmarkId,
+        })
+      : undefined;
     const result = await saveBookmarkFromApp({
       database: context.db,
       userId: context.user.id,
@@ -51,6 +73,7 @@ export const save = protectedProcedure
           userId: context.user.id,
           id: removedBookmarkId,
           canonicalUrl: result.bookmark.canonicalUrl,
+          invalidation: null,
         }),
       ),
     );
@@ -58,6 +81,8 @@ export const save = protectedProcedure
       database: context.db,
       userId: context.user.id,
       bookmarkId: result.bookmark.id,
+      previousBookmark,
+      contentStatusKeys: ALL_CONTENT_STATUS_KEYS,
     });
     return {
       ...result,
@@ -108,6 +133,11 @@ export const updateState = protectedProcedure
       ),
   )
   .handler(async ({ context, input }) => {
+    const previousBookmark = await loadBookmarkBeforeMutation({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
     const bookmark = await updateBookmarkState({
       database: context.db,
       userId: context.user.id,
@@ -117,6 +147,7 @@ export const updateState = protectedProcedure
       database: context.db,
       userId: context.user.id,
       bookmarkId: bookmark.id,
+      previousBookmark,
     });
     return applicationBookmark ?? bookmark;
   });
@@ -130,6 +161,11 @@ export const setView = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
+    const previousBookmark = await loadBookmarkBeforeMutation({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
     await setBookmarkView({
       database: context.db,
       userId: context.user.id,
@@ -139,6 +175,7 @@ export const setView = protectedProcedure
       database: context.db,
       userId: context.user.id,
       bookmarkId: input.bookmarkId,
+      previousBookmark,
     });
   });
 
@@ -151,6 +188,11 @@ export const setTag = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
+    const previousBookmark = await loadBookmarkBeforeMutation({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
     await setBookmarkTag({
       database: context.db,
       userId: context.user.id,
@@ -160,6 +202,7 @@ export const setTag = protectedProcedure
       database: context.db,
       userId: context.user.id,
       bookmarkId: input.bookmarkId,
+      previousBookmark,
     });
   });
 
@@ -171,6 +214,11 @@ export const setBulkReadValue = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
+    const previousBookmarks = await loadApplicationBookmarksById({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkIds: input.bookmarkIds,
+    });
     const updated = await updateBookmarksReadState({
       database: context.db,
       userId: context.user.id,
@@ -184,6 +232,7 @@ export const setBulkReadValue = protectedProcedure
     await publishBookmarkUpsertBatch({
       userId: context.user.id,
       bookmarks: applicationBookmarks,
+      previousBookmarks,
     });
     return updated;
   });
@@ -191,6 +240,11 @@ export const setBulkReadValue = protectedProcedure
 export const remove = protectedProcedure
   .input(z.object({ bookmarkId: bookmarkIdSchema }))
   .handler(async ({ context, input }) => {
+    const bookmark = await loadBookmarkBeforeMutation({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkId: input.bookmarkId,
+    });
     const deleted = await deleteBookmark({
       database: context.db,
       userId: context.user.id,
@@ -200,6 +254,7 @@ export const remove = protectedProcedure
       userId: context.user.id,
       id: deleted.id,
       canonicalUrl: deleted.canonicalUrl,
+      ...(bookmark ? { bookmark } : {}),
     });
     return deleted;
   });

--- a/apps/app/src/server/api/routers/contentCategoriesRouter.ts
+++ b/apps/app/src/server/api/routers/contentCategoriesRouter.ts
@@ -8,6 +8,10 @@ import {
   deduplicateByLastValue,
   MAX_BULK_MUTATION_ITEMS,
 } from "~/lib/schemas/bulk";
+import {
+  organizationInvalidationSummary,
+  publishReconciliationInvalidation,
+} from "~/server/reconciliation/invalidation";
 
 const categoryNameSchema = z.string().min(2);
 const feedCategorizationSchema = z.object({
@@ -34,7 +38,7 @@ export const create = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
-    return await context.db.transaction(async (tx) => {
+    const result = await context.db.transaction(async (tx) => {
       const feedIdsToCategorize =
         input.feedCategorizations
           ?.filter((categorization) => categorization.selected)
@@ -76,6 +80,13 @@ export const create = protectedProcedure
 
       return category;
     });
+    if (result) {
+      await publishReconciliationInvalidation(
+        context.user.id,
+        organizationInvalidationSummary(),
+      );
+    }
+    return result;
   });
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {
@@ -161,6 +172,10 @@ export const update = protectedProcedure
           );
       }
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const deleteCategory = protectedProcedure
@@ -175,4 +190,8 @@ export const deleteCategory = protectedProcedure
           eq(contentCategories.userId, context.user.id),
         ),
       );
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });

--- a/apps/app/src/server/api/routers/feed-router/index.ts
+++ b/apps/app/src/server/api/routers/feed-router/index.ts
@@ -38,6 +38,10 @@ import {
   boundedStringsSchema,
   MAX_BULK_MUTATION_ITEMS,
 } from "~/lib/schemas/bulk";
+import {
+  organizationInvalidationSummary,
+  publishReconciliationInvalidation,
+} from "~/server/reconciliation/invalidation";
 
 type BulkImportFromFileSuccess = {
   feedUrl: string;
@@ -60,13 +64,18 @@ const createFeedInputSchema = z.object({
 
 export const create = protectedProcedure
   .input(createFeedInputSchema)
-  .handler(({ context, input }) =>
-    createFeedsForUser({
+  .handler(async ({ context, input }) => {
+    const result = await createFeedsForUser({
       database: context.db,
       userId: context.user.id,
       ...input,
-    }),
-  );
+    });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
+    return result;
+  });
 
 export const createFromSubscriptionImport = protectedProcedure
   .input(
@@ -241,6 +250,12 @@ export const createFromSubscriptionImport = protectedProcedure
       allResults.push(...chunkResults);
     }
 
+    if (allResults.some((result) => result.success)) {
+      await publishReconciliationInvalidation(
+        context.user.id,
+        organizationInvalidationSummary(),
+      );
+    }
     return allResults;
   });
 
@@ -273,6 +288,10 @@ const deleteFeed = protectedProcedure
         );
       }
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 export { deleteFeed as delete };
 
@@ -301,7 +320,7 @@ export const update = protectedProcedure
     }),
   )
   .handler(async ({ context, input }) => {
-    return await context.db.transaction(async (tx) => {
+    const result = await context.db.transaction(async (tx) => {
       const [categoriesOwned, viewsOwned] = await Promise.all([
         verifyContentCategoriesOwnedByUser({
           categoryIds: input.categoryIds,
@@ -390,6 +409,13 @@ export const update = protectedProcedure
 
       return feedsSchema.parse(updatedFeed);
     });
+    if (result) {
+      await publishReconciliationInvalidation(
+        context.user.id,
+        organizationInvalidationSummary(),
+      );
+    }
+    return result;
   });
 
 export const bulkDelete = protectedProcedure
@@ -431,6 +457,10 @@ export const bulkDelete = protectedProcedure
         );
       }
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const setActive = protectedProcedure
@@ -464,7 +494,12 @@ export const setActive = protectedProcedure
     const updatedFeed = updatedFeeds[0];
     if (!updatedFeed) return null;
 
-    return feedsSchema.parse(updatedFeed);
+    const parsed = feedsSchema.parse(updatedFeed);
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
+    return parsed;
   });
 
 export const bulkSetActive = protectedProcedure
@@ -523,6 +558,10 @@ export const bulkSetActive = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const discoverFeeds = protectedProcedure

--- a/apps/app/src/server/api/routers/feedCategoriesRouter.ts
+++ b/apps/app/src/server/api/routers/feedCategoriesRouter.ts
@@ -5,6 +5,10 @@ import { verifyFeedsOwnedByUser } from "./feed-router/utils";
 import { protectedProcedure } from "~/server/orpc/base";
 import { contentCategories, feedCategories } from "~/server/db/schema";
 import { boundedNumberIdsSchema } from "~/lib/schemas/bulk";
+import {
+  organizationInvalidationSummary,
+  publishReconciliationInvalidation,
+} from "~/server/reconciliation/invalidation";
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {
   const contentCategoriesList = await context.db
@@ -44,6 +48,10 @@ export const assignToFeed = protectedProcedure
         categoryId: input.categoryId,
       });
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const removeFromFeed = protectedProcedure
@@ -69,6 +77,10 @@ export const removeFromFeed = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const bulkAssignToFeeds = protectedProcedure
@@ -99,6 +111,10 @@ export const bulkAssignToFeeds = protectedProcedure
         )
         .onConflictDoNothing();
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const bulkRemoveFromFeeds = protectedProcedure
@@ -128,4 +144,8 @@ export const bulkRemoveFromFeeds = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });

--- a/apps/app/src/server/api/routers/feedItemRouter.ts
+++ b/apps/app/src/server/api/routers/feedItemRouter.ts
@@ -14,6 +14,12 @@ import {
   deduplicateByLastValue,
   MAX_BULK_MUTATION_ITEMS,
 } from "~/lib/schemas/bulk";
+import {
+  ALL_CONTENT_STATUS_KEYS,
+  buildFeedInvalidationSummary,
+  contentStatusKeysAroundChange,
+} from "~/lib/reconciliation";
+import { publishReconciliationInvalidation } from "~/server/reconciliation/invalidation";
 
 type FeedItemsChunk =
   | {
@@ -115,6 +121,17 @@ export const setWatchedValue = protectedProcedure
       );
     }
 
+    await publishReconciliationInvalidation(
+      context.user.id,
+      buildFeedInvalidationSummary({
+        feedIds: [input.feedId],
+        contentStatusKeys: contentStatusKeysAroundChange({
+          saveStatuses: [result.isWatchLater ? "saved" : "inbox"],
+          archiveStatuses: ["unread", "archived"],
+        }),
+      }),
+    );
+
     return {
       id: result.id,
       isWatched: result.isWatched,
@@ -147,7 +164,7 @@ export const setBulkWatchedValue = protectedProcedure
     if (input.items.length === 0) return;
 
     const updatedAt = new Date();
-    return context.db.transaction(async (tx) => {
+    const result = await context.db.transaction(async (tx) => {
       // Extract unique feedIds and verify ownership
       const feedIds = [...new Set(input.items.map((item) => item.feedId))];
 
@@ -180,6 +197,14 @@ export const setBulkWatchedValue = protectedProcedure
           updatedAt: feedItems.updatedAt,
         });
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      buildFeedInvalidationSummary({
+        feedIds: input.items.map(({ feedId }) => feedId),
+        contentStatusKeys: ALL_CONTENT_STATUS_KEYS,
+      }),
+    );
+    return result;
   });
 
 export const setWatchLaterValue = protectedProcedure
@@ -268,6 +293,17 @@ export const setWatchLaterValue = protectedProcedure
         },
       );
     }
+
+    await publishReconciliationInvalidation(
+      context.user.id,
+      buildFeedInvalidationSummary({
+        feedIds: [input.feedId],
+        contentStatusKeys: contentStatusKeysAroundChange({
+          saveStatuses: ["inbox", "saved"],
+          archiveStatuses: [result.isWatched ? "archived" : "unread"],
+        }),
+      }),
+    );
 
     return {
       id: result.id,

--- a/apps/app/src/server/api/routers/initialRouter.ts
+++ b/apps/app/src/server/api/routers/initialRouter.ts
@@ -22,6 +22,7 @@ import {
 import { publisher, trackChannelConnection } from "../publisher";
 import { getClientChannel, getUserChannel } from "../channels";
 import { insertFeedWithCategories } from "./feed-router/utils";
+import type { PublishedChunk } from "../publisher";
 import type { SQL } from "drizzle-orm";
 import type {
   ApplicationFeed,
@@ -37,13 +38,8 @@ import type {
 } from "~/server/db/schema";
 import type { ORPCContext } from "~/server/orpc/base";
 import type { FetchFeedsStatus } from "~/server/rss/fetchFeeds";
-import type {
-  BookmarkSyncChunk,
-  MixedContentChunk,
-} from "~/server/mixed-content/sync";
 import type { NavigationSnapshot } from "~/server/navigation/snapshot";
 import type { ContentStatusFilter } from "~/lib/content-status";
-import type { RssPublishedChunk } from "~/lib/rss";
 import {
   contentStatusFilterSchema,
   DEFAULT_CONTENT_STATUS_FILTER,
@@ -68,6 +64,7 @@ import {
 import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
 import { sortViewsByPlacement } from "~/lib/data/views/utils";
 import { prepareArrayChunks } from "~/lib/iterators";
+import { organizationInvalidationSummary } from "~/server/reconciliation/invalidation";
 import { buildUncategorizedView } from "~/server/api/utils/buildUncategorizedView";
 import {
   DEFAULT_VIEW_LAYOUT,
@@ -233,15 +230,7 @@ export type RevalidateViewChunk =
   | { type: "view-feeds"; viewId: number; feedIds: number[] }
   | { type: "error"; message: string; phase: string };
 
-type RouterPublishedChunk =
-  | { source: "initial"; chunk: GetByViewChunk }
-  | { source: "revalidate"; chunk: RevalidateViewChunk }
-  | { source: "content-status"; chunk: GetItemsByContentStatusChunk }
-  | { source: "feed"; chunk: GetItemsByFeedChunk }
-  | { source: "category"; chunk: GetItemsByCategoryIdChunk }
-  | { source: "bookmark"; chunk: BookmarkSyncChunk }
-  | { source: "mixed"; chunk: MixedContentChunk }
-  | { source: "rss"; chunk: RssPublishedChunk };
+type RouterPublishedChunk = PublishedChunk;
 
 type ChannelSubscription = {
   channel: string;
@@ -1483,6 +1472,7 @@ export const requestImportedData = protectedProcedure
     await publisher.publish(channel, {
       source: "initial",
       chunk: { type: "initial-data-complete" },
+      invalidation: organizationInvalidationSummary(),
     });
 
     // Step 5: Run fetch and insert for fresh RSS items - ONLY for newly imported feeds
@@ -2115,6 +2105,7 @@ export const streamingImport = protectedProcedure
     await publisher.publish(channel, {
       source: "initial",
       chunk: { type: "initial-data-complete" },
+      invalidation: organizationInvalidationSummary(),
     });
 
     return { status: "completed" };

--- a/apps/app/src/server/api/routers/viewFeedsRouter.ts
+++ b/apps/app/src/server/api/routers/viewFeedsRouter.ts
@@ -8,6 +8,10 @@ import {
 import { protectedProcedure } from "~/server/orpc/base";
 import { viewFeeds, views } from "~/server/db/schema";
 import { boundedNumberIdsSchema } from "~/lib/schemas/bulk";
+import {
+  organizationInvalidationSummary,
+  publishReconciliationInvalidation,
+} from "~/server/reconciliation/invalidation";
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {
   const userViews = await context.db
@@ -56,6 +60,10 @@ export const assignToView = protectedProcedure
         })
         .onConflictDoNothing();
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const removeFromView = protectedProcedure
@@ -91,6 +99,10 @@ export const removeFromView = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const bulkAssignToView = protectedProcedure
@@ -131,6 +143,10 @@ export const bulkAssignToView = protectedProcedure
         )
         .onConflictDoNothing();
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });
 
 export const bulkRemoveFromView = protectedProcedure
@@ -170,4 +186,8 @@ export const bulkRemoveFromView = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
   });

--- a/apps/app/src/server/api/routers/viewRouter.ts
+++ b/apps/app/src/server/api/routers/viewRouter.ts
@@ -25,11 +25,15 @@ import {
   deduplicateByLastValue,
   MAX_BULK_MUTATION_ITEMS,
 } from "~/lib/schemas/bulk";
+import {
+  organizationInvalidationSummary,
+  publishReconciliationInvalidation,
+} from "~/server/reconciliation/invalidation";
 
 export const create = protectedProcedure
   .input(createViewSchema)
   .handler(async ({ context, input }) => {
-    return await context.db.transaction(async (tx) => {
+    const result = await context.db.transaction(async (tx) => {
       const [categoriesOwned, feedsOwned] = await Promise.all([
         verifyContentCategoriesOwnedByUser({
           categoryIds: input.categoryIds ?? [],
@@ -103,12 +107,19 @@ export const create = protectedProcedure
 
       return view;
     });
+    if (result) {
+      await publishReconciliationInvalidation(
+        context.user.id,
+        organizationInvalidationSummary(),
+      );
+    }
+    return result;
   });
 
 export const update = protectedProcedure
   .input(updateViewSchema)
   .handler(async ({ context, input }) => {
-    return context.db.transaction(async (tx) => {
+    const result = await context.db.transaction(async (tx) => {
       const [categoriesOwned, feedsOwned] = await Promise.all([
         verifyContentCategoriesOwnedByUser({
           categoryIds: input.categoryIds,
@@ -230,6 +241,13 @@ export const update = protectedProcedure
         viewSections: viewSectionSchema.array().parse(updatedSections),
       } satisfies ApplicationView;
     });
+    if (result) {
+      await publishReconciliationInvalidation(
+        context.user.id,
+        organizationInvalidationSummary(),
+      );
+    }
+    return result;
   });
 
 export const updatePlacement = protectedProcedure
@@ -270,14 +288,25 @@ export const updatePlacement = protectedProcedure
           ),
         );
     });
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary({
+        scopes: { type: "known", selectors: [] },
+      }),
+    );
   });
 
 export const deleteView = protectedProcedure
   .input(deleteViewSchema)
   .handler(async ({ context, input }) => {
-    return await context.db
+    const result = await context.db
       .delete(views)
       .where(and(eq(views.id, input.id), eq(views.userId, context.user.id)));
+    await publishReconciliationInvalidation(
+      context.user.id,
+      organizationInvalidationSummary(),
+    );
+    return result;
   });
 
 export const getAll = protectedProcedure.handler(async ({ context }) => {

--- a/apps/app/src/server/mixed-content/sync.ts
+++ b/apps/app/src/server/mixed-content/sync.ts
@@ -5,8 +5,15 @@ import type {
   MixedContentScope,
 } from "./projection";
 import type { db as defaultDatabase } from "~/server/db";
-import type { ContentStatusFilter } from "~/lib/content-status";
+import type {
+  ContentStatusFilter,
+  ContentStatusKey,
+} from "~/lib/content-status";
 import type { BookmarkSyncManifestEntry } from "~/lib/data/bookmarks/manifest";
+import type {
+  BookmarkInvalidationState,
+  ReconciliationInvalidationSummary,
+} from "~/lib/reconciliation";
 import {
   BOOKMARK_SYNC_PAGE_SIZE,
   BOOKMARK_SYNC_RESPONSE_BUDGET_BYTES,
@@ -15,6 +22,7 @@ import {
 } from "~/lib/data/bookmarks/manifest";
 import { getUserChannel } from "~/server/api/channels";
 import { publisher } from "~/server/api/publisher";
+import { buildBookmarkInvalidationSummary } from "~/lib/reconciliation";
 
 type MixedContentDatabase = typeof defaultDatabase;
 
@@ -125,12 +133,22 @@ export async function publishBookmarkUpsert(input: {
   database: MixedContentDatabase;
   userId: string;
   bookmarkId: string;
+  previousBookmark?: BookmarkInvalidationState | null;
+  contentStatusKeys?: ContentStatusKey[];
+  invalidation?: ReconciliationInvalidationSummary;
 }) {
   const bookmark = await loadApplicationBookmark(input);
   if (!bookmark) return null;
   await publisher.publish(getUserChannel(input.userId), {
     source: "bookmark",
     chunk: { type: "bookmark-upsert", bookmark },
+    invalidation:
+      input.invalidation ??
+      buildBookmarkInvalidationSummary({
+        before: input.previousBookmark,
+        after: bookmark,
+        contentStatusKeys: input.contentStatusKeys,
+      }),
   });
   return bookmark;
 }
@@ -138,7 +156,13 @@ export async function publishBookmarkUpsert(input: {
 export async function publishBookmarkUpsertBatch(input: {
   userId: string;
   bookmarks: ApplicationBookmark[];
+  previousBookmarks?: BookmarkInvalidationState[];
+  contentStatusKeys?: ContentStatusKey[];
 }) {
+  const invalidation = buildBookmarkInvalidationSummary({
+    states: [...(input.previousBookmarks ?? []), ...input.bookmarks],
+    contentStatusKeys: input.contentStatusKeys,
+  });
   for (let index = 0; index < input.bookmarks.length; index += 50) {
     // Each event is bounded so publisher and SSE buffers cannot accumulate a
     // single library-sized payload.
@@ -149,6 +173,7 @@ export async function publishBookmarkUpsertBatch(input: {
         type: "bookmark-upsert-batch",
         bookmarks: input.bookmarks.slice(index, index + 50),
       },
+      invalidation: index === 0 ? invalidation : undefined,
     });
   }
 }
@@ -157,6 +182,8 @@ export async function publishBookmarkDeletion(input: {
   userId: string;
   id: string;
   canonicalUrl: string;
+  bookmark?: BookmarkInvalidationState;
+  invalidation?: ReconciliationInvalidationSummary | null;
 }) {
   await publisher.publish(getUserChannel(input.userId), {
     source: "bookmark",
@@ -165,5 +192,18 @@ export async function publishBookmarkDeletion(input: {
       id: input.id,
       canonicalUrl: input.canonicalUrl,
     },
+    ...(input.invalidation === null
+      ? {}
+      : {
+          invalidation:
+            input.invalidation ??
+            (input.bookmark
+              ? buildBookmarkInvalidationSummary({ before: input.bookmark })
+              : {
+                  type: "reconciliation-invalidation" as const,
+                  domains: ["navigation" as const],
+                  scopeImpact: { type: "unknown" as const },
+                }),
+        }),
   });
 }

--- a/apps/app/src/server/reconciliation/invalidation.ts
+++ b/apps/app/src/server/reconciliation/invalidation.ts
@@ -1,0 +1,38 @@
+import type { ReconciliationInvalidationSummary } from "~/lib/reconciliation";
+import { getUserChannel } from "~/server/api/channels";
+import { publisher } from "~/server/api/publisher";
+
+export function publishReconciliationInvalidation(
+  userId: string,
+  summary: ReconciliationInvalidationSummary,
+) {
+  return publisher.publish(getUserChannel(userId), {
+    source: "invalidation",
+    chunk: summary,
+  });
+}
+
+export function organizationInvalidationSummary(
+  input: {
+    scopes?: ReconciliationInvalidationSummary["scopeImpact"];
+  } = {},
+): ReconciliationInvalidationSummary {
+  return {
+    type: "reconciliation-invalidation",
+    domains: ["organization", "navigation"],
+    scopeImpact: input.scopes ?? {
+      type: "known",
+      selectors: [
+        {
+          type: "all-retained",
+          contentStatusKeys: [
+            "inbox:unread",
+            "inbox:archived",
+            "saved:unread",
+            "saved:archived",
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/apps/app/tests/unit/bookmarks/extension-route.test.ts
+++ b/apps/app/tests/unit/bookmarks/extension-route.test.ts
@@ -390,11 +390,17 @@ describe("extension Bookmark HTTP contract", () => {
         bookmarkId: "bookmark-one",
       }),
     );
-    expect(deps.publish).toHaveBeenCalledWith({
-      userId: "user-one",
-      id: "bookmark-one",
-      canonicalUrl: "https://example.com/article",
-    });
+    expect(deps.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-one",
+        id: "bookmark-one",
+        canonicalUrl: "https://example.com/article",
+        invalidation: expect.objectContaining({
+          type: "reconciliation-invalidation",
+          domains: ["organization", "navigation"],
+        }),
+      }),
+    );
   });
 
   it("applies the request ceiling to organization and removal", async () => {

--- a/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
+++ b/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
@@ -81,7 +81,7 @@ beforeEach(() => {
 });
 
 describe("connected Feed item action revalidation", () => {
-  it("leaves navigation snapshot refresh to the subscription echo", async () => {
+  it("leaves repair to the committed server invalidation", async () => {
     const actions = useFeedItemActions("saved-item");
 
     expect(actions.toggleRead()).toBe(true);
@@ -91,20 +91,21 @@ describe("connected Feed item action revalidation", () => {
 
     expect(
       mocks.refreshNavigationAfterFeedItemChangeIfNeeded,
-    ).toHaveBeenCalledOnce();
+    ).not.toHaveBeenCalled();
     expect(mocks.refreshNavigationSnapshotSafely).not.toHaveBeenCalled();
   });
 
-  it("refreshes directly once when the subscription is disconnected", async () => {
+  it("waits for full reconnect recovery when the subscription is disconnected", async () => {
     mocks.isDataSubscriptionConnected.mockReturnValue(false);
     const actions = useFeedItemActions("saved-item");
 
     expect(actions.toggleRead()).toBe(true);
     await vi.waitFor(() =>
-      expect(mocks.refreshNavigationSnapshotSafely).toHaveBeenCalledOnce(),
+      expect(mocks.resolveOptimisticWatchedValue).toHaveBeenCalledOnce(),
     );
+    expect(mocks.refreshNavigationSnapshotSafely).not.toHaveBeenCalled();
     expect(
       mocks.refreshNavigationAfterFeedItemChangeIfNeeded,
-    ).toHaveBeenCalledOnce();
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -6,6 +6,7 @@ import type {
   ReconciliationRequestDescriptor,
   ReconciliationScopeTarget,
   ReconciliationStreamEvent,
+  ReconciliationTarget,
 } from "~/lib/reconciliation";
 import type { NavigationSnapshot } from "~/server/navigation/snapshot";
 import {
@@ -86,18 +87,67 @@ function completeEpoch(reconciliationId: string): ReconciliationStreamEvent[] {
   ];
 }
 
+function completeTargetedScope(
+  reconciliationId: string,
+): ReconciliationStreamEvent[] {
+  return [
+    {
+      reconciliationId,
+      chunk: { type: "active-first-page", page: PAGE },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "domain-complete",
+        domain: "active-scope",
+        target: ACTIVE_SCOPE,
+      },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "epoch-complete",
+        requiredDomains: ["active-scope"],
+      },
+    },
+  ];
+}
+
+function completeTargetedOrganization(
+  reconciliationId: string,
+): ReconciliationStreamEvent[] {
+  return [
+    {
+      reconciliationId,
+      chunk: { type: "organization-snapshot", snapshot: ORGANIZATION },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "domain-complete", domain: "organization" },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "epoch-complete",
+        requiredDomains: ["organization"],
+      },
+    },
+  ];
+}
+
 function harness(
   events: (
     request: ReconciliationRequestDescriptor,
   ) => ReconciliationStreamEvent[],
   applyLiveEvent?: (payload: string[]) =>
-    | ReconciliationScopeTarget[]
+    | ReconciliationTarget[]
     | {
-        repairTargets?: ReconciliationScopeTarget[];
-        dirtyTargets?: ReconciliationScopeTarget[];
+        repairTargets?: ReconciliationTarget[];
+        dirtyTargets?: ReconciliationTarget[];
         repairIntent?: ReconciliationRequestDescriptor["intent"];
       }
     | void,
+  options: { isVisible?: () => boolean; isOnline?: () => boolean } = {},
 ) {
   const requests: ReconciliationRequestDescriptor[] = [];
   const applications: string[] = [];
@@ -138,6 +188,8 @@ function harness(
       return applyLiveEvent?.(payload);
     },
     getCurrentSelection: () => currentSelection,
+    isVisible: options.isVisible,
+    isOnline: options.isOnline,
   });
   return {
     runtime,
@@ -360,5 +412,174 @@ describe("client reconciliation runtime", () => {
       type: "targeted",
       targets: [ACTIVE_SCOPE],
     });
+  });
+
+  it("retains usable data and retries only the failed target with capped scheduling", async () => {
+    vi.useFakeTimers();
+    let targetedAttempt = 0;
+    const test = harness(
+      (request) => {
+        if (request.intent.type === "full") {
+          return completeEpoch(request.reconciliationId);
+        }
+        targetedAttempt++;
+        return targetedAttempt === 1
+          ? [
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: {
+                  type: "domain-error",
+                  failure: {
+                    phase: "load-active-scope",
+                    domain: "active-scope",
+                    target: ACTIVE_SCOPE,
+                    message: "temporary failure",
+                  },
+                },
+              },
+            ]
+          : completeTargetedScope(request.reconciliationId);
+      },
+      () => ({
+        repairTargets: [ACTIVE_SCOPE],
+        repairIntent: { type: "targeted", targets: [ACTIVE_SCOPE] },
+      }),
+    );
+    test.setSelection(ACTIVE_SCOPE);
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.runtime.getState().trustedUpToDate).toBe(true);
+
+    test.runtime.receiveLiveEvent(["mutation"]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.requests).toHaveLength(2);
+    expect(test.runtime.getState().cacheUsableAt).not.toBeNull();
+    expect(test.runtime.getState().trustedUpToDate).toBe(false);
+    expect(test.runtime.getState().retryPending).toBe(true);
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(test.requests).toHaveLength(3);
+    expect(test.requests[2]?.intent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
+    expect(test.runtime.getState().trustedUpToDate).toBe(true);
+    expect(test.runtime.getState().retryPending).toBe(false);
+    test.runtime.stop();
+    vi.useRealTimers();
+  });
+
+  it("pauses recovery while hidden and coalesces refocus into one retry", async () => {
+    vi.useFakeTimers();
+    let visible = false;
+    const test = harness(
+      (request) =>
+        request.intent.type === "full"
+          ? [
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: {
+                  type: "domain-error",
+                  failure: {
+                    phase: "load-navigation",
+                    domain: "navigation",
+                    message: "offline",
+                  },
+                },
+              },
+            ]
+          : [],
+      undefined,
+      { isVisible: () => visible, isOnline: () => true },
+    );
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.requests).toHaveLength(1);
+    expect(test.runtime.getState().retryPending).toBe(true);
+    expect(test.runtime.getState().retryAt).toBeNull();
+
+    visible = true;
+    test.runtime.environmentChanged();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.requests).toHaveLength(2);
+    test.runtime.environmentChanged();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.requests).toHaveLength(2);
+    test.runtime.stop();
+    vi.useRealTimers();
+  });
+
+  it("does not let an unrelated successful repair cancel a failed target retry", async () => {
+    vi.useFakeTimers();
+    let scopeAttempts = 0;
+    const test = harness(
+      (request) => {
+        if (request.intent.type === "full") {
+          return completeEpoch(request.reconciliationId);
+        }
+        const target = request.intent.targets[0];
+        if (target?.type === "organization") {
+          return completeTargetedOrganization(request.reconciliationId);
+        }
+        scopeAttempts++;
+        return scopeAttempts === 1
+          ? [
+              {
+                reconciliationId: request.reconciliationId,
+                chunk: {
+                  type: "domain-error",
+                  failure: {
+                    phase: "load-active-scope",
+                    domain: "active-scope",
+                    target: ACTIVE_SCOPE,
+                    message: "temporary failure",
+                  },
+                },
+              },
+            ]
+          : completeTargetedScope(request.reconciliationId);
+      },
+      (payload) => {
+        const repairTargets: ReconciliationTarget[] = payload.includes(
+          "scope-mutation",
+        )
+          ? [ACTIVE_SCOPE]
+          : [{ type: "organization" }];
+        return {
+          repairTargets,
+          repairIntent: { type: "targeted", targets: repairTargets },
+        };
+      },
+    );
+    test.setSelection(ACTIVE_SCOPE);
+    hydrate(test.runtime);
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    test.runtime.receiveLiveEvent(["scope-mutation"]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.runtime.getState().retryPending).toBe(true);
+
+    test.runtime.receiveLiveEvent(["organization-mutation"]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.requests).toHaveLength(3);
+    expect(test.runtime.getState().retryPending).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(test.requests).toHaveLength(4);
+    expect(test.requests[3]?.intent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
+    expect(test.runtime.getState().retryPending).toBe(false);
+    test.runtime.stop();
+    vi.useRealTimers();
   });
 });

--- a/apps/app/tests/unit/reconciliation/invalidation.test.ts
+++ b/apps/app/tests/unit/reconciliation/invalidation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ReconciliationInvalidationMemberships,
+  ReconciliationScopeTarget,
+} from "~/lib/reconciliation";
+import {
+  buildBookmarkInvalidationSummary,
+  buildFeedInvalidationSummary,
+  expandInvalidationSummary,
+} from "~/lib/reconciliation";
+
+const memberships: ReconciliationInvalidationMemberships = {
+  views: [
+    { id: 10, categoryIds: [], feedIds: [7] },
+    { id: 11, categoryIds: [20], feedIds: [] },
+  ],
+  viewFeedIds: { 10: [7] },
+  feedCategories: [{ feedId: 7, categoryId: 20 }],
+};
+
+function target(
+  scope: ReconciliationScopeTarget["scope"],
+  saveStatus: "inbox" | "saved" = "inbox",
+  archiveStatus: "unread" | "archived" = "unread",
+): ReconciliationScopeTarget {
+  return { type: "scope", scope, contentStatus: { saveStatus, archiveStatus } };
+}
+
+describe("reconciliation invalidation summaries", () => {
+  it("expands Feed effects through Feed, View, and Tag memberships", () => {
+    const retainedScopes = [
+      target({ type: "feed", feedId: 7 }),
+      target({ type: "view", viewId: 10 }),
+      target({ type: "tag", tagId: 20 }),
+      target({ type: "view", viewId: 11 }, "saved"),
+    ];
+    const expanded = expandInvalidationSummary({
+      summary: buildFeedInvalidationSummary({
+        feedIds: [7],
+        contentStatusKeys: ["inbox:unread"],
+      }),
+      retainedScopes,
+      memberships,
+    });
+    expect(expanded.scopeImpactUnknown).toBe(false);
+    expect(expanded.scopes).toEqual(retainedScopes.slice(0, 3));
+  });
+
+  it("targets Bookmark status and View/Tag membership without Feed collision", () => {
+    const retainedScopes = [
+      target({ type: "view", viewId: 11 }, "saved"),
+      target({ type: "tag", tagId: 20 }, "saved"),
+      target({ type: "feed", feedId: 7 }, "saved"),
+      target({ type: "view", viewId: 10 }, "saved"),
+    ];
+    const expanded = expandInvalidationSummary({
+      summary: buildBookmarkInvalidationSummary({
+        after: {
+          isSaved: true,
+          isRead: false,
+          viewIds: [],
+          tagIds: [20],
+        },
+      }),
+      retainedScopes,
+      memberships,
+    });
+    expect(expanded.scopes).toEqual(retainedScopes.slice(0, 2));
+  });
+
+  it("keeps an explicitly unknown scope impact distinct", () => {
+    expect(
+      expandInvalidationSummary({
+        summary: {
+          type: "reconciliation-invalidation",
+          domains: ["organization", "navigation"],
+          scopeImpact: { type: "unknown" },
+        },
+        retainedScopes: [target({ type: "view", viewId: 10 })],
+        memberships,
+      }),
+    ).toEqual({ scopeImpactUnknown: true, scopes: [] });
+  });
+});

--- a/apps/app/tests/unit/reconciliation/reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation.test.ts
@@ -263,6 +263,12 @@ describe("reconciliation coordinator", () => {
     expect(harness.state.domains.organization.appliedAt).toBe(2);
     expect(harness.state.domains["active-scope"].appliedAt).toBe(3);
     expect(harness.state.domains.navigation.appliedAt).toBe(4);
+
+    harness.send({ type: "targets-dirtied", targets: [OTHER_SCOPE] });
+    expect(harness.state.trustedUpToDate).toBe(true);
+    expect(
+      harness.state.targets[getReconciliationTargetKey(OTHER_SCOPE)]?.status,
+    ).toBe("dirty");
   });
 
   it("preserves applied domains and withholds parity after partial failure", () => {
@@ -307,7 +313,7 @@ describe("reconciliation coordinator", () => {
     expect(harness.state.trustedUpToDate).toBe(false);
   });
 
-  it("rejects a stale target atomically and schedules one trailing full repair", () => {
+  it("rejects stale authority and schedules one trailing targeted repair", () => {
     const harness = coordinatorHarness();
     hydrateAll(harness.send);
     const request = startedRequest(
@@ -339,7 +345,10 @@ describe("reconciliation coordinator", () => {
     expect(
       harness.state.dirtyTargets[getReconciliationTargetKey(ACTIVE_SCOPE)],
     ).toBeDefined();
-    expect(harness.state.trailingIntent?.type).toBe("full");
+    expect(harness.state.trailingIntent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
 
     const trailing = harness.send({
       type: "request-settled",
@@ -347,8 +356,8 @@ describe("reconciliation coordinator", () => {
       at: 2,
     });
     expect(startedRequest(trailing).intent).toEqual({
-      type: "full",
-      selectedScope: ACTIVE_SCOPE,
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
     });
   });
 
@@ -473,6 +482,7 @@ describe("reconciliation coordinator", () => {
 
   it("marks an inactive target dirty without eagerly scheduling repair", () => {
     const harness = coordinatorHarness();
+    harness.send({ type: "active-scope-changed", target: ACTIVE_SCOPE });
 
     expect(
       harness.send({ type: "targets-dirtied", targets: [OTHER_SCOPE] }),
@@ -481,6 +491,7 @@ describe("reconciliation coordinator", () => {
     expect(
       harness.state.targets[getReconciliationTargetKey(OTHER_SCOPE)]?.status,
     ).toBe("dirty");
+    expect(harness.state.domains["active-scope"].status).toBe("unverified");
 
     const request = startedRequest(
       harness.send({


### PR DESCRIPTION
- publish semantic invalidation summaries for bookmark, feed-item, feed, View, and Tag mutations
- eagerly repair global and active targets while retaining inactive scopes as lazy dirty state
- retry failed targets with visible/online backoff and surface syncing or retrying through the existing Refresh button
- preserve cached content, optimistic updates, and open editor drafts during reconciliation