### PR TITLE
Show posted dates for all items

### DIFF
--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -2,7 +2,6 @@
 
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
-import { useAtomValue } from "jotai";
 import {
   ArchiveIcon,
   BookmarkCheckIcon,
@@ -12,11 +11,8 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
-import type { ContentStatusFilter } from "~/lib/content-status";
-import { CONTENT_TYPE } from "~/lib/content/descriptor";
 import { KeyboardShortcutDisplay } from "~/components/ButtonWithShortcut";
 import { Button } from "~/components/ui/button";
-import { contentStatusFilterAtom } from "~/lib/data/atoms";
 import { useFeedItemsSetWatchLaterValueMutation } from "~/lib/data/feed-items/mutations";
 import { useFeeds as useFeedsArray } from "~/lib/data/feeds/store";
 import {
@@ -37,29 +33,13 @@ import {
 import { useDialogStore } from "~/components/feed/dialogStore";
 import { contentDestination } from "~/lib/data/content-items/resolver";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
-import {
-  contentStatusOrderDimension,
-  selectContentStatusOrderValue,
-} from "~/lib/content-status";
 
 export type ItemSize = "standard" | "large";
-type WatchedDatePrefix = "read" | "watched";
 
-function feedItemDatePresentation(
-  item: {
-    postedAt: Date;
-    isWatchLaterUpdatedAt?: Date | null;
-  },
-  contentStatus: ContentStatusFilter,
+export function getBookmarkPostedAt(
+  bookmark: Pick<ApplicationBookmark, "createdAt" | "publishedAt">,
 ) {
-  const orderDimension = contentStatusOrderDimension(contentStatus);
-  return {
-    displayDate:
-      orderDimension === "saved"
-        ? (item.isWatchLaterUpdatedAt ?? item.postedAt)
-        : item.postedAt,
-    shouldShowWatchedDate: orderDimension === "archived",
-  };
+  return bookmark.publishedAt ?? bookmark.createdAt;
 }
 
 // Typography components for consistent styling across layouts
@@ -100,35 +80,16 @@ interface ItemMetaProps {
   author: string | undefined;
   feedName: string | undefined;
   postedAt: Date;
-  watchedAt?: Date | null;
-  showWatchedDate?: boolean;
-  watchedDatePrefix?: WatchedDatePrefix;
   className?: string;
 }
 
-function ItemMeta({
+export function ItemMeta({
   author,
   feedName,
   postedAt,
-  watchedAt,
-  showWatchedDate = false,
-  watchedDatePrefix = "watched",
   className,
 }: ItemMetaProps) {
-  const shouldUseWatchedDate = showWatchedDate && !!watchedAt;
-  const primaryDate = shouldUseWatchedDate ? watchedAt : postedAt;
-  const watchedDateLabel = watchedDatePrefix === "read" ? "Read" : "Watched";
-  const primaryDateText = shouldUseWatchedDate
-    ? `${watchedDateLabel} ${timeAgo(primaryDate)}`
-    : timeAgo(primaryDate);
-  const postedDateText = shouldUseWatchedDate
-    ? `Posted ${timeAgo(postedAt)}`
-    : undefined;
-  const metadataParts = [
-    author || feedName,
-    primaryDateText,
-    postedDateText,
-  ].filter(Boolean);
+  const metadataParts = [author || feedName, timeAgo(postedAt)].filter(Boolean);
 
   return (
     <p
@@ -143,12 +104,6 @@ function ItemMeta({
 }
 
 // Thumbnail components for consistent styling across layouts
-
-function getWatchedDatePrefix(item: {
-  contentType: "text" | "video";
-}): WatchedDatePrefix {
-  return item.contentType === CONTENT_TYPE.TEXT ? "read" : "watched";
-}
 
 type ThumbnailType =
   "horizontal-video" | "vertical-video" | "article" | "icon" | "none";
@@ -639,18 +594,13 @@ function BookmarkItemDisplay({
   onSelect?: () => void;
   grid: boolean;
 }) {
-  const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
   const destination = contentDestination({
     entityKind: "bookmark",
     entity: bookmark,
   });
   const href = destination.href;
   const isLarge = size === "large";
-  const date = selectContentStatusOrderValue(contentStatusFilter, {
-    published: bookmark.publishedAt || bookmark.createdAt,
-    saved: bookmark.savedUpdatedAt,
-    archived: bookmark.readUpdatedAt,
-  });
+  const postedAt = getBookmarkPostedAt(bookmark);
 
   if (grid) {
     return (
@@ -685,7 +635,7 @@ function BookmarkItemDisplay({
               feedName={
                 bookmark.siteName ?? new URL(bookmark.sourceUrl).hostname
               }
-              postedAt={date}
+              postedAt={postedAt}
               className="pt-0.5"
             />
           </div>
@@ -742,7 +692,7 @@ function BookmarkItemDisplay({
           <ItemMeta
             author={bookmark.author ?? undefined}
             feedName={bookmark.siteName ?? new URL(bookmark.sourceUrl).hostname}
-            postedAt={date}
+            postedAt={postedAt}
           />
         </div>
       </Link>
@@ -771,7 +721,6 @@ function FeedItemDisplay({
   sectionItemType,
 }: ItemDisplayProps) {
   const feeds = useFeedsArray();
-  const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
   const item = useFeedItemValue(contentId);
 
   if (!item) return null;
@@ -792,11 +741,6 @@ function FeedItemDisplay({
   const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
 
   const isLarge = size === "large";
-  const { displayDate, shouldShowWatchedDate } = feedItemDatePresentation(
-    item,
-    contentStatusFilter,
-  );
-  const watchedDatePrefix = getWatchedDatePrefix(item);
 
   return (
     <article
@@ -841,10 +785,7 @@ function FeedItemDisplay({
               <ItemMeta
                 author={item.author}
                 feedName={feed?.name}
-                postedAt={displayDate}
-                watchedAt={item.isWatchedUpdatedAt}
-                showWatchedDate={shouldShowWatchedDate}
-                watchedDatePrefix={watchedDatePrefix}
+                postedAt={item.postedAt}
                 className="pt-1"
               />
             </div>
@@ -861,10 +802,7 @@ function FeedItemDisplay({
               <ItemMeta
                 author={item.author}
                 feedName={feed?.name}
-                postedAt={displayDate}
-                watchedAt={item.isWatchedUpdatedAt}
-                showWatchedDate={shouldShowWatchedDate}
-                watchedDatePrefix={watchedDatePrefix}
+                postedAt={item.postedAt}
               />
             </div>
           </>
@@ -896,7 +834,6 @@ function FeedGridItemDisplay({
   sectionItemType,
 }: GridItemDisplayProps) {
   const feeds = useFeedsArray();
-  const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
   const item = useFeedItemValue(contentId);
 
   if (!item) return null;
@@ -914,11 +851,6 @@ function FeedGridItemDisplay({
   const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
 
   const isLarge = size === "large";
-  const { displayDate, shouldShowWatchedDate } = feedItemDatePresentation(
-    item,
-    contentStatusFilter,
-  );
-  const watchedDatePrefix = getWatchedDatePrefix(item);
 
   return (
     <article
@@ -953,10 +885,7 @@ function FeedGridItemDisplay({
           <ItemMeta
             author={item.author}
             feedName={feed?.name}
-            postedAt={displayDate}
-            watchedAt={item.isWatchedUpdatedAt}
-            showWatchedDate={shouldShowWatchedDate}
-            watchedDatePrefix={watchedDatePrefix}
+            postedAt={item.postedAt}
             className="pt-0.5"
           />
         </div>

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -10,7 +10,7 @@ import {
   SendIcon,
   Trash2Icon,
 } from "lucide-react";
-import { getBookmarkPostedAt } from "./itemDate";
+import { getBookmarkAddedAt } from "./itemDate";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 import { KeyboardShortcutDisplay } from "~/components/ButtonWithShortcut";
 import { Button } from "~/components/ui/button";
@@ -595,7 +595,7 @@ function BookmarkItemDisplay({
   });
   const href = destination.href;
   const isLarge = size === "large";
-  const postedAt = getBookmarkPostedAt(bookmark);
+  const postedAt = getBookmarkAddedAt(bookmark);
 
   if (grid) {
     return (

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -10,6 +10,7 @@ import {
   SendIcon,
   Trash2Icon,
 } from "lucide-react";
+import { getBookmarkPostedAt } from "./itemDate";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 import { KeyboardShortcutDisplay } from "~/components/ButtonWithShortcut";
 import { Button } from "~/components/ui/button";
@@ -35,12 +36,6 @@ import { contentDestination } from "~/lib/data/content-items/resolver";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
 
 export type ItemSize = "standard" | "large";
-
-export function getBookmarkPostedAt(
-  bookmark: Pick<ApplicationBookmark, "createdAt" | "publishedAt">,
-) {
-  return bookmark.publishedAt ?? bookmark.createdAt;
-}
 
 // Typography components for consistent styling across layouts
 

--- a/apps/app/src/components/feed/view-lists/itemDate.ts
+++ b/apps/app/src/components/feed/view-lists/itemDate.ts
@@ -1,6 +1,6 @@
-export function getBookmarkPostedAt(bookmark: {
+export function getBookmarkAddedAt(bookmark: {
   createdAt: Date;
   publishedAt: Date | null;
 }) {
-  return bookmark.publishedAt ?? bookmark.createdAt;
+  return bookmark.createdAt;
 }

--- a/apps/app/src/components/feed/view-lists/itemDate.ts
+++ b/apps/app/src/components/feed/view-lists/itemDate.ts
@@ -1,0 +1,6 @@
+export function getBookmarkPostedAt(bookmark: {
+  createdAt: Date;
+  publishedAt: Date | null;
+}) {
+  return bookmark.publishedAt ?? bookmark.createdAt;
+}

--- a/apps/app/tests/unit/components/item-meta.test.ts
+++ b/apps/app/tests/unit/components/item-meta.test.ts
@@ -1,0 +1,39 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getBookmarkPostedAt,
+  ItemMeta,
+} from "~/components/feed/view-lists/ItemDisplay";
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+afterEach(() => vi.useRealTimers());
+
+describe("ItemMeta", () => {
+  it("shows one plain relative posted date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const markup = renderToStaticMarkup(
+      createElement(ItemMeta, {
+        author: "Ada Lovelace",
+        feedName: "Example Feed",
+        postedAt: new Date("2026-08-18T12:00:00.000Z"),
+      }),
+    );
+
+    expect(markup).toContain("Ada Lovelace • 1 day ago");
+    expect(markup).not.toMatch(/Posted|Read|Watched|Saved/);
+  });
+
+  it("uses a Bookmark publication date with a creation-date fallback", () => {
+    const createdAt = new Date("2026-08-17T12:00:00.000Z");
+    const publishedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    expect(getBookmarkPostedAt({ createdAt, publishedAt })).toBe(publishedAt);
+    expect(getBookmarkPostedAt({ createdAt, publishedAt: null })).toBe(
+      createdAt,
+    );
+  });
+});

--- a/apps/app/tests/unit/components/item-meta.test.ts
+++ b/apps/app/tests/unit/components/item-meta.test.ts
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ItemMeta } from "~/components/feed/view-lists/ItemDisplay";
-import { getBookmarkPostedAt } from "~/components/feed/view-lists/itemDate";
+import { getBookmarkAddedAt } from "~/components/feed/view-lists/itemDate";
 
 const NOW = new Date("2026-08-19T12:00:00.000Z");
 
@@ -25,13 +25,10 @@ describe("ItemMeta", () => {
     expect(markup).not.toMatch(/Posted|Read|Watched|Saved/);
   });
 
-  it("uses a Bookmark publication date with a creation-date fallback", () => {
+  it("uses a Bookmark creation date even when it has a publication date", () => {
     const createdAt = new Date("2026-08-17T12:00:00.000Z");
     const publishedAt = new Date("2026-08-18T12:00:00.000Z");
 
-    expect(getBookmarkPostedAt({ createdAt, publishedAt })).toBe(publishedAt);
-    expect(getBookmarkPostedAt({ createdAt, publishedAt: null })).toBe(
-      createdAt,
-    );
+    expect(getBookmarkAddedAt({ createdAt, publishedAt })).toBe(createdAt);
   });
 });

--- a/apps/app/tests/unit/components/item-meta.test.ts
+++ b/apps/app/tests/unit/components/item-meta.test.ts
@@ -1,10 +1,8 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  getBookmarkPostedAt,
-  ItemMeta,
-} from "~/components/feed/view-lists/ItemDisplay";
+import { ItemMeta } from "~/components/feed/view-lists/ItemDisplay";
+import { getBookmarkPostedAt } from "~/components/feed/view-lists/itemDate";
 
 const NOW = new Date("2026-08-19T12:00:00.000Z");
 


### PR DESCRIPTION
- Show each Feed item's posted date in every content-status combination
- Show each Bookmark's added date from its creation timestamp
- Preserve existing sorting and section ordering