### PR TITLE
Restore root navigation position

### DIFF
--- a/apps/app/src/app/_app.index.tsx
+++ b/apps/app/src/app/_app.index.tsx
@@ -15,15 +15,13 @@ import { useShortcut } from "~/lib/hooks/useShortcut";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useHasInitialData } from "~/lib/data/store";
 import FeedLoading from "~/components/loading";
-import { useHomeScrollRestoration } from "~/lib/scroll";
+import { useRootScrollResetBeforePaint } from "~/lib/root-scroll-restoration";
 
 export const Route = createFileRoute("/_app/")({
   component: Home,
 });
 
 function Home() {
-  useHomeScrollRestoration();
-
   const views = useAtomValue(viewsAtom);
   const viewFilterId = useAtomValue(viewFilterIdAtom);
   const updateViewFilter = useUpdateViewFilter();
@@ -101,6 +99,7 @@ function Home() {
   });
 
   const hasInitialData = useHasInitialData();
+  useRootScrollResetBeforePaint(!hasInitialData);
 
   if (!hasInitialData) {
     return <FeedLoading />;

--- a/apps/app/src/components/CustomVideoDialog.tsx
+++ b/apps/app/src/components/CustomVideoDialog.tsx
@@ -7,7 +7,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { useDialogStore } from "~/components/feed/dialogStore";
-import { saveHomeScrollPosition } from "~/lib/scroll";
+import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
 
 function getYouTubeVideoIdFromUrl(url: string) {
   const match = new RegExp(
@@ -57,7 +57,7 @@ export function CustomVideoDialog() {
               className="w-full"
               onClick={() => {
                 if (pathname === "/") {
-                  saveHomeScrollPosition();
+                  captureRootScrollRestoration();
                 }
                 setVideoUrl("");
                 onOpenChange(false);

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -29,7 +29,7 @@ import { timeAgo } from "~/lib/utils";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useFeedItemActions } from "~/lib/hooks/useFeedItemActions";
 import { useShowShortcuts } from "~/lib/hooks/useShowShortcuts";
-import { saveHomeScrollPosition } from "~/lib/scroll";
+import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import {
   useDeleteBookmarkMutation,
@@ -666,7 +666,11 @@ function BookmarkItemDisplay({
           to={href}
           target={destination.external ? "_blank" : undefined}
           rel={destination.external ? "noopener noreferrer" : undefined}
-          onClick={destination.external ? undefined : saveHomeScrollPosition}
+          onClick={
+            destination.external
+              ? undefined
+              : () => captureRootScrollRestoration(bookmark.id)
+          }
           className={clsx(
             "flex h-full flex-1 flex-col rounded p-2 text-left",
             isSelected && "md:bg-muted",
@@ -713,7 +717,11 @@ function BookmarkItemDisplay({
         to={href}
         target={destination.external ? "_blank" : undefined}
         rel={destination.external ? "noopener noreferrer" : undefined}
-        onClick={destination.external ? undefined : saveHomeScrollPosition}
+        onClick={
+          destination.external
+            ? undefined
+            : () => captureRootScrollRestoration(bookmark.id)
+        }
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
@@ -808,7 +816,11 @@ function FeedItemDisplay({
         target={target}
         rel={rel}
         preload={shouldOpenInSerial ? "intent" : undefined}
-        onClick={shouldOpenInSerial ? saveHomeScrollPosition : undefined}
+        onClick={
+          shouldOpenInSerial
+            ? () => captureRootScrollRestoration(contentId)
+            : undefined
+        }
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
@@ -921,7 +933,11 @@ function FeedGridItemDisplay({
         target={target}
         rel={rel}
         preload={shouldOpenInSerial ? "intent" : undefined}
-        onClick={shouldOpenInSerial ? saveHomeScrollPosition : undefined}
+        onClick={
+          shouldOpenInSerial
+            ? () => captureRootScrollRestoration(contentId)
+            : undefined
+        }
         className={clsx(
           "flex h-full flex-1 flex-col rounded p-2 text-left",
           isSelected && "md:bg-muted",

--- a/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
+++ b/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { CheckIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState, FeedEmptyState } from "./EmptyStates";
@@ -47,6 +47,7 @@ import { useValidateViewItems } from "~/lib/hooks/useValidateViewItems";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
 import { showUndoToast } from "~/lib/undo";
 import { VIEW_LAYOUT } from "~/server/db/constants";
+import { useRootItemScrollRestoration } from "~/lib/root-scroll-restoration";
 
 function getNextAvailableItemAfterSection(
   sectionIndex: number,
@@ -354,6 +355,24 @@ export function RenderViewItems() {
     visibleFilteredFeedItemsOrder,
   );
   const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
+  const selectedItemId = useAtomValue(selectedItemIdAtom);
+  const setSelectedItemId = useSetAtom(selectedItemIdAtom);
+  const navigationItems = useMemo(
+    () => fullComputedSections.flatMap((section) => section.items),
+    [fullComputedSections],
+  );
+  const rootListReady =
+    hasInitialData &&
+    (navigationItems.length > 0 ||
+      (hasFetchedFeeds &&
+        hasFetchedFeedCategories &&
+        (feedItemsLastFetchedAt !== null || feeds.length === 0)));
+  useRootItemScrollRestoration({
+    activeItemIds: navigationItems,
+    selectedItemId,
+    setSelectedItemId,
+    ready: rootListReady,
+  });
   const contentStatusKey = buildContentStatusKey(contentStatusFilter);
   const viewListKey = `view-${currentView?.id ?? "none"}-${contentStatusKey}`;
   const contentStatusContextKey = `${viewListKey}-feed-${feedFilter}-tag-${categoryFilter}`;

--- a/apps/app/src/components/feed/view-lists/useViewListScroll.tsx
+++ b/apps/app/src/components/feed/view-lists/useViewListScroll.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useInfiniteScroll } from "~/lib/hooks/useInfiniteScroll";
 import { useItemWindow } from "~/lib/hooks/useItemWindow";
 import { useLoadMoreItems } from "~/lib/hooks/useLoadMoreItems";
-import { updateCurrentHomeRenderedItemCount } from "~/lib/scroll";
+import { updateCurrentRootRenderedItemCount } from "~/lib/root-scroll-restoration";
 
 type PendingServerExpansion = {
   id: number;
@@ -25,7 +25,7 @@ export function useViewListScroll(itemIds: string[]) {
   const hasUserScrolledCurrentList = scrolledListKey === currentListKey;
 
   useEffect(() => {
-    updateCurrentHomeRenderedItemCount(currentListKey, renderCount);
+    updateCurrentRootRenderedItemCount(currentListKey, renderCount);
   }, [currentListKey, renderCount]);
 
   useEffect(() => {

--- a/apps/app/src/lib/article-block-scroll.ts
+++ b/apps/app/src/lib/article-block-scroll.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { getScrollContainer } from "~/lib/scroll";
+
+export const ARTICLE_BLOCK_SCROLL = {
+  mediaViewportPosition: 1 / 2,
+  textViewportPosition: 1 / 6,
+} as const;
+
+function isMediaBlock(element: HTMLElement) {
+  return (
+    element.tagName === "IMG" ||
+    element.tagName === "FIGURE" ||
+    !!element.querySelector("img")
+  );
+}
+
+export function getArticleBlockTargetScrollTop(
+  element: HTMLElement,
+  container: HTMLElement = getScrollContainer(),
+) {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  const elementOffset = isMediaBlock(element) ? elementRect.height / 2 : 0;
+  const viewportPosition = isMediaBlock(element)
+    ? ARTICLE_BLOCK_SCROLL.mediaViewportPosition
+    : ARTICLE_BLOCK_SCROLL.textViewportPosition;
+
+  return (
+    container.scrollTop +
+    (elementRect.top - containerRect.top) -
+    containerRect.height * viewportPosition +
+    elementOffset
+  );
+}
+
+export function scrollArticleBlockToTarget(
+  element: HTMLElement,
+  behavior: ScrollBehavior,
+  container: HTMLElement = getScrollContainer(),
+) {
+  container.scrollTo({
+    top: getArticleBlockTargetScrollTop(element, container),
+    behavior,
+  });
+}
+
+export function setArticleRestorationVisibility(
+  element: HTMLElement,
+  visible: boolean,
+) {
+  element.style.visibility = visible ? "" : "hidden";
+}

--- a/apps/app/src/lib/hooks/useArticleNavigation.ts
+++ b/apps/app/src/lib/hooks/useArticleNavigation.ts
@@ -10,11 +10,14 @@ import {
   SHORTCUT_KEYS,
 } from "~/lib/constants/shortcuts";
 import { getScrollContainer } from "~/lib/scroll";
+import {
+  getArticleBlockTargetScrollTop,
+  scrollArticleBlockToTarget,
+} from "~/lib/article-block-scroll";
 
 export const articleSelectedElementAtom = atom<HTMLElement | null>(null);
 
 const SCROLL_DURATION_MS = 300;
-const TARGET_VIEWPORT_POSITION = 1 / 3;
 const SELECTABLE_TAGS = new Set([
   "P",
   "H1",
@@ -109,8 +112,6 @@ export function isElementInViewport(element: Element): boolean {
 export function getClosestVisibleElement(elements: HTMLElement[]): number {
   const container = getScrollContainer();
   const containerRect = container.getBoundingClientRect();
-  const viewportTarget =
-    containerRect.top + containerRect.height * TARGET_VIEWPORT_POSITION;
   let closestIndex = -1;
   let closestDistance = Infinity;
 
@@ -119,8 +120,10 @@ export function getClosestVisibleElement(elements: HTMLElement[]): number {
     if (rect.bottom < containerRect.top || rect.top > containerRect.bottom)
       continue;
 
-    const elementCenter = rect.top + rect.height / 2;
-    const distance = Math.abs(elementCenter - viewportTarget);
+    const distance = Math.abs(
+      getArticleBlockTargetScrollTop(elements[i]!, container) -
+        container.scrollTop,
+    );
 
     if (distance < closestDistance) {
       closestDistance = distance;
@@ -186,30 +189,14 @@ export function useArticleNavigation(
 
   const scrollToElement = useCallback(
     (element: HTMLElement, forceInstant = false) => {
-      const container = getScrollContainer();
-      const containerRect = container.getBoundingClientRect();
-      const rect = element.getBoundingClientRect();
-      const hasImage =
-        element.tagName === "IMG" ||
-        element.tagName === "FIGURE" ||
-        !!element.querySelector("img");
-      const targetPosition = hasImage
-        ? containerRect.height / 2
-        : containerRect.height * TARGET_VIEWPORT_POSITION;
-      const scrollTop =
-        container.scrollTop +
-        (rect.top - containerRect.top) -
-        targetPosition +
-        rect.height / 2;
-
       const now = performance.now();
       const isRapid = now - lastNavTimeRef.current < SCROLL_DURATION_MS;
       lastNavTimeRef.current = now;
 
-      container.scrollTo({
-        top: scrollTop,
-        behavior: forceInstant || isRapid ? "instant" : "smooth",
-      });
+      scrollArticleBlockToTarget(
+        element,
+        forceInstant || isRapid ? "instant" : "smooth",
+      );
     },
     [],
   );

--- a/apps/app/src/lib/hooks/useContentItemActions.ts
+++ b/apps/app/src/lib/hooks/useContentItemActions.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { useFeedItemActions } from "./useFeedItemActions";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { useUpdateBookmarkStateMutation } from "~/lib/data/bookmarks/mutations";
-import { saveHomeScrollPosition } from "~/lib/scroll";
+import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
 import { contentDestination } from "~/lib/data/content-items/resolver";
 
 export function useContentItemActions(itemId: string) {
@@ -46,12 +46,12 @@ export function useContentItemActions(itemId: string) {
       entity: bookmark,
     });
     if (!destination.external) {
-      saveHomeScrollPosition();
+      captureRootScrollRestoration(itemId);
       void router.navigate({ to: destination.href });
       return;
     }
     window.open(destination.href, "_blank", "noopener,noreferrer");
-  }, [bookmark, feedItemActions, router]);
+  }, [bookmark, feedItemActions, itemId, router]);
 
   const openOriginal = useCallback(() => {
     if (!bookmark) return feedItemActions.openOriginal();

--- a/apps/app/src/lib/hooks/useFeedItemActions.ts
+++ b/apps/app/src/lib/hooks/useFeedItemActions.ts
@@ -15,7 +15,7 @@ import {
 } from "../data/feed-items/mutations";
 import { refreshNavigationAfterFeedItemChangeIfNeeded } from "../data/navigation/refreshOnLocalTransition";
 import { useFeeds as useFeedsArray } from "../data/feeds/store";
-import { saveHomeScrollPosition } from "~/lib/scroll";
+import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
 import { getDataSubscriptionClientId } from "~/lib/data/clientChannel";
 import { refreshNavigationSnapshotSafely } from "~/lib/data/navigation/store";
 import { isDataSubscriptionConnected } from "~/lib/data/subscriptionConnection";
@@ -118,12 +118,12 @@ export function useFeedItemActions(itemId: string) {
       feed?.openLocation === "serial" || !feed?.openLocation;
 
     if (shouldOpenInSerial) {
-      saveHomeScrollPosition();
+      captureRootScrollRestoration(itemId);
       router.navigate({ to: `/${itemDestination}/${item.id}` });
     } else {
       window.open(item.url, "_blank", "noopener noreferrer");
     }
-  }, [item, feeds, router]);
+  }, [item, feeds, itemId, router]);
 
   const openOriginal = useCallback(() => {
     if (!item?.url) return;

--- a/apps/app/src/lib/hooks/useFeedItemNavigation.ts
+++ b/apps/app/src/lib/hooks/useFeedItemNavigation.ts
@@ -31,6 +31,7 @@ import {
   useSaveToInstapaperMutation,
   useShowInstapaperAction,
 } from "~/lib/data/instapaper";
+import { getNextRootItemId } from "~/lib/root-scroll-restoration";
 
 interface SectionInfo {
   size: number;
@@ -198,9 +199,10 @@ export function useFeedItemNavigation(
       const selectItemForTiming = options.deferScroll
         ? selectItemAfterRender
         : selectItem;
-      const nextIndex = currentIndex + 1;
-      if (nextIndex < items.length) {
-        selectItemForTiming(items[nextIndex]!);
+      const currentItemId = items[currentIndex] ?? null;
+      const nextItemId = getNextRootItemId(items, currentItemId);
+      if (nextItemId) {
+        selectItemForTiming(nextItemId);
       } else if (currentIndex > 0) {
         selectItemForTiming(items[currentIndex - 1]!);
       } else {
@@ -212,9 +214,10 @@ export function useFeedItemNavigation(
 
   const selectItemAfterCurrentItemLeavesView = useCallback(
     (currentIndex: number) => {
-      const isCurrentItemLastVisibleItem = currentIndex === items.length - 1;
+      const currentItemId = items[currentIndex] ?? null;
+      const nextItemId = getNextRootItemId(items, currentItemId);
 
-      if (isCurrentItemLastVisibleItem) {
+      if (!nextItemId) {
         setSelectedItemId(null);
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
@@ -224,9 +227,9 @@ export function useFeedItemNavigation(
         return;
       }
 
-      selectNextItem(currentIndex, { deferScroll: true });
+      selectItemAfterRender(nextItemId);
     },
-    [items.length, selectNextItem, setSelectedItemId],
+    [items, selectItemAfterRender, setSelectedItemId],
   );
 
   useEffect(() => {

--- a/apps/app/src/lib/hooks/useItemWindow.ts
+++ b/apps/app/src/lib/hooks/useItemWindow.ts
@@ -8,12 +8,12 @@ import {
   getBoundedItemWindow,
   setRetainedEntityPins,
 } from "~/lib/data/page-retention";
-import { getSavedHomeRenderedItemCount } from "~/lib/scroll";
+import { getSavedRootRenderedItemCount } from "~/lib/root-scroll-restoration";
 import { ITEMS_PER_PAGE } from "~/server/api/constants";
 import { bookmarksStore } from "~/lib/data/bookmarks/store";
 
 function getInitialRenderCount(itemIds: string[], listKey: string) {
-  const savedRenderedItemCount = getSavedHomeRenderedItemCount(listKey);
+  const savedRenderedItemCount = getSavedRootRenderedItemCount(listKey);
   const renderCount = savedRenderedItemCount ?? ITEMS_PER_PAGE;
 
   return Math.min(renderCount, itemIds.length || renderCount);
@@ -47,7 +47,7 @@ export function useItemWindow(itemIds: string[], listKey: string) {
     }
 
     const renderBudget =
-      getSavedHomeRenderedItemCount(listKey) ?? ITEMS_PER_PAGE;
+      getSavedRootRenderedItemCount(listKey) ?? ITEMS_PER_PAGE;
     setRenderCount((currentRenderCount) =>
       reconcileRenderCountForItems({
         currentRenderCount,

--- a/apps/app/src/lib/hooks/useRestoreArticleProgress.ts
+++ b/apps/app/src/lib/hooks/useRestoreArticleProgress.ts
@@ -4,8 +4,11 @@ import { useLayoutEffect, useRef } from "react";
 import { getElements } from "./useArticleNavigation";
 import { getShortcutKeys, SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { getScrollContainer } from "~/lib/scroll";
+import {
+  scrollArticleBlockToTarget,
+  setArticleRestorationVisibility,
+} from "~/lib/article-block-scroll";
 
-const TARGET_VIEWPORT_POSITION = 1 / 3;
 const READER_SCROLL_KEYS = new Set([
   ...getShortcutKeys(SHORTCUT_KEYS.ARROW_UP),
   ...getShortcutKeys(SHORTCUT_KEYS.ARROW_DOWN),
@@ -35,6 +38,7 @@ export function useRestoreArticleProgress({
     const container = getScrollContainer();
     const markUserInteraction = () => {
       hasUserInteractedRef.current = true;
+      if (articleElement) setArticleRestorationVisibility(articleElement, true);
     };
     const handleKeydown = (event: KeyboardEvent) => {
       if (READER_SCROLL_KEYS.has(event.key)) markUserInteraction();
@@ -55,20 +59,33 @@ export function useRestoreArticleProgress({
       container.removeEventListener("touchstart", markUserInteraction);
       window.removeEventListener("keydown", handleKeydown);
     };
-  }, [contentId]);
+  }, [articleElement, contentId]);
 
   useLayoutEffect(() => {
+    if (!articleElement) {
+      return;
+    }
     if (
-      !ready ||
-      !articleElement ||
-      progress === undefined ||
       restoredContentIdRef.current === contentId ||
       hasUserInteractedRef.current
     ) {
+      setArticleRestorationVisibility(articleElement, true);
       return;
     }
+
+    setArticleRestorationVisibility(articleElement, false);
+    if (!ready || progress === undefined) {
+      return () => {
+        setArticleRestorationVisibility(articleElement, true);
+      };
+    }
+
     const savedProgress = progress;
     const contentElement = articleElement;
+
+    function revealContent() {
+      setArticleRestorationVisibility(contentElement, true);
+    }
 
     let firstFrame = 0;
     let secondFrame = 0;
@@ -94,6 +111,7 @@ export function useRestoreArticleProgress({
         restoredContentIdRef.current = contentId;
         observer.disconnect();
         getScrollContainer().scrollTo({ top: 0, behavior: "instant" });
+        revealContent();
         return;
       }
 
@@ -112,19 +130,12 @@ export function useRestoreArticleProgress({
 
           restoredContentIdRef.current = contentId;
           observer.disconnect();
-          const container = getScrollContainer();
           const element =
             renderedElements[
               Math.min(savedProgress, renderedElements.length - 1)
             ]!;
-          const containerRect = container.getBoundingClientRect();
-          const elementRect = element.getBoundingClientRect();
-          const scrollTop =
-            container.scrollTop +
-            (elementRect.top - containerRect.top) -
-            containerRect.height * TARGET_VIEWPORT_POSITION +
-            elementRect.height / 2;
-          container.scrollTo({ top: scrollTop, behavior: "instant" });
+          scrollArticleBlockToTarget(element, "instant");
+          revealContent();
         });
       });
     }
@@ -136,6 +147,7 @@ export function useRestoreArticleProgress({
       observer.disconnect();
       cancelAnimationFrame(firstFrame);
       cancelAnimationFrame(secondFrame);
+      revealContent();
     };
   }, [articleElement, contentId, progress, ready]);
 }

--- a/apps/app/src/lib/hooks/useScrollToFeedItem.ts
+++ b/apps/app/src/lib/hooks/useScrollToFeedItem.ts
@@ -26,11 +26,11 @@ export function getFirstRenderedFeedItemId() {
   );
 }
 
-function scrollFeedItemElementToTarget(
+export function scrollRootItemToTarget(
   element: Element,
   behavior: ScrollBehavior,
+  container: HTMLElement = getScrollContainer(),
 ) {
-  const container = getScrollContainer();
   const containerRect = container.getBoundingClientRect();
   const rect = element.getBoundingClientRect();
   const targetPosition =
@@ -57,7 +57,7 @@ export function useScrollToFeedItem() {
     lastScrollTimeRef.current = now;
 
     const behavior = forceInstant || isRapid ? "instant" : "smooth";
-    scrollFeedItemElementToTarget(element, behavior);
+    scrollRootItemToTarget(element, behavior);
     return true;
   }, []);
 }

--- a/apps/app/src/lib/root-scroll-restoration.ts
+++ b/apps/app/src/lib/root-scroll-restoration.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  getFeedItemElement,
+  scrollRootItemToTarget,
+} from "~/lib/hooks/useScrollToFeedItem";
+import { getScrollContainer } from "~/lib/scroll";
+
+type RootNavigationAnchor = {
+  selectedItemId: string | null;
+  successorItemId: string | null;
+};
+
+type CurrentRootNavigation = {
+  itemIds: readonly string[];
+  selectedItemId: string | null;
+};
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+let currentRootNavigation: CurrentRootNavigation = {
+  itemIds: [],
+  selectedItemId: null,
+};
+let pendingRootNavigationAnchor: RootNavigationAnchor | null = null;
+let savedRootRenderedItemCount: number | null = null;
+let savedRootRenderedItemListKey: string | null = null;
+let currentRootRenderedItemCount: number | null = null;
+let currentRootRenderedItemListKey: string | null = null;
+
+export function getNextRootItemId(
+  itemIds: readonly string[],
+  currentItemId: string | null,
+) {
+  if (!currentItemId) return null;
+
+  const currentIndex = itemIds.indexOf(currentItemId);
+  return currentIndex >= 0 ? (itemIds[currentIndex + 1] ?? null) : null;
+}
+
+export function resolveRootRestorationItemId({
+  activeItemIds,
+  selectedItemId,
+  successorItemId,
+}: {
+  activeItemIds: readonly string[];
+  selectedItemId: string | null;
+  successorItemId: string | null;
+}) {
+  const activeItemIdSet = new Set(activeItemIds);
+  if (selectedItemId && activeItemIdSet.has(selectedItemId)) {
+    return selectedItemId;
+  }
+  if (successorItemId && activeItemIdSet.has(successorItemId)) {
+    return successorItemId;
+  }
+  return null;
+}
+
+export function captureRootScrollRestoration(
+  departingItemId: string | null = currentRootNavigation.selectedItemId,
+) {
+  const { itemIds } = currentRootNavigation;
+  pendingRootNavigationAnchor = {
+    selectedItemId: departingItemId,
+    successorItemId: getNextRootItemId(itemIds, departingItemId),
+  };
+
+  if (
+    currentRootRenderedItemListKey !== null &&
+    currentRootRenderedItemCount !== null
+  ) {
+    savedRootRenderedItemListKey = currentRootRenderedItemListKey;
+    savedRootRenderedItemCount = currentRootRenderedItemCount;
+  }
+}
+
+export function updateCurrentRootRenderedItemCount(
+  listKey: string,
+  renderedItemCount: number,
+) {
+  currentRootRenderedItemListKey = listKey;
+  currentRootRenderedItemCount = renderedItemCount;
+}
+
+export function getSavedRootRenderedItemCount(listKey: string) {
+  if (savedRootRenderedItemListKey !== listKey) return null;
+
+  return savedRootRenderedItemCount;
+}
+
+export function useRootScrollResetBeforePaint(enabled: boolean) {
+  useIsomorphicLayoutEffect(() => {
+    if (!enabled) return;
+    getScrollContainer().scrollTo({ top: 0, behavior: "instant" });
+  }, [enabled]);
+}
+
+export function useRootItemScrollRestoration({
+  activeItemIds,
+  selectedItemId,
+  setSelectedItemId,
+  ready,
+}: {
+  activeItemIds: readonly string[];
+  selectedItemId: string | null;
+  setSelectedItemId: (itemId: string | null) => void;
+  ready: boolean;
+}) {
+  const needsRestorationRef = useRef(true);
+  const restorationAnchorRef = useRef<RootNavigationAnchor | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    currentRootNavigation = {
+      itemIds: activeItemIds,
+      selectedItemId,
+    };
+  }, [activeItemIds, selectedItemId]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!ready) return;
+
+    restorationAnchorRef.current ??= pendingRootNavigationAnchor ?? {
+      selectedItemId,
+      successorItemId: null,
+    };
+    const restorationAnchor = restorationAnchorRef.current;
+    const restorationItemId = resolveRootRestorationItemId({
+      activeItemIds,
+      ...restorationAnchor,
+    });
+    const selectedAnchorLeftList =
+      selectedItemId === restorationAnchor.selectedItemId &&
+      restorationItemId !== restorationAnchor.selectedItemId;
+    const shouldRestore = needsRestorationRef.current || selectedAnchorLeftList;
+
+    if (!shouldRestore) {
+      if (selectedItemId !== restorationAnchor.selectedItemId) {
+        restorationAnchorRef.current = null;
+      }
+      return;
+    }
+
+    if (selectedItemId !== restorationItemId) {
+      needsRestorationRef.current = true;
+      setSelectedItemId(restorationItemId);
+      return;
+    }
+
+    if (restorationItemId) {
+      const itemElement = getFeedItemElement(restorationItemId);
+      if (!itemElement) return;
+      scrollRootItemToTarget(itemElement, "instant");
+    } else {
+      getScrollContainer().scrollTo({ top: 0, behavior: "instant" });
+    }
+
+    pendingRootNavigationAnchor = null;
+    needsRestorationRef.current = false;
+    if (restorationItemId !== restorationAnchor.selectedItemId) {
+      restorationAnchorRef.current = null;
+    }
+  }, [activeItemIds, ready, selectedItemId, setSelectedItemId]);
+}

--- a/apps/app/src/lib/scroll.ts
+++ b/apps/app/src/lib/scroll.ts
@@ -1,15 +1,3 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
-
-const DEFAULT_HOME_SCROLL_POSITION = 0;
-let savedHomeScrollPosition: number | null = null;
-let savedHomeRenderedItemCount: number | null = null;
-let savedHomeRenderedItemListKey: string | null = null;
-let currentHomeRenderedItemCount: number | null = null;
-let currentHomeRenderedItemListKey: string | null = null;
-
-const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useLayoutEffect;
-
 /**
  * Returns the primary scroll container — the SidebarInset `<main>` element.
  * Falls back to `document.documentElement` when the sidebar layout isn't
@@ -20,71 +8,4 @@ export function getScrollContainer(): HTMLElement {
     document.querySelector<HTMLElement>('[data-slot="sidebar-inset"]') ??
     document.documentElement
   );
-}
-
-export function saveHomeScrollPosition() {
-  savedHomeScrollPosition = getScrollContainer().scrollTop;
-
-  if (
-    currentHomeRenderedItemListKey !== null &&
-    currentHomeRenderedItemCount !== null
-  ) {
-    savedHomeRenderedItemListKey = currentHomeRenderedItemListKey;
-    savedHomeRenderedItemCount = currentHomeRenderedItemCount;
-  }
-}
-
-export function updateCurrentHomeRenderedItemCount(
-  listKey: string,
-  renderedItemCount: number,
-) {
-  currentHomeRenderedItemListKey = listKey;
-  currentHomeRenderedItemCount = renderedItemCount;
-}
-
-export function getSavedHomeRenderedItemCount(listKey: string) {
-  if (savedHomeRenderedItemListKey !== listKey) return null;
-
-  return savedHomeRenderedItemCount;
-}
-
-function restoreHomeScrollPosition() {
-  const scrollTop = savedHomeScrollPosition ?? DEFAULT_HOME_SCROLL_POSITION;
-  getScrollContainer().scrollTo({ top: scrollTop, behavior: "instant" });
-}
-
-export function useHomeScrollRestoration() {
-  const canSaveScrollRef = useRef(false);
-
-  useIsomorphicLayoutEffect(() => {
-    canSaveScrollRef.current = false;
-    restoreHomeScrollPosition();
-
-    const restoreAnimationFrame = requestAnimationFrame(() => {
-      restoreHomeScrollPosition();
-      canSaveScrollRef.current = true;
-      saveHomeScrollPosition();
-    });
-
-    return () => {
-      cancelAnimationFrame(restoreAnimationFrame);
-      canSaveScrollRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const container = getScrollContainer();
-
-    const handleScroll = () => {
-      if (!canSaveScrollRef.current) return;
-
-      saveHomeScrollPosition();
-    };
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
 }

--- a/apps/app/src/router.tsx
+++ b/apps/app/src/router.tsx
@@ -6,7 +6,7 @@ import { getPublicConfigKey } from "./lib/public-config";
 export function getRouter() {
   const router = createRouter({
     routeTree,
-    scrollRestoration: true,
+    scrollRestoration: ({ location }) => location.pathname !== "/",
   });
 
   if (!router.isServer) {

--- a/apps/app/tests/e2e/fixtures/scroll-position.ts
+++ b/apps/app/tests/e2e/fixtures/scroll-position.ts
@@ -1,0 +1,5 @@
+export const SCROLL_POSITION_TOLERANCE_PX = 50;
+
+export function getScrollPositionDelta(actual: number, expected: number) {
+  return Math.abs(actual - expected);
+}

--- a/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
@@ -10,6 +10,10 @@ import {
   seedArticleData,
   setFeedItemContent,
 } from "../fixtures/seed-db";
+import {
+  getScrollPositionDelta,
+  SCROLL_POSITION_TOLERANCE_PX,
+} from "../fixtures/scroll-position";
 
 test.describe("article progress tracking", () => {
   let testEmail: string;
@@ -49,7 +53,9 @@ test.describe("article progress tracking", () => {
     const initialScrollTop = await scrollContainer.evaluate(
       (el) => el.scrollTop,
     );
-    expect(initialScrollTop).toBe(0);
+    expect(getScrollPositionDelta(initialScrollTop, 0)).toBeLessThanOrEqual(
+      SCROLL_POSITION_TOLERANCE_PX,
+    );
 
     // Scroll down using mouse wheel events to trigger progress tracking.
     // We hover over the scroll container first so the wheel events land on it.
@@ -78,8 +84,13 @@ test.describe("article progress tracking", () => {
     // Saving progress updates feedItem, but must not trigger entry restoration
     // and reposition a user who has already interacted with the article.
     await expect
-      .poll(() => scrollContainer.evaluate((el) => el.scrollTop))
-      .toBe(scrolledTop);
+      .poll(async () =>
+        getScrollPositionDelta(
+          await scrollContainer.evaluate((el) => el.scrollTop),
+          scrolledTop,
+        ),
+      )
+      .toBeLessThanOrEqual(SCROLL_POSITION_TOLERANCE_PX);
 
     // Reopening from the content list restores the saved reading location.
     await page.goto("/");
@@ -140,9 +151,12 @@ test.describe("article progress tracking", () => {
     await expect(page.getByText("Paragraph 1:")).toBeVisible();
     await page.waitForTimeout(1000);
 
-    expect(await scrollContainer.evaluate((element) => element.scrollTop)).toBe(
-      0,
-    );
+    expect(
+      getScrollPositionDelta(
+        await scrollContainer.evaluate((element) => element.scrollTop),
+        0,
+      ),
+    ).toBeLessThanOrEqual(SCROLL_POSITION_TOLERANCE_PX);
   });
 
   test("restores the reading position after Back then Forward", async ({
@@ -189,8 +203,13 @@ test.describe("article progress tracking", () => {
     await expect(page).toHaveURL(/\/read\//);
     await expect(page.getByText("Paragraph 1:")).toBeVisible();
     await expect
-      .poll(() => scrollContainer.evaluate((element) => element.scrollTop))
-      .toBe(previousArticleScroll);
+      .poll(async () =>
+        getScrollPositionDelta(
+          await scrollContainer.evaluate((element) => element.scrollTop),
+          previousArticleScroll,
+        ),
+      )
+      .toBeLessThanOrEqual(SCROLL_POSITION_TOLERANCE_PX);
   });
 
   test("navigates through content inside top-level div wrappers", async ({

--- a/apps/app/tests/e2e/self-hosted/item-actions.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/item-actions.spec.ts
@@ -66,6 +66,84 @@ test.describe("feed item actions", () => {
     await expect(readArticle).toBeVisible({ timeout: 10000 });
   });
 
+  test("restores the selected root item or its successor without animation", async ({
+    page,
+  }) => {
+    const { email, password, feedItemIds } = await seedMultipleArticleData(
+      SELF_HOSTED_TURSO_PORT,
+      SELF_HOSTED_APP_PORT,
+      20,
+    );
+    testEmail = email;
+
+    await signIn({ page, email, password });
+    const selectedItemId = feedItemIds[10]!;
+    const successorItemId = feedItemIds[11]!;
+    const selectedItem = page.locator(
+      `article[data-item-id="${selectedItemId}"]`,
+    );
+    await selectedItem.scrollIntoViewIfNeeded();
+    await selectedItem.getByRole("link").click();
+    await expect(page).toHaveURL(`/read/${selectedItemId}`);
+    await expect(
+      page.getByRole("heading", { name: "Test Article 11" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Archive" }).click();
+    await expect(page.getByRole("button", { name: "Unarchive" })).toBeVisible();
+    await page.getByRole("button", { name: "Home" }).click();
+    await expect(page).toHaveURL("/");
+    await expect(selectedItem).toHaveCount(0);
+
+    const successorItem = page.locator(
+      `article[data-item-id="${successorItemId}"]`,
+    );
+    await expect(successorItem.getByRole("link")).toHaveClass(/md:bg-muted/);
+    await expect
+      .poll(async () => {
+        const [containerBox, itemBox] = await Promise.all([
+          page.locator('[data-slot="sidebar-inset"]').boundingBox(),
+          successorItem.boundingBox(),
+        ]);
+        if (!containerBox || !itemBox) return Number.POSITIVE_INFINITY;
+
+        const itemCenter = itemBox.y + itemBox.height / 2;
+        const target = containerBox.y + containerBox.height / 3;
+        return Math.abs(itemCenter - target);
+      })
+      .toBeLessThan(2);
+  });
+
+  test("restores the root to the top when there is no selected item", async ({
+    page,
+  }) => {
+    const { email, password, feedItemIds } = await seedMultipleArticleData(
+      SELF_HOSTED_TURSO_PORT,
+      SELF_HOSTED_APP_PORT,
+      20,
+    );
+    testEmail = email;
+
+    await signIn({ page, email, password });
+    await page.goto(`/read/${feedItemIds[0]!}`);
+    await expect(
+      page.getByRole("heading", { name: "Test Article 1" }),
+    ).toBeVisible();
+    const scrollContainer = page.locator('[data-slot="sidebar-inset"]');
+    await scrollContainer.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    expect(
+      await scrollContainer.evaluate((element) => element.scrollTop),
+    ).toBeGreaterThan(0);
+
+    await page.getByRole("button", { name: "Home" }).click();
+    await expect(page).toHaveURL("/");
+    await expect
+      .poll(() => scrollContainer.evaluate((element) => element.scrollTop))
+      .toBe(0);
+  });
+
   test("does not show a copy-link action on feed items", async ({ page }) => {
     const { email, password, feedItemId } = await seedArticleData(
       SELF_HOSTED_TURSO_PORT,

--- a/apps/app/tests/e2e/self-hosted/item-actions.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/item-actions.spec.ts
@@ -4,6 +4,10 @@ import {
   SELF_HOSTED_TURSO_PORT,
 } from "../fixtures/ports";
 import {
+  getScrollPositionDelta,
+  SCROLL_POSITION_TOLERANCE_PX,
+} from "../fixtures/scroll-position";
+import {
   cleanupUser,
   seedArticleData,
   seedMultipleArticleData,
@@ -109,9 +113,9 @@ test.describe("feed item actions", () => {
 
         const itemCenter = itemBox.y + itemBox.height / 2;
         const target = containerBox.y + containerBox.height / 3;
-        return Math.abs(itemCenter - target);
+        return getScrollPositionDelta(itemCenter, target);
       })
-      .toBeLessThan(2);
+      .toBeLessThanOrEqual(SCROLL_POSITION_TOLERANCE_PX);
   });
 
   test("restores the root to the top when there is no selected item", async ({
@@ -140,8 +144,13 @@ test.describe("feed item actions", () => {
     await page.getByRole("button", { name: "Home" }).click();
     await expect(page).toHaveURL("/");
     await expect
-      .poll(() => scrollContainer.evaluate((element) => element.scrollTop))
-      .toBe(0);
+      .poll(async () =>
+        getScrollPositionDelta(
+          await scrollContainer.evaluate((element) => element.scrollTop),
+          0,
+        ),
+      )
+      .toBeLessThanOrEqual(SCROLL_POSITION_TOLERANCE_PX);
   });
 
   test("does not show a copy-link action on feed items", async ({ page }) => {

--- a/apps/app/tests/unit/navigation/article-block-scroll.test.ts
+++ b/apps/app/tests/unit/navigation/article-block-scroll.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  scrollArticleBlockToTarget,
+  setArticleRestorationVisibility,
+} from "~/lib/article-block-scroll";
+
+function rect(input: { top: number; height: number }): DOMRect {
+  return {
+    top: input.top,
+    bottom: input.top + input.height,
+    height: input.height,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: input.top,
+    toJSON: () => ({}),
+  };
+}
+
+function element(input: {
+  tagName: string;
+  top: number;
+  height: number;
+  containsImage?: boolean;
+}) {
+  return {
+    tagName: input.tagName,
+    style: { visibility: "" },
+    getBoundingClientRect: () => rect(input),
+    querySelector: () => (input.containsImage ? {} : null),
+  } as unknown as HTMLElement;
+}
+
+function container() {
+  const scrollTo = vi.fn();
+  return {
+    element: {
+      scrollTop: 300,
+      getBoundingClientRect: () => rect({ top: 40, height: 900 }),
+      scrollTo,
+    } as unknown as HTMLElement,
+    scrollTo,
+  };
+}
+
+describe("article block scroll placement", () => {
+  it("places a text block's top edge one-sixth down the viewport", () => {
+    const target = container();
+
+    scrollArticleBlockToTarget(
+      element({ tagName: "P", top: 640, height: 120 }),
+      "instant",
+      target.element,
+    );
+
+    expect(target.scrollTo).toHaveBeenCalledWith({
+      top: 750,
+      behavior: "instant",
+    });
+  });
+
+  it.each([
+    element({ tagName: "IMG", top: 640, height: 400 }),
+    element({ tagName: "FIGURE", top: 640, height: 400 }),
+    element({ tagName: "DIV", top: 640, height: 400, containsImage: true }),
+  ])("centers image blocks in the viewport", (block) => {
+    const target = container();
+
+    scrollArticleBlockToTarget(block, "instant", target.element);
+
+    expect(target.scrollTo).toHaveBeenCalledWith({
+      top: 650,
+      behavior: "instant",
+    });
+  });
+
+  it("keeps article content hidden until restoration completes", () => {
+    const block = element({ tagName: "P", top: 640, height: 120 });
+
+    setArticleRestorationVisibility(block, false);
+    expect(block.style.visibility).toBe("hidden");
+
+    setArticleRestorationVisibility(block, true);
+    expect(block.style.visibility).toBe("");
+  });
+});

--- a/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
+++ b/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
@@ -69,7 +69,9 @@ vi.mock("~/lib/data/clientChannel", () => ({
 vi.mock("~/lib/data/subscriptionConnection", () => ({
   isDataSubscriptionConnected: mocks.isDataSubscriptionConnected,
 }));
-vi.mock("~/lib/scroll", () => ({ saveHomeScrollPosition: vi.fn() }));
+vi.mock("~/lib/root-scroll-restoration", () => ({
+  captureRootScrollRestoration: vi.fn(),
+}));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/apps/app/tests/unit/navigation/root-scroll-restoration.test.ts
+++ b/apps/app/tests/unit/navigation/root-scroll-restoration.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getNextRootItemId,
+  resolveRootRestorationItemId,
+} from "~/lib/root-scroll-restoration";
+import { scrollRootItemToTarget } from "~/lib/hooks/useScrollToFeedItem";
+
+function rect(input: { top: number; height: number }): DOMRect {
+  return {
+    top: input.top,
+    bottom: input.top + input.height,
+    height: input.height,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: input.top,
+    toJSON: () => ({}),
+  };
+}
+
+describe("root scroll restoration", () => {
+  it("computes the immediate successor without falling backward", () => {
+    const items = ["first", "selected", "next"];
+
+    expect(getNextRootItemId(items, "selected")).toBe("next");
+    expect(getNextRootItemId(items, "next")).toBeNull();
+    expect(getNextRootItemId(items, "missing")).toBeNull();
+    expect(getNextRootItemId(items, null)).toBeNull();
+  });
+
+  it("restores the selection, then its captured successor, then the top", () => {
+    expect(
+      resolveRootRestorationItemId({
+        activeItemIds: ["selected", "next"],
+        selectedItemId: "selected",
+        successorItemId: "next",
+      }),
+    ).toBe("selected");
+
+    expect(
+      resolveRootRestorationItemId({
+        activeItemIds: ["first", "next"],
+        selectedItemId: "selected",
+        successorItemId: "next",
+      }),
+    ).toBe("next");
+
+    expect(
+      resolveRootRestorationItemId({
+        activeItemIds: ["first"],
+        selectedItemId: "selected",
+        successorItemId: "next",
+      }),
+    ).toBeNull();
+  });
+
+  it("places the selected item's center one-third down the viewport", () => {
+    const scrollTo = vi.fn();
+    const container = {
+      scrollTop: 300,
+      getBoundingClientRect: () => rect({ top: 40, height: 900 }),
+      scrollTo,
+    } as unknown as HTMLElement;
+    const item = {
+      getBoundingClientRect: () => rect({ top: 640, height: 120 }),
+    } as unknown as Element;
+
+    scrollRootItemToTarget(item, "instant", container);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 660,
+      behavior: "instant",
+    });
+  });
+});


### PR DESCRIPTION
- Restore the root list to its selected item, captured successor, or top before paint.
- Share canonical placement helpers across root navigation and article progress restoration.