### PR TITLE
Load articles immediately on open

### DIFF
--- a/apps/app/src/components/bookmarks/BookmarkArticleContent.tsx
+++ b/apps/app/src/components/bookmarks/BookmarkArticleContent.tsx
@@ -2,7 +2,7 @@
 
 import createDOMPurify from "dompurify";
 import parse, { Element } from "html-react-parser";
-import { useEffect, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import type { HTMLReactParserOptions } from "html-react-parser";
 import { CustomVideoPlayer } from "~/components/CustomVideoPlayer";
 import { flattenReaderImages } from "~/components/content-reader/flattenReaderImages";
@@ -14,25 +14,24 @@ import {
 } from "~/server/bookmarks/sanitizePolicy";
 
 const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/;
+const subscribeToClientSnapshot = () => () => undefined;
 
 export function BookmarkArticleContent({ content }: { content: string }) {
-  const [sanitizedContent, setSanitizedContent] = useState("");
   const [videoPlayer] = useFlagState("CUSTOM_VIDEO_PLAYER");
-
-  useEffect(() => {
-    const purifier = createDOMPurify(window);
-    const frame = window.requestAnimationFrame(() => {
-      setSanitizedContent(
-        purifier.sanitize(content, {
-          ALLOWED_TAGS: [...BOOKMARK_CAPTURE_ALLOWED_TAGS],
-          ALLOWED_ATTR: [...BOOKMARK_CAPTURE_ALLOWED_ATTRIBUTES],
-          ALLOW_DATA_ATTR: false,
-          ALLOW_ARIA_ATTR: false,
-        }),
-      );
+  const clientSanitizedContent = useMemo(() => {
+    if (typeof window === "undefined") return "";
+    return createDOMPurify(window).sanitize(content, {
+      ALLOWED_TAGS: [...BOOKMARK_CAPTURE_ALLOWED_TAGS],
+      ALLOWED_ATTR: [...BOOKMARK_CAPTURE_ALLOWED_ATTRIBUTES],
+      ALLOW_DATA_ATTR: false,
+      ALLOW_ARIA_ATTR: false,
     });
-    return () => window.cancelAnimationFrame(frame);
   }, [content]);
+  const sanitizedContent = useSyncExternalStore(
+    subscribeToClientSnapshot,
+    () => clientSanitizedContent,
+    () => "",
+  );
 
   if (!sanitizedContent) {
     return (

--- a/apps/app/tests/unit/components/bookmark-article-content.test.ts
+++ b/apps/app/tests/unit/components/bookmark-article-content.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BookmarkArticleContent } from "~/components/bookmarks/BookmarkArticleContent";
+
+vi.mock("~/lib/hooks/useFlagState", () => ({
+  useFlagState: () => ["iframe", () => undefined],
+}));
+vi.mock("~/components/CustomVideoPlayer", () => ({
+  CustomVideoPlayer: () => null,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Bookmark article content", () => {
+  it("renders the Page capture without waiting for another animation frame", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        createElement(BookmarkArticleContent, {
+          content: "<p>Captured article body</p>",
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe("Captured article body");
+    expect(container.querySelector("[data-reader-content-pending]")).toBeNull();
+    act(() => root.unmount());
+  });
+});

--- a/apps/app/tests/unit/data/article-content-notification.test.ts
+++ b/apps/app/tests/unit/data/article-content-notification.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import { feedItemsStore, useFeedItemValue } from "~/lib/data/store";
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+function feedItem(): ApplicationFeedItem {
+  return {
+    id: "article-one",
+    feedId: 1,
+    contentId: "article-one",
+    title: "Article",
+    author: "Author",
+    url: "https://example.com/article",
+    thumbnail: "",
+    content: "",
+    contentSnippet: "Preview",
+    contentType: "text",
+    isWatched: false,
+    isWatchLater: false,
+    progress: 0,
+    duration: 0,
+    orientation: null,
+    postedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    isWatchedUpdatedAt: null,
+    isWatchLaterUpdatedAt: null,
+    contentHash: "content-hash",
+    platform: "website",
+  };
+}
+
+function MountedArticle() {
+  const item = useFeedItemValue("article-one");
+  return createElement("article", null, item?.content);
+}
+
+afterEach(() => {
+  feedItemsStore.getState().reset();
+});
+
+describe("article content notification", () => {
+  it("renders full text when it arrives after the reader mounts", () => {
+    feedItemsStore.getState().setFeedItem("article-one", feedItem());
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(createElement(MountedArticle));
+    });
+    expect(container.textContent).toBe("");
+
+    act(() => {
+      feedItemsStore.getState().applyFulltextItems([
+        {
+          id: "article-one",
+          content: "Complete article body",
+          contentSnippet: "Complete preview",
+        },
+      ]);
+    });
+
+    expect(container.textContent).toBe("Complete article body");
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
- Sanitize Bookmark Page captures during the reader render instead of waiting for a later animation frame.
- Cover immediate Bookmark rendering and Feed-item full-text notifications.