### PR TITLE
Move back to GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   changes:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       app: ${{ steps.affected.outputs.app }}
     steps:
@@ -36,7 +36,7 @@ jobs:
           fi
 
   checks:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,9 +83,28 @@ jobs:
             "$SERIAL_EXTENSION_VERSION"
 
   e2e:
+    name: e2e (${{ matrix.name }})
     needs: changes
     if: needs.changes.outputs.app == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: main
+            suite: main
+          - name: demo
+            suite: demo
+          - name: self-hosted 1/3
+            suite: self-hosted
+            shard: --shard=1/3
+            verify_cleanup: true
+          - name: self-hosted 2/3
+            suite: self-hosted
+            shard: --shard=2/3
+          - name: self-hosted 3/3
+            suite: self-hosted
+            shard: --shard=3/3
     steps:
       - uses: actions/checkout@v4
 
@@ -106,15 +125,17 @@ jobs:
           curl -sSfL https://get.tur.so/install.sh | bash
           echo "$HOME/.turso" >> "$GITHUB_PATH"
 
-      - name: Run app E2E tests
-        run: |
-          pnpm --filter @serial/app test:e2e
-          pnpm --filter @serial/app test:e2e:cleanup
+      - name: Run ${{ matrix.name }} E2E tests
+        run: pnpm --filter @serial/app test:e2e:${{ matrix.suite }} ${{ matrix.shard }}
+
+      - name: Verify E2E process cleanup
+        if: ${{ always() && matrix.verify_cleanup }}
+        run: pnpm --filter @serial/app test:e2e:cleanup
 
   gate:
     if: always()
     needs: [changes, checks, e2e]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Check required jobs
         env:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   affected:
     if: github.repository == 'megaflorasoftware/serial'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       app: ${{ steps.check.outputs.app }}
     steps:
@@ -53,7 +53,7 @@ jobs:
   build-and-push:
     needs: affected
     if: needs.affected.outputs.app == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy-www-edge-script.yml
+++ b/.github/workflows/deploy-www-edge-script.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   deploy:
     if: github.repository == 'megaflorasoftware/serial'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   affected:
     if: github.repository == 'megaflorasoftware/serial'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       www: ${{ steps.check.outputs.www }}
     steps:
@@ -52,7 +52,7 @@ jobs:
   build:
     needs: affected
     if: needs.affected.outputs.www == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +80,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   react-doctor:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/standard-site-sync.yml
+++ b/.github/workflows/standard-site-sync.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Standard.Site configuration
         id: configuration

--- a/apps/app/playwright.self-hosted.config.ts
+++ b/apps/app/playwright.self-hosted.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     {
       name: "self-hosted",
       testDir: "./tests/e2e/self-hosted",
-      workers: process.env.CI ? 1 : undefined,
+      workers: process.env.CI ? 2 : undefined,
       use: {
         ...baseConfig.use,
         ...devices["Desktop Chrome"],

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   envDir: "./tests",
   test: {
     include: ["tests/unit/**/*.test.ts"],
+    testTimeout: process.env.CI ? 15_000 : 5_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Move workflows to GitHub-hosted Ubuntu runners
- Split self-hosted E2E coverage across three shards
- Carry over the related test stability and cleanup settings