### PR TITLE
Stabilize CI hook timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Detect affected deployables
         id: affected
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
         run: |
           pnpm exec turbo run build:artifact --affected --dry=json > affected.json
           if jq -e '.tasks[] | select(.taskId == "@serial/app#build:artifact")' affected.json > /dev/null; then
@@ -63,6 +65,7 @@ jobs:
           WWW_STANDARD_SITE_PUBLICATION_URI: ${{ vars.WWW_STANDARD_SITE_PUBLICATION_URI }}
           WWW_UMAMI_WEBSITE_ID: ${{ vars.WWW_UMAMI_WEBSITE_ID }}
           WWW_UMAMI_SRC: ${{ vars.WWW_UMAMI_SRC }}
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
       - name: Check formatting
         run: pnpm format

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   envDir: "./tests",
   test: {
     include: ["tests/unit/**/*.test.ts"],
+    hookTimeout: process.env.CI ? 15_000 : 10_000,
     testTimeout: process.env.CI ? 15_000 : 5_000,
   },
   resolve: {


### PR DESCRIPTION
- give Vitest hooks the existing CI-only 15-second timeout
- resolve Turbo affected ranges from the pull request base commit
- preserve local test behavior and avoid unrelated package work