### PR TITLE
Fix reconciliation races and retention

### DIFF
--- a/apps/app/scripts/performance/client-audit-model.ts
+++ b/apps/app/scripts/performance/client-audit-model.ts
@@ -479,10 +479,13 @@ function measure(operation: () => number): ClientAuditOperation {
   };
 }
 
-function bookmarkUpsertPayload(bookmark: ApplicationBookmark): PublishedChunk {
+function bookmarkUpsertPayload(
+  bookmark: ApplicationBookmark,
+  affectsListProjection = true,
+): PublishedChunk {
   return {
     source: "bookmark",
-    chunk: { type: "bookmark-upsert", bookmark },
+    chunk: { type: "bookmark-upsert", bookmark, affectsListProjection },
   };
 }
 
@@ -649,7 +652,7 @@ export function runClientAuditProfile(
   const bookmarkProgressEvent = measure(
     () =>
       processPublishedChunks([
-        bookmarkUpsertPayload(updatedBookmark(baseBookmark, 1)),
+        bookmarkUpsertPayload(updatedBookmark(baseBookmark, 1), false),
       ]).length,
   );
 
@@ -658,13 +661,16 @@ export function runClientAuditProfile(
   const bookmarkCaptureEvent = measure(
     () =>
       processPublishedChunks([
-        bookmarkUpsertPayload({
-          ...captureBookmark,
-          title: "Updated capture title",
-          captureHash: "updated-capture-hash",
-          capturedAt: new Date(FIXTURE_TIME.getTime() + 1),
-          updatedAt: new Date(FIXTURE_TIME.getTime() + 1),
-        }),
+        bookmarkUpsertPayload(
+          {
+            ...captureBookmark,
+            title: "Updated capture title",
+            captureHash: "updated-capture-hash",
+            capturedAt: new Date(FIXTURE_TIME.getTime() + 1),
+            updatedAt: new Date(FIXTURE_TIME.getTime() + 1),
+          },
+          false,
+        ),
       ]).length,
   );
 
@@ -724,6 +730,7 @@ export function runClientAuditProfile(
         fixture.bookmarks[index % fixture.bookmarks.length]!,
         index,
       ),
+      false,
     ),
   );
   const bookmarkBurstSingleFrame = measure(

--- a/apps/app/scripts/performance/run-view-matrix-benchmark.ts
+++ b/apps/app/scripts/performance/run-view-matrix-benchmark.ts
@@ -16,7 +16,7 @@ import {
 } from "./view-matrix-model";
 import type { ActiveFirstPageResult } from "~/lib/reconciliation";
 import type { ScopeData } from "~/server/mixed-content/projection/scope";
-import { getFeedItemMembershipRevision } from "~/lib/data/feed-items/membershipRevision";
+import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
 import { getPersistedFeedItemRetentionState } from "~/lib/data/feed-page-retention";
 import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import { mixedContentStore } from "~/lib/data/mixed-content/store";
@@ -76,7 +76,7 @@ async function measureMatrix(input: {
       selection: {
         type: "cold",
         contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
-        membershipRevision: getFeedItemMembershipRevision(),
+        membershipRevision: getMixedContentMembershipRevision(),
       },
     },
   })) {

--- a/apps/app/src/app/api.extension.bookmarks.ts
+++ b/apps/app/src/app/api.extension.bookmarks.ts
@@ -23,6 +23,7 @@ import {
   createExtensionBookmarkView,
 } from "~/server/bookmarks/extensionOrganization";
 import {
+  publishBookmarkConsolidationDeletions,
   publishBookmarkDeletion,
   publishBookmarkUpsert,
 } from "~/server/mixed-content/events";
@@ -55,16 +56,11 @@ const DEFAULT_ROUTE_DEPENDENCIES: ExtensionBookmarkRouteDependencies = {
     const removedBookmarkIds =
       result.removedBookmarkIds ??
       (result.removedBookmarkId ? [result.removedBookmarkId] : []);
-    await Promise.all(
-      removedBookmarkIds.map((removedBookmarkId) =>
-        publishBookmarkDeletion({
-          userId,
-          id: removedBookmarkId,
-          canonicalUrl: result.bookmark.canonicalUrl,
-          invalidation: null,
-        }),
-      ),
-    );
+    await publishBookmarkConsolidationDeletions({
+      userId,
+      bookmarkIds: removedBookmarkIds,
+      canonicalUrl: result.bookmark.canonicalUrl,
+    });
     return publishBookmarkUpsert({
       database: db,
       userId,

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -6,7 +6,13 @@ import {
   bookmarkPropertiesChange,
 } from "@serial/bookmark-capture";
 import { useMutation } from "@tanstack/react-query";
+import { isBookmarkProjectionChange } from "../mixed-content/bookmarkProjection";
+import { advanceMixedContentMembershipRevision } from "../mixed-content/membershipRevision";
 import { mixedContentStore } from "../mixed-content/store";
+import {
+  clearRetainedEntityPins,
+  setRetainedEntityPins,
+} from "../page-retention";
 import { viewsStore } from "../views/store";
 import { bookmarksStore } from "./store";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
@@ -15,10 +21,36 @@ import { orpc } from "~/lib/orpc";
 const mutationCoordinator =
   new BookmarkMutationCoordinator<ApplicationBookmark>();
 
+function optimisticRetentionOwner(token: {
+  bookmarkId: string;
+  sequence: number;
+}) {
+  return `optimistic:bookmark:${token.bookmarkId}:${token.sequence}`;
+}
+
+function retainOptimisticBookmark(token: {
+  bookmarkId: string;
+  sequence: number;
+}) {
+  setRetainedEntityPins(optimisticRetentionOwner(token), {
+    bookmarkIds: [token.bookmarkId],
+  });
+}
+
+function releaseOptimisticBookmark(token: {
+  bookmarkId: string;
+  sequence: number;
+}) {
+  clearRetainedEntityPins(optimisticRetentionOwner(token));
+}
+
 function projectBookmark(
   bookmark: ApplicationBookmark,
   previousBookmark: ApplicationBookmark | undefined,
 ) {
+  if (isBookmarkProjectionChange(previousBookmark, bookmark)) {
+    advanceMixedContentMembershipRevision();
+  }
   bookmarksStore.getState().upsert(bookmark);
   mixedContentStore.getState().reprojectUpsert({
     bookmark,
@@ -28,6 +60,7 @@ function projectBookmark(
 }
 
 function removeProjectedBookmark(bookmark: ApplicationBookmark) {
+  advanceMixedContentMembershipRevision();
   bookmarksStore.getState().remove(bookmark.id);
   mixedContentStore.getState().reprojectDeletion({
     bookmarkId: bookmark.id,
@@ -107,40 +140,58 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
             : []),
         ];
         const token = mutationCoordinator.begin(bookmarkId, changes);
-        projectBookmark(
-          mutationCoordinator.apply(previousBookmark, token),
-          previousBookmark,
-        );
+        retainOptimisticBookmark(token);
+        try {
+          projectBookmark(
+            mutationCoordinator.apply(previousBookmark, token),
+            previousBookmark,
+          );
+        } catch (error) {
+          releaseOptimisticBookmark(token);
+          throw error;
+        }
         return { previousBookmark, token };
       },
       onSuccess: (bookmark, _input, context) => {
-        const serverBookmark = bookmark as ApplicationBookmark;
-        const currentBookmark = bookmarksStore
-          .getState()
-          .getBookmark(bookmarkId);
-        const reconciled =
-          context?.token && currentBookmark
-            ? mutationCoordinator.reconcile(
-                currentBookmark,
-                serverBookmark,
-                context.token,
-              )
-            : serverBookmark;
-        projectBookmark(reconciled, currentBookmark);
+        try {
+          const serverBookmark = bookmark as ApplicationBookmark;
+          const currentBookmark = bookmarksStore
+            .getState()
+            .getBookmark(bookmarkId);
+          const reconciled =
+            context?.token && currentBookmark
+              ? mutationCoordinator.reconcile(
+                  currentBookmark,
+                  serverBookmark,
+                  context.token,
+                )
+              : serverBookmark;
+          projectBookmark(reconciled, currentBookmark);
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
+        }
       },
       onError: (_error, _input, context) => {
-        const optimisticBookmark = bookmarksStore
-          .getState()
-          .getBookmark(bookmarkId);
-        if (context?.previousBookmark && context.token && optimisticBookmark) {
-          projectBookmark(
-            mutationCoordinator.rollback(
+        try {
+          const optimisticBookmark = bookmarksStore
+            .getState()
+            .getBookmark(bookmarkId);
+          if (
+            context?.previousBookmark &&
+            context.token &&
+            optimisticBookmark
+          ) {
+            projectBookmark(
+              mutationCoordinator.rollback(
+                optimisticBookmark,
+                context.previousBookmark,
+                context.token,
+              ),
               optimisticBookmark,
-              context.previousBookmark,
-              context.token,
-            ),
-            optimisticBookmark,
-          );
+            );
+          }
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
         }
       },
     }),
@@ -158,39 +209,53 @@ export function useSetBookmarkViewMutation() {
         const token = mutationCoordinator.begin(input.bookmarkId, [
           bookmarkMembershipChange("view", input.viewId, input.assigned),
         ]);
-        projectBookmark(
-          mutationCoordinator.apply(previousBookmark, token),
-          previousBookmark,
-        );
+        retainOptimisticBookmark(token);
+        try {
+          projectBookmark(
+            mutationCoordinator.apply(previousBookmark, token),
+            previousBookmark,
+          );
+        } catch (error) {
+          releaseOptimisticBookmark(token);
+          throw error;
+        }
         return { previousBookmark, token };
       },
       onSuccess: (bookmark, _input, context) => {
-        const currentBookmark = context?.previousBookmark
-          ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
-          : undefined;
-        if (bookmark && currentBookmark && context?.token) {
-          const applicationBookmark = mutationCoordinator.reconcile(
-            currentBookmark,
-            bookmark,
-            context.token,
-          );
-          projectBookmark(applicationBookmark, currentBookmark);
+        try {
+          const currentBookmark = context?.previousBookmark
+            ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
+            : undefined;
+          if (bookmark && currentBookmark && context?.token) {
+            const applicationBookmark = mutationCoordinator.reconcile(
+              currentBookmark,
+              bookmark,
+              context.token,
+            );
+            projectBookmark(applicationBookmark, currentBookmark);
+          }
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
         }
       },
       onError: (_error, _input, context) => {
-        if (!context?.previousBookmark || !context.token) return;
-        const currentBookmark = bookmarksStore
-          .getState()
-          .getBookmark(context.previousBookmark.id);
-        if (!currentBookmark) return;
-        projectBookmark(
-          mutationCoordinator.rollback(
+        try {
+          if (!context?.previousBookmark || !context.token) return;
+          const currentBookmark = bookmarksStore
+            .getState()
+            .getBookmark(context.previousBookmark.id);
+          if (!currentBookmark) return;
+          projectBookmark(
+            mutationCoordinator.rollback(
+              currentBookmark,
+              context.previousBookmark,
+              context.token,
+            ),
             currentBookmark,
-            context.previousBookmark,
-            context.token,
-          ),
-          currentBookmark,
-        );
+          );
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
+        }
       },
     }),
   );
@@ -207,39 +272,53 @@ export function useSetBookmarkTagMutation() {
         const token = mutationCoordinator.begin(input.bookmarkId, [
           bookmarkMembershipChange("tag", input.tagId, input.assigned),
         ]);
-        projectBookmark(
-          mutationCoordinator.apply(previousBookmark, token),
-          previousBookmark,
-        );
+        retainOptimisticBookmark(token);
+        try {
+          projectBookmark(
+            mutationCoordinator.apply(previousBookmark, token),
+            previousBookmark,
+          );
+        } catch (error) {
+          releaseOptimisticBookmark(token);
+          throw error;
+        }
         return { previousBookmark, token };
       },
       onSuccess: (bookmark, _input, context) => {
-        const currentBookmark = context?.previousBookmark
-          ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
-          : undefined;
-        if (bookmark && currentBookmark && context?.token) {
-          const applicationBookmark = mutationCoordinator.reconcile(
-            currentBookmark,
-            bookmark,
-            context.token,
-          );
-          projectBookmark(applicationBookmark, currentBookmark);
+        try {
+          const currentBookmark = context?.previousBookmark
+            ? bookmarksStore.getState().getBookmark(context.previousBookmark.id)
+            : undefined;
+          if (bookmark && currentBookmark && context?.token) {
+            const applicationBookmark = mutationCoordinator.reconcile(
+              currentBookmark,
+              bookmark,
+              context.token,
+            );
+            projectBookmark(applicationBookmark, currentBookmark);
+          }
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
         }
       },
       onError: (_error, _input, context) => {
-        if (!context?.previousBookmark || !context.token) return;
-        const currentBookmark = bookmarksStore
-          .getState()
-          .getBookmark(context.previousBookmark.id);
-        if (!currentBookmark) return;
-        projectBookmark(
-          mutationCoordinator.rollback(
+        try {
+          if (!context?.previousBookmark || !context.token) return;
+          const currentBookmark = bookmarksStore
+            .getState()
+            .getBookmark(context.previousBookmark.id);
+          if (!currentBookmark) return;
+          projectBookmark(
+            mutationCoordinator.rollback(
+              currentBookmark,
+              context.previousBookmark,
+              context.token,
+            ),
             currentBookmark,
-            context.previousBookmark,
-            context.token,
-          ),
-          currentBookmark,
-        );
+          );
+        } finally {
+          if (context?.token) releaseOptimisticBookmark(context.token);
+        }
       },
     }),
   );

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -8,7 +8,10 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import { isBookmarkProjectionChange } from "../mixed-content/bookmarkProjection";
 import { advanceMixedContentMembershipRevision } from "../mixed-content/membershipRevision";
-import { mixedContentStore } from "../mixed-content/store";
+import {
+  hasBookmarkBodyOwner,
+  mixedContentStore,
+} from "../mixed-content/store";
 import {
   clearRetainedEntityPins,
   setRetainedEntityPins,
@@ -92,10 +95,14 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
   return useMutation(
     orpc.bookmark.updateState.mutationOptions({
       onMutate: (input) => {
+        const changesMixedProjection =
+          input.isSaved !== undefined || input.isRead !== undefined;
         const previousBookmark = bookmarksStore
           .getState()
           .getBookmark(bookmarkId);
-        if (!previousBookmark) return { previousBookmark };
+        if (!previousBookmark) {
+          return { previousBookmark, changesMixedProjection };
+        }
         const now = new Date();
         const changes = [
           ...(input.isSaved !== undefined
@@ -150,7 +157,7 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
           releaseOptimisticBookmark(token);
           throw error;
         }
-        return { previousBookmark, token };
+        return { previousBookmark, token, changesMixedProjection };
       },
       onSuccess: (bookmark, _input, context) => {
         try {
@@ -158,6 +165,12 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
           const currentBookmark = bookmarksStore
             .getState()
             .getBookmark(bookmarkId);
+          if (!currentBookmark && !context?.changesMixedProjection) {
+            if (hasBookmarkBodyOwner(bookmarkId)) {
+              bookmarksStore.getState().upsert(serverBookmark);
+            }
+            return;
+          }
           const reconciled =
             context?.token && currentBookmark
               ? mutationCoordinator.reconcile(

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -63,14 +63,19 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
       getBookmark: (id) => bookmarkEntities[id],
       snapshot: () => bookmarkEntities,
       upsert: (bookmark) => {
-        bookmarkEntities[bookmark.id] = bookmark;
+        bookmarkEntities = {
+          ...bookmarkEntities,
+          [bookmark.id]: bookmark,
+        };
         set({ revision: get().revision + 1 });
       },
       upsertMany: (bookmarks) => {
         if (bookmarks.length === 0) return;
+        const nextEntities = { ...bookmarkEntities };
         for (const bookmark of bookmarks) {
-          bookmarkEntities[bookmark.id] = bookmark;
+          nextEntities[bookmark.id] = bookmark;
         }
+        bookmarkEntities = nextEntities;
         set({ revision: get().revision + 1 });
       },
       remove: (id) => {

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -18,9 +18,11 @@ type BookmarkStore = {
   upsert: (bookmark: ApplicationBookmark) => void;
   upsertMany: (bookmarks: ApplicationBookmark[]) => void;
   remove: (id: string) => void;
+  removeMany: (ids: Iterable<string>) => void;
+  pruneExcept: (retainedIds: ReadonlySet<string>) => void;
 };
 
-const bookmarkEntities: Record<string, ApplicationBookmark> = {};
+let bookmarkEntities: Record<string, ApplicationBookmark> = {};
 
 function isPersistedBookmarkStore(
   value: unknown,
@@ -33,8 +35,17 @@ function isPersistedBookmarkStore(
 function replaceBookmarkEntities(
   bookmarks: Record<string, ApplicationBookmark>,
 ) {
-  for (const id of Object.keys(bookmarkEntities)) delete bookmarkEntities[id];
-  Object.assign(bookmarkEntities, bookmarks);
+  bookmarkEntities = { ...bookmarks };
+}
+
+function removeBookmarkEntities(ids: Iterable<string>) {
+  const removedIds = [...ids].filter((id) => id in bookmarkEntities);
+  if (removedIds.length === 0) return false;
+
+  const nextEntities = { ...bookmarkEntities };
+  for (const id of removedIds) delete nextEntities[id];
+  bookmarkEntities = nextEntities;
+  return true;
 }
 
 const vanillaBookmarkStore = createStore<BookmarkStore>()(
@@ -63,7 +74,21 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
         set({ revision: get().revision + 1 });
       },
       remove: (id) => {
-        delete bookmarkEntities[id];
+        if (!removeBookmarkEntities([id])) return;
+        set({ revision: get().revision + 1 });
+      },
+      removeMany: (ids) => {
+        if (!removeBookmarkEntities(ids)) return;
+        set({ revision: get().revision + 1 });
+      },
+      pruneExcept: (retainedIds) => {
+        if (
+          !removeBookmarkEntities(
+            Object.keys(bookmarkEntities).filter((id) => !retainedIds.has(id)),
+          )
+        ) {
+          return;
+        }
         set({ revision: get().revision + 1 });
       },
     }),

--- a/apps/app/src/lib/data/directRequests.ts
+++ b/apps/app/src/lib/data/directRequests.ts
@@ -4,9 +4,9 @@ import { orpc, orpcRouterClient } from "../orpc";
 import { getQueryClient } from "../query-client";
 import { feedsStore } from "./feeds/store";
 import {
-  getFeedItemMembershipRevision,
-  isFeedItemMembershipRevisionStale,
-} from "./feed-items/membershipRevision";
+  getMixedContentMembershipRevision,
+  isMixedContentMembershipRevisionStale,
+} from "./mixed-content/membershipRevision";
 import { loadingActor } from "./loading-machine";
 import { applyRequestedMixedContentPage } from "./subscriptionCoordinator";
 import { feedItemsStore } from "./store";
@@ -59,11 +59,13 @@ export const dataRequestActions = {
     >[0]["cursor"],
     limit?: number,
   ) => {
-    const membershipRevision = getFeedItemMembershipRevision();
+    const membershipRevision = getMixedContentMembershipRevision();
     return orpcRouterClient.mixedContent
       .requestPage({ scope, contentStatus, cursor, limit })
       .then((page) => {
-        if (isFeedItemMembershipRevisionStale(membershipRevision)) return page;
+        if (isMixedContentMembershipRevisionStale(membershipRevision)) {
+          return page;
+        }
         applyRequestedMixedContentPage({
           scope,
           contentStatus,

--- a/apps/app/src/lib/data/feed-items/mutations.ts
+++ b/apps/app/src/lib/data/feed-items/mutations.ts
@@ -2,13 +2,14 @@ import { useMutation } from "@tanstack/react-query";
 import { feedItemsStore, useFeedItemState } from "../store";
 import { feedCategoriesStore } from "../feed-categories/store";
 import { mixedContentStore } from "../mixed-content/store";
+import { advanceMixedContentMembershipRevision } from "../mixed-content/membershipRevision";
 import { viewsStore } from "../views/store";
 import {
   clearPendingFeedItemOverride,
   setPendingWatchedOverride,
   setPendingWatchLaterOverride,
 } from "./pendingMutations";
-import { advanceFeedItemMembershipRevision } from "./membershipRevision";
+import { hasFeedItemListProjectionChanged } from "./listProjection";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 import { orpc, orpcRouterClient } from "~/lib/orpc";
 
@@ -44,6 +45,13 @@ function setFeedItemsWithMixedProjection(items: ApplicationFeedItem[]) {
   const previousFeedItems = Object.fromEntries(
     items.map((item) => [item.id, store.feedItemsDict[item.id]]),
   );
+  if (
+    items.some((item) =>
+      hasFeedItemListProjectionChanged(previousFeedItems[item.id], item),
+    )
+  ) {
+    advanceMixedContentMembershipRevision();
+  }
   store.setFeedItems(items);
   mixedContentStore.getState().reprojectFeedItems({
     itemIds: items.map((item) => item.id),
@@ -75,7 +83,6 @@ export function applyOptimisticWatchedValues(
     return [{ ...feedItem, isWatched, isWatchedUpdatedAt }];
   });
   if (updatedItems.length > 0) {
-    advanceFeedItemMembershipRevision();
     setFeedItemsWithMixedProjection(updatedItems);
   }
   return contexts;
@@ -102,7 +109,6 @@ export function applyOptimisticWatchLaterValue(
     isWatchLater,
     isWatchLaterUpdatedAt,
   );
-  advanceFeedItemMembershipRevision();
   setFeedItemsWithMixedProjection([
     { ...feedItem, isWatchLater, isWatchLaterUpdatedAt },
   ]);

--- a/apps/app/src/lib/data/mixed-content/membershipRevision.ts
+++ b/apps/app/src/lib/data/mixed-content/membershipRevision.ts
@@ -1,15 +1,15 @@
 let membershipRevision = 0;
 
-export function getFeedItemMembershipRevision() {
+export function getMixedContentMembershipRevision() {
   return membershipRevision;
 }
 
-export function advanceFeedItemMembershipRevision() {
+export function advanceMixedContentMembershipRevision() {
   membershipRevision += 1;
   return membershipRevision;
 }
 
-export function isFeedItemMembershipRevisionStale(
+export function isMixedContentMembershipRevisionStale(
   candidateRevision: number | undefined,
 ) {
   return (

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -6,6 +6,8 @@ import {
   clearRetainedEntityPins,
   setRetainedEntityPins,
 } from "../page-retention";
+import { isBookmarkProjectionChange } from "./bookmarkProjection";
+import { advanceMixedContentMembershipRevision } from "./membershipRevision";
 import { mixedContentStore } from "./store";
 import type { MixedContentReference } from "~/server/mixed-content/projection";
 import { orpcRouterClient } from "~/lib/orpc";
@@ -37,6 +39,12 @@ export async function setMixedReadValue(input: {
     .map((id) => bookmarksStore.getState().getBookmark(id))
     .filter((bookmark) => bookmark !== undefined);
   const now = new Date();
+  const optimisticBookmarks = previousBookmarks.map((bookmark) => ({
+    ...bookmark,
+    isRead: input.isRead,
+    readUpdatedAt: now,
+    updatedAt: now,
+  }));
 
   for (const bookmarkId of targets.bookmarkIds) {
     setRetainedEntityPins(`optimistic:bookmark:${bookmarkId}`, {
@@ -44,13 +52,16 @@ export async function setMixedReadValue(input: {
     });
   }
 
-  for (const bookmark of previousBookmarks) {
-    const optimisticBookmark = {
-      ...bookmark,
-      isRead: input.isRead,
-      readUpdatedAt: now,
-      updatedAt: now,
-    };
+  if (
+    optimisticBookmarks.some((bookmark, index) =>
+      isBookmarkProjectionChange(previousBookmarks[index], bookmark),
+    )
+  ) {
+    advanceMixedContentMembershipRevision();
+  }
+
+  for (const [index, bookmark] of previousBookmarks.entries()) {
+    const optimisticBookmark = optimisticBookmarks[index]!;
     bookmarksStore.getState().upsert(optimisticBookmark);
     mixedContentStore.getState().reprojectUpsert({
       bookmark: optimisticBookmark,
@@ -75,6 +86,16 @@ export async function setMixedReadValue(input: {
         : Promise.resolve(),
     ]);
   } catch (error) {
+    if (
+      previousBookmarks.some((bookmark) =>
+        isBookmarkProjectionChange(
+          bookmarksStore.getState().getBookmark(bookmark.id),
+          bookmark,
+        ),
+      )
+    ) {
+      advanceMixedContentMembershipRevision();
+    }
     for (const bookmark of previousBookmarks) {
       const optimisticBookmark = bookmarksStore
         .getState()

--- a/apps/app/src/lib/data/mixed-content/page-retention.ts
+++ b/apps/app/src/lib/data/mixed-content/page-retention.ts
@@ -42,6 +42,53 @@ export function retainedMixedReferenceKeys(
   return new Set(pages.flatMap((page) => page.value.referenceKeys));
 }
 
+export function retainedMixedBookmarkIds(
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>,
+) {
+  const bookmarkPrefix = "bookmark:";
+  return new Set(
+    pages.flatMap((page) =>
+      page.value.referenceKeys.flatMap((key) =>
+        key.startsWith(bookmarkPrefix)
+          ? [key.slice(bookmarkPrefix.length)]
+          : [],
+      ),
+    ),
+  );
+}
+
+export function replaceRetainedMixedRootPage(
+  pages: Array<RetainedCursorPage<MixedPageRetentionValue>>,
+  page: MixedContentPage,
+) {
+  const rootIndex = pages.findIndex(
+    (candidate) => candidate.requestCursorKey === "root",
+  );
+  if (rootIndex < 0) {
+    return mergeRetainedMixedPage({
+      pages,
+      page,
+      requestCursor: null,
+      replacesScope: false,
+    });
+  }
+
+  const previousRoot = pages[rootIndex]!;
+  const nextCursorKey = cursorRetentionKey(page.cursor);
+  const value = { referenceKeys: page.references.map(mixedReferenceKey) };
+  const nextPages = [...pages];
+  nextPages[rootIndex] = {
+    key: `root->${nextCursorKey}`,
+    requestCursorKey: "root",
+    nextCursorKey,
+    entityIds: page.references.map((reference) => reference.entityId),
+    value,
+    byteSize: estimateRetainedBytes(value),
+    sequence: previousRoot.sequence,
+  };
+  return nextPages;
+}
+
 export function mergeRetainedMixedPage({
   pages,
   page,

--- a/apps/app/src/lib/data/mixed-content/store.ts
+++ b/apps/app/src/lib/data/mixed-content/store.ts
@@ -1,5 +1,6 @@
 import { createStore } from "zustand";
 import { persist } from "zustand/middleware";
+import { bookmarksStore } from "../bookmarks/store";
 import {
   createFeedItemFilterIndex,
   createFeedItemFilterPredicate,
@@ -8,6 +9,10 @@ import {
 } from "../feed-items/listProjection";
 import { createNormalizedIDBStorage } from "../normalized-idb-storage";
 import { createSelectorHooks } from "../createSelectorHooks";
+import {
+  getRetainedEntityPins,
+  onBookmarkRetentionPinsReleased,
+} from "../page-retention";
 import {
   bookmarkContentStatus,
   bookmarkReference,
@@ -27,6 +32,8 @@ import {
   getPersistedMixedContentState,
   mergeRetainedMixedPage,
   mixedReferenceKey,
+  replaceRetainedMixedRootPage,
+  retainedMixedBookmarkIds,
   retainedMixedReferenceKeys,
   updateBookmarkPageMembership,
   updateReferencePageMembership,
@@ -53,6 +60,43 @@ import { selectFeedItemOrderCoordinate } from "~/lib/data/feed-items/orderCoordi
 
 export { getMixedScopeKey } from "./bookmarkProjection";
 export type { LoadedMixedScope } from "./page-retention";
+
+let bookmarkOwnershipInitialized = false;
+
+function ownedBookmarkIds(scopes: Record<string, LoadedMixedScope>) {
+  const ids = getRetainedEntityPins("bookmark");
+  for (const scope of Object.values(scopes)) {
+    for (const id of retainedMixedBookmarkIds(scope.pages)) ids.add(id);
+  }
+  return ids;
+}
+
+export function hasBookmarkBodyOwner(bookmarkId: string) {
+  return ownedBookmarkIds(mixedContentStore.getState().scopes).has(bookmarkId);
+}
+
+function pruneBookmarkBodies(
+  scopes: Record<string, LoadedMixedScope>,
+  candidates: Iterable<string>,
+) {
+  const ownedIds = ownedBookmarkIds(scopes);
+  if (!bookmarkOwnershipInitialized) {
+    bookmarkOwnershipInitialized = true;
+    bookmarksStore.getState().pruneExcept(ownedIds);
+    return;
+  }
+
+  bookmarksStore
+    .getState()
+    .removeMany([...candidates].filter((id) => !ownedIds.has(id)));
+}
+
+export function synchronizeBookmarkBodyRetention() {
+  bookmarksStore
+    .getState()
+    .pruneExcept(ownedBookmarkIds(mixedContentStore.getState().scopes));
+  bookmarkOwnershipInitialized = true;
+}
 
 export function getViewContentAvailability(
   scopes: Record<string, LoadedMixedScope>,
@@ -126,13 +170,19 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
       fetchingScopes: {},
       projectionIndexes: emptyProjectionIndexes(),
       projectionIndexesComplete: true,
-      reset: () =>
+      reset: () => {
+        const bookmarkIds = Object.values(get().scopes).flatMap((scope) => [
+          ...retainedMixedBookmarkIds(scope.pages),
+        ]);
         set({
           scopes: {},
           fetchingScopes: {},
           projectionIndexes: emptyProjectionIndexes(),
           projectionIndexesComplete: true,
-        }),
+        });
+        pruneBookmarkBodies({}, bookmarkIds);
+        bookmarkOwnershipInitialized = false;
+      },
       setScopeFetching: (scopeKey, isFetching) =>
         set((state) => ({
           fetchingScopes: {
@@ -151,6 +201,9 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           requestCursor,
           replacesScope,
         });
+        const previousBookmarkIds = retainedMixedBookmarkIds(
+          existing?.pages ?? [],
+        );
         const retainedKeys = retainedMixedReferenceKeys(pages);
         const pinnedEntityIds = getMixedRetentionPins();
         const nextScope = {
@@ -192,6 +245,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
           projectionIndexes,
           projectionIndexesComplete: true,
         });
+        pruneBookmarkBodies(scopes, previousBookmarkIds);
       },
       reconcileFirstPage: ({ scope, contentStatus, page }) => {
         const key = getMixedScopeKey(scope, contentStatus);
@@ -223,6 +277,18 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             page,
             replacesScope: true,
           });
+        } else {
+          const scopes = {
+            ...current.scopes,
+            [key]: {
+              ...existing,
+              pages: replaceRetainedMixedRootPage(existing.pages, page),
+              cursor: page.cursor,
+              hasMore: page.hasMore,
+            },
+          };
+          set({ scopes });
+          pruneBookmarkBodies(scopes, []);
         }
 
         return { firstPageChanged };
@@ -313,6 +379,7 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
             projectionIndexesComplete: true,
           });
         }
+        pruneBookmarkBodies(scopes, [bookmark.id]);
         return affected;
       },
       reprojectDeletion: ({ bookmarkId }) => {
@@ -493,3 +560,35 @@ const vanillaMixedContentStore = createStore<MixedContentStore>()(
 );
 
 export const mixedContentStore = createSelectorHooks(vanillaMixedContentStore);
+
+onBookmarkRetentionPinsReleased((releasedBookmarkIds) => {
+  pruneBookmarkBodies(mixedContentStore.getState().scopes, releasedBookmarkIds);
+});
+
+type PersistLifecycle = {
+  persist: {
+    hasHydrated: () => boolean;
+    onFinishHydration: (listener: () => void) => () => void;
+  };
+};
+
+const bookmarkPersistence = bookmarksStore as unknown as PersistLifecycle;
+const mixedContentPersistence =
+  mixedContentStore as unknown as PersistLifecycle;
+const synchronizeHydratedBookmarkRetention = () => {
+  if (
+    !bookmarkPersistence.persist.hasHydrated() ||
+    !mixedContentPersistence.persist.hasHydrated()
+  ) {
+    return;
+  }
+  synchronizeBookmarkBodyRetention();
+};
+
+bookmarkPersistence.persist.onFinishHydration(
+  synchronizeHydratedBookmarkRetention,
+);
+mixedContentPersistence.persist.onFinishHydration(
+  synchronizeHydratedBookmarkRetention,
+);
+synchronizeHydratedBookmarkRetention();

--- a/apps/app/src/lib/data/page-retention.ts
+++ b/apps/app/src/lib/data/page-retention.ts
@@ -38,6 +38,23 @@ type RetentionPins = {
 };
 
 const pinsByOwner = new Map<string, RetentionPins>();
+const pinReleaseListeners = new Set<
+  (releasedBookmarkIds: ReadonlySet<string>) => void
+>();
+
+function notifyReleasedBookmarkPins(
+  previousPins: RetentionPins | undefined,
+  nextPins: RetentionPins | undefined,
+) {
+  if (!previousPins) return;
+  const releasedBookmarkIds = new Set(
+    [...previousPins.bookmarkIds].filter(
+      (id) => !nextPins?.bookmarkIds.has(id),
+    ),
+  );
+  if (releasedBookmarkIds.size === 0) return;
+  for (const listener of pinReleaseListeners) listener(releasedBookmarkIds);
+}
 
 function sortedPages<T>(pages: Array<RetainedCursorPage<T>>) {
   return [...pages].sort(
@@ -159,14 +176,26 @@ export function setRetainedEntityPins(
     bookmarkIds?: Iterable<string>;
   },
 ) {
-  pinsByOwner.set(owner, {
+  const previousPins = pinsByOwner.get(owner);
+  const nextPins = {
     feedItemIds: new Set(pins.feedItemIds),
     bookmarkIds: new Set(pins.bookmarkIds),
-  });
+  };
+  pinsByOwner.set(owner, nextPins);
+  notifyReleasedBookmarkPins(previousPins, nextPins);
 }
 
 export function clearRetainedEntityPins(owner: string) {
+  const previousPins = pinsByOwner.get(owner);
   pinsByOwner.delete(owner);
+  notifyReleasedBookmarkPins(previousPins, undefined);
+}
+
+export function onBookmarkRetentionPinsReleased(
+  listener: (releasedBookmarkIds: ReadonlySet<string>) => void,
+) {
+  pinReleaseListeners.add(listener);
+  return () => pinReleaseListeners.delete(listener);
 }
 
 export function getRetainedEntityPins(kind: "feed-item" | "bookmark") {

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -4,7 +4,7 @@ import { useSyncExternalStore } from "react";
 import { bookmarksStore } from "./bookmarks/store";
 import { contentCategoriesStore } from "./content-categories/store";
 import { feedCategoriesStore } from "./feed-categories/store";
-import { getFeedItemMembershipRevision } from "./feed-items/membershipRevision";
+import { getMixedContentMembershipRevision } from "./mixed-content/membershipRevision";
 import { feedsStore } from "./feeds/store";
 import { loadingActor, updateRefreshCooldown } from "./loading-machine";
 import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
@@ -146,7 +146,7 @@ function buildInput(
         selection: {
           type: "cold",
           contentStatus: request.intent.coldContentStatus,
-          membershipRevision: getFeedItemMembershipRevision(),
+          membershipRevision: getMixedContentMembershipRevision(),
         },
       };
     }
@@ -159,7 +159,7 @@ function buildInput(
         scope: selectedScope.scope,
         contentStatus: selectedScope.contentStatus,
         pageManifest: firstPageManifest(selectedScope),
-        membershipRevision: getFeedItemMembershipRevision(),
+        membershipRevision: getMixedContentMembershipRevision(),
       },
     };
   }
@@ -172,7 +172,7 @@ function buildInput(
         return {
           target,
           pageManifest: firstPageManifest(target),
-          membershipRevision: getFeedItemMembershipRevision(),
+          membershipRevision: getMixedContentMembershipRevision(),
         };
       }
       return target.type === "organization"

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -27,6 +27,7 @@ import type {
   ReconciliationEntityManifestEntry,
   ReconciliationHydrationDomain,
   ReconciliationInput,
+  ReconciliationInvalidationSummary,
   ReconciliationPageManifest,
   ReconciliationRequestDescriptor,
   ReconciliationScopeTarget,
@@ -36,6 +37,8 @@ import type { PublishedChunk } from "~/server/api/publisher";
 import type { RssAttemptSummary, RssTrigger } from "~/lib/rss";
 import { orpcRouterClient } from "~/lib/orpc";
 import {
+  ALL_CONTENT_STATUS_KEYS,
+  buildFeedInvalidationSummary,
   createReconciliationRuntime,
   expandInvalidationSummary,
   getBookmarkReconciliationVersion,
@@ -245,14 +248,33 @@ function retainedScopeTargets(activeTarget: ReconciliationScopeTarget | null) {
   ];
 }
 
-function mutationInvalidationEffects(
-  payloads: PublishedChunk[],
-  activeTarget: ReconciliationScopeTarget | null,
-) {
-  const summaries = payloads.flatMap((payload) => {
+function invalidationSummariesFrom(payloads: PublishedChunk[]) {
+  return payloads.flatMap((payload) => {
     if (payload.source === "invalidation") return [payload.chunk];
     return payload.invalidation ? [payload.invalidation] : [];
   });
+}
+
+function rssDetailInvalidationFrom(payloads: PublishedChunk[]) {
+  const feedIds = payloads.flatMap((payload) =>
+    payload.source === "rss" &&
+    payload.chunk.type === "feed-items" &&
+    payload.chunk.feedItems.length > 0
+      ? [payload.chunk.feedId]
+      : [],
+  );
+  return feedIds.length > 0
+    ? buildFeedInvalidationSummary({
+        feedIds,
+        contentStatusKeys: ALL_CONTENT_STATUS_KEYS,
+      })
+    : null;
+}
+
+function invalidationEffects(
+  summaries: ReconciliationInvalidationSummary[],
+  activeTarget: ReconciliationScopeTarget | null,
+) {
   if (summaries.length === 0) return null;
 
   const retainedScopes = retainedScopeTargets(activeTarget);
@@ -264,6 +286,17 @@ function mutationInvalidationEffects(
   const repairTargets = new Map<string, ReconciliationTarget>();
   const dirtyTargets = new Map<string, ReconciliationTarget>();
   let unknown = false;
+  const recordScopeTarget = (target: ReconciliationScopeTarget) => {
+    const key = getReconciliationTargetKey(target);
+    if (
+      target.scope.type === "view" ||
+      (activeTarget && key === getReconciliationTargetKey(activeTarget))
+    ) {
+      repairTargets.set(key, target);
+    } else {
+      dirtyTargets.set(key, target);
+    }
+  };
 
   for (const summary of summaries) {
     for (const domain of summary.domains) {
@@ -275,17 +308,13 @@ function mutationInvalidationEffects(
       retainedScopes,
       memberships,
     });
-    unknown ||= expanded.scopeImpactUnknown;
+    if (expanded.scopeImpactUnknown) {
+      unknown = true;
+      for (const target of retainedScopes) recordScopeTarget(target);
+      continue;
+    }
     for (const target of expanded.scopes) {
-      const key = getReconciliationTargetKey(target);
-      if (
-        target.scope.type === "view" ||
-        (activeTarget && key === getReconciliationTargetKey(activeTarget))
-      ) {
-        repairTargets.set(key, target);
-      } else {
-        dirtyTargets.set(key, target);
-      }
+      recordScopeTarget(target);
     }
   }
 
@@ -307,6 +336,70 @@ function mutationInvalidationEffects(
           ? ({ type: "targeted", targets: eagerTargets } as const)
           : undefined,
   };
+}
+
+function mutationInvalidationEffects(
+  payloads: PublishedChunk[],
+  activeTarget: ReconciliationScopeTarget | null,
+) {
+  return invalidationEffects(invalidationSummariesFrom(payloads), activeTarget);
+}
+
+function liveEventTargets(
+  payloads: PublishedChunk[],
+  activeTarget: ReconciliationScopeTarget | null,
+  scopeTargetsHydrated: boolean,
+) {
+  const targets = new Map<string, ReconciliationTarget>();
+  const addTarget = (target: ReconciliationTarget) => {
+    targets.set(getReconciliationTargetKey(target), target);
+  };
+  const rssDetailInvalidation = rssDetailInvalidationFrom(payloads);
+  const summaries = [
+    ...invalidationSummariesFrom(payloads),
+    ...(rssDetailInvalidation ? [rssDetailInvalidation] : []),
+  ];
+  let affectsAllScopes = summaries.some(
+    (summary) => summary.scopeImpact.type === "unknown",
+  );
+
+  if (scopeTargetsHydrated) {
+    const effects = invalidationEffects(summaries, activeTarget);
+    for (const target of [
+      ...(effects?.repairTargets ?? []),
+      ...(effects?.dirtyTargets ?? []),
+    ]) {
+      addTarget(target);
+    }
+  } else {
+    for (const summary of summaries) {
+      for (const domain of summary.domains) addTarget({ type: domain });
+      if (
+        summary.scopeImpact.type === "known" &&
+        summary.scopeImpact.selectors.length > 0
+      ) {
+        affectsAllScopes = true;
+      }
+    }
+  }
+
+  const rssSummary = rssSummaryFrom(payloads);
+  if (rssSummary && rssSummary.affectedFeeds.length > 0) {
+    addTarget({ type: "navigation" });
+    if (scopeTargetsHydrated) {
+      for (const target of retainedScopeTargets(activeTarget)) {
+        if (
+          rssSummaryAffectsTarget(rssSummary, target, rssRepairMemberships())
+        ) {
+          addTarget(target);
+        }
+      }
+    } else {
+      affectsAllScopes = true;
+    }
+  }
+
+  return { targets: [...targets.values()], affectsAllScopes };
 }
 
 let manualFullPromise: Promise<void> | null = null;
@@ -393,13 +486,23 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
       refreshNavigation: false,
     });
     const activeTarget = currentSelection();
-    const invalidationEffects = mutationInvalidationEffects(
-      payloads,
-      activeTarget,
-    );
+    const mutationEffects = mutationInvalidationEffects(payloads, activeTarget);
     const summary = rssSummaryFrom(payloads);
     const onlyRssPayloads = payloads.every(({ source }) => source === "rss");
-    if (onlyRssPayloads && !summary) return;
+    if (onlyRssPayloads && !summary) {
+      const rssDetailInvalidation = rssDetailInvalidationFrom(payloads);
+      if (!rssDetailInvalidation) return;
+      const effects = invalidationEffects(
+        [rssDetailInvalidation],
+        activeTarget,
+      );
+      return {
+        dirtyTargets: [
+          ...(effects?.repairTargets ?? []),
+          ...(effects?.dirtyTargets ?? []),
+        ],
+      };
+    }
     if (summary) {
       performanceMark("serial:rss-complete");
       const repairTargets: ReconciliationTarget[] = [];
@@ -418,9 +521,15 @@ const runtime = createReconciliationRuntime<PublishedChunk[]>({
         repairIntent: { type: "targeted", targets: repairTargets } as const,
       };
     }
-    if (invalidationEffects) return invalidationEffects;
+    if (mutationEffects) return mutationEffects;
     return;
   },
+  getLiveEventTargets: (payloads, { hydratedDomains }) =>
+    liveEventTargets(
+      payloads,
+      currentSelection(),
+      hydratedDomains.organization && hydratedDomains["active-scope"],
+    ),
   getCurrentSelection: currentSelection,
   mark: performanceMark,
   onParityApplied: ({ automaticRssOwner, reconciliationId }) => {

--- a/apps/app/src/lib/data/reconciliationPage.ts
+++ b/apps/app/src/lib/data/reconciliationPage.ts
@@ -1,6 +1,6 @@
 import { getDefaultStore } from "jotai";
 import { bookmarksStore } from "./bookmarks/store";
-import { getFeedItemMembershipRevision } from "./feed-items/membershipRevision";
+import { getMixedContentMembershipRevision } from "./mixed-content/membershipRevision";
 import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
 import { feedItemsStore } from "./store";
 import { viewsStore } from "./views/store";
@@ -35,7 +35,9 @@ function removeFeedItem(id: string) {
 }
 
 export function applyReconciliationFirstPage(page: ActiveFirstPageResult) {
-  if (page.membershipRevision !== getFeedItemMembershipRevision()) return false;
+  if (page.membershipRevision !== getMixedContentMembershipRevision()) {
+    return false;
+  }
 
   const feedItemUpserts: ApplicationFeedItem[] = [];
   for (const diff of page.feedItemDiffs) {

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -8,6 +8,7 @@ import {
 } from "./mixed-content/store";
 import { viewsStore } from "./views/store";
 import { isBookmarkProjectionChange } from "./mixed-content/bookmarkProjection";
+import { advanceMixedContentMembershipRevision } from "./mixed-content/membershipRevision";
 import { refreshNavigationSnapshotSafely } from "./navigation/store";
 import { hasFeedItemListProjectionChanged } from "./feed-items/listProjection";
 import type { LoadedMixedScope } from "./mixed-content/store";
@@ -56,6 +57,7 @@ export function applyPublishedChunks(
   options: { refreshNavigation?: boolean } = {},
 ) {
   const affectedScopes = new Map<string, LoadedMixedScope>();
+  let bookmarkProjectionChanged = false;
   let navigationSnapshotChanged = payloads.some(
     ({ chunk }) =>
       "refreshNavigationSnapshot" in chunk &&
@@ -112,11 +114,14 @@ export function applyPublishedChunks(
       const previousBookmark = bookmarksStore
         .getState()
         .getBookmark(chunk.bookmark.id);
-      bookmarksStore.getState().upsert(chunk.bookmark);
-      navigationSnapshotChanged ||= isBookmarkProjectionChange(
+      const projectionChanged = isBookmarkProjectionChange(
         previousBookmark,
         chunk.bookmark,
       );
+      bookmarkProjectionChanged ||=
+        chunk.affectsListProjection !== false && projectionChanged;
+      bookmarksStore.getState().upsert(chunk.bookmark);
+      navigationSnapshotChanged ||= projectionChanged;
       const affected = mixedContentStore.getState().reprojectUpsert({
         bookmark: chunk.bookmark,
         previousBookmark,
@@ -140,6 +145,14 @@ export function applyPublishedChunks(
           bookmarksStore.getState().getBookmark(bookmark.id),
         ]),
       );
+      bookmarkProjectionChanged ||=
+        retainedBookmarks.length < chunk.bookmarks.length ||
+        retainedBookmarks.some((bookmark) =>
+          isBookmarkProjectionChange(
+            previousBookmarks.get(bookmark.id),
+            bookmark,
+          ),
+        );
       bookmarksStore.getState().upsertMany(retainedBookmarks);
       for (const bookmark of retainedBookmarks) {
         navigationSnapshotChanged ||= isBookmarkProjectionChange(
@@ -160,6 +173,7 @@ export function applyPublishedChunks(
       }
       continue;
     }
+    bookmarkProjectionChanged = true;
     navigationSnapshotChanged = true;
     bookmarksStore.getState().remove(chunk.id);
     const affected = mixedContentStore.getState().reprojectDeletion({
@@ -171,6 +185,9 @@ export function applyPublishedChunks(
         scope,
       );
     }
+  }
+  if (bookmarkProjectionChanged) {
+    advanceMixedContentMembershipRevision();
   }
   if (navigationSnapshotChanged && options.refreshNavigation !== false) {
     void refreshNavigationSnapshotSafely();

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -1,7 +1,11 @@
 import { bookmarksStore } from "./bookmarks/store";
 import { feedCategoriesStore } from "./feed-categories/store";
 import { feedItemsStore } from "./store";
-import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
+import {
+  getMixedScopeKey,
+  hasBookmarkBodyOwner,
+  mixedContentStore,
+} from "./mixed-content/store";
 import { viewsStore } from "./views/store";
 import { isBookmarkProjectionChange } from "./mixed-content/bookmarkProjection";
 import { refreshNavigationSnapshotSafely } from "./navigation/store";
@@ -99,6 +103,12 @@ export function applyPublishedChunks(
     if (payload.source !== "bookmark") continue;
     const { chunk } = payload;
     if (chunk.type === "bookmark-upsert") {
+      if (
+        !hasBookmarkBodyOwner(chunk.bookmark.id) &&
+        chunk.affectsListProjection === false
+      ) {
+        continue;
+      }
       const previousBookmark = bookmarksStore
         .getState()
         .getBookmark(chunk.bookmark.id);
@@ -121,14 +131,17 @@ export function applyPublishedChunks(
       continue;
     }
     if (chunk.type === "bookmark-upsert-batch") {
+      const retainedBookmarks = chunk.bookmarks.filter((bookmark) =>
+        hasBookmarkBodyOwner(bookmark.id),
+      );
       const previousBookmarks = new Map(
-        chunk.bookmarks.map((bookmark) => [
+        retainedBookmarks.map((bookmark) => [
           bookmark.id,
           bookmarksStore.getState().getBookmark(bookmark.id),
         ]),
       );
-      bookmarksStore.getState().upsertMany(chunk.bookmarks);
-      for (const bookmark of chunk.bookmarks) {
+      bookmarksStore.getState().upsertMany(retainedBookmarks);
+      for (const bookmark of retainedBookmarks) {
         navigationSnapshotChanged ||= isBookmarkProjectionChange(
           previousBookmarks.get(bookmark.id),
           bookmark,

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -71,6 +71,8 @@ type BufferedLiveEvent<TLiveEvent> = {
   payload: TLiveEvent;
 };
 
+const ALL_SCOPE_TARGETS_KEY = "scope:*";
+
 type BufferedApplication<TAuthoritative, TLiveEvent> =
   BufferedAuthoritative<TAuthoritative> | BufferedLiveEvent<TLiveEvent>;
 
@@ -155,6 +157,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       type: "live-event-received";
       eventId: string;
       targets: ReconciliationTarget[];
+      affectsAllScopes?: boolean;
       requiresHydration: ReconciliationHydrationDomain[];
       payload?: TLiveEvent;
       invalidates?: ReconciliationTarget[];
@@ -494,7 +497,14 @@ function isHydrated<TAuthoritative, TLiveEvent>(
 }
 
 function targetKeysOverlap(left: readonly string[], right: Set<string>) {
-  return left.some((key) => right.has(key));
+  const leftAffectsAllScopes = left.includes(ALL_SCOPE_TARGETS_KEY);
+  const rightAffectsAllScopes = right.has(ALL_SCOPE_TARGETS_KEY);
+  return (
+    left.some((key) => right.has(key)) ||
+    (leftAffectsAllScopes &&
+      [...right].some((key) => key.startsWith("scope:"))) ||
+    (rightAffectsAllScopes && left.some((key) => key.startsWith("scope:")))
+  );
 }
 
 function hasPendingTargetOverlap<TAuthoritative, TLiveEvent>(
@@ -547,6 +557,7 @@ function flushBufferedApplications<TAuthoritative, TLiveEvent>(
   const remaining: Array<BufferedApplication<TAuthoritative, TLiveEvent>> = [];
   const commands: Array<ReconciliationCommand<TAuthoritative, TLiveEvent>> = [];
   const staleTargets: ReconciliationTarget[] = [];
+  const invalidatedStaleTargetKeys = new Set<string>();
   for (const application of state.bufferedApplications) {
     const blocked =
       !isHydrated(state, application.requiresHydration) ||
@@ -578,6 +589,17 @@ function flushBufferedApplications<TAuthoritative, TLiveEvent>(
       )
     ) {
       staleTargets.push(application.target);
+      const targetKey = getReconciliationTargetKey(application.target);
+      const capturedRevision =
+        state.requests[application.reconciliationId]?.capturedRevisions[
+          targetKey
+        ];
+      if (
+        capturedRevision !== undefined &&
+        capturedRevision < targetState(state, application.target).revision
+      ) {
+        invalidatedStaleTargetKeys.add(targetKey);
+      }
       continue;
     }
     commands.push({
@@ -594,9 +616,25 @@ function flushBufferedApplications<TAuthoritative, TLiveEvent>(
   });
   if (staleTargets.length === 0) return { state: nextState, commands };
   nextState = markTargetsDirty(nextState, staleTargets, false);
+  const targetsWithoutCurrentRepair = staleTargets.filter((target) => {
+    if (!invalidatedStaleTargetKeys.has(getReconciliationTargetKey(target))) {
+      return true;
+    }
+    return (
+      !nextState.inFlight ||
+      !requestRevisionIsCurrent(
+        nextState,
+        nextState.inFlight.reconciliationId,
+        target,
+      )
+    );
+  });
+  if (targetsWithoutCurrentRepair.length === 0) {
+    return { state: nextState, commands };
+  }
   const queued = enqueueRequest(
     nextState,
-    repairIntentFor(nextState, staleTargets),
+    repairIntentFor(nextState, targetsWithoutCurrentRepair),
   );
   return { state: queued.state, commands: [...commands, ...queued.commands] };
 }
@@ -822,7 +860,10 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
       if (event.payload === undefined) {
         return { state: withDerivedTrust(nextState), commands };
       }
-      const targetKeys = event.targets.map(getReconciliationTargetKey);
+      const targetKeys = [
+        ...event.targets.map(getReconciliationTargetKey),
+        ...(event.affectsAllScopes ? [ALL_SCOPE_TARGETS_KEY] : []),
+      ];
       const hasEarlierBlockedTarget = hasPendingTargetOverlap(
         nextState,
         targetKeys,

--- a/apps/app/src/lib/reconciliation/coordinator.ts
+++ b/apps/app/src/lib/reconciliation/coordinator.ts
@@ -89,6 +89,7 @@ export type ReconciliationCoordinatorState<
   dirtyTargets: Record<string, ReconciliationTarget>;
   hydratedDomains: Record<ReconciliationHydrationDomain, boolean>;
   bufferedApplications: Array<BufferedApplication<TAuthoritative, TLiveEvent>>;
+  applyingLiveEvents: Record<string, string[]>;
   latestFullEpoch: FullEpoch | null;
   activeScope: ReconciliationScopeTarget | null;
   cacheUsableAt: number | null;
@@ -159,6 +160,7 @@ export type ReconciliationCoordinatorEvent<TAuthoritative, TLiveEvent> =
       invalidates?: ReconciliationTarget[];
       repairIntent?: ReconciliationRequestIntent;
     }
+  | { type: "live-event-applied"; eventId: string }
   | {
       type: "targets-dirtied";
       targets: ReconciliationTarget[];
@@ -220,6 +222,7 @@ export function createReconciliationCoordinatorState<
     dirtyTargets: {},
     hydratedDomains: initialHydrationState(),
     bufferedApplications: [],
+    applyingLiveEvents: {},
     latestFullEpoch: null,
     activeScope: null,
     cacheUsableAt: null,
@@ -494,6 +497,21 @@ function targetKeysOverlap(left: readonly string[], right: Set<string>) {
   return left.some((key) => right.has(key));
 }
 
+function hasPendingTargetOverlap<TAuthoritative, TLiveEvent>(
+  state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
+  targetKeys: readonly string[],
+) {
+  const targetKeySet = new Set(targetKeys);
+  return (
+    state.bufferedApplications.some((application) =>
+      targetKeysOverlap(application.targetKeys, targetKeySet),
+    ) ||
+    Object.values(state.applyingLiveEvents).some((applyingTargetKeys) =>
+      targetKeysOverlap(applyingTargetKeys, targetKeySet),
+    )
+  );
+}
+
 function requestRevisionIsCurrent<TAuthoritative, TLiveEvent>(
   state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
   reconciliationId: string,
@@ -522,7 +540,10 @@ function bufferApplication<TAuthoritative, TLiveEvent>(
 function flushBufferedApplications<TAuthoritative, TLiveEvent>(
   state: ReconciliationCoordinatorState<TAuthoritative, TLiveEvent>,
 ): ReconciliationCoordinatorTransition<TAuthoritative, TLiveEvent> {
-  const blockedTargetKeys = new Set<string>();
+  const applyingLiveEvents = { ...state.applyingLiveEvents };
+  const blockedTargetKeys = new Set(
+    Object.values(applyingLiveEvents).flatMap((targetKeys) => targetKeys),
+  );
   const remaining: Array<BufferedApplication<TAuthoritative, TLiveEvent>> = [];
   const commands: Array<ReconciliationCommand<TAuthoritative, TLiveEvent>> = [];
   const staleTargets: ReconciliationTarget[] = [];
@@ -543,6 +564,10 @@ function flushBufferedApplications<TAuthoritative, TLiveEvent>(
         eventId: application.eventId,
         payload: application.payload,
       });
+      applyingLiveEvents[application.eventId] = application.targetKeys;
+      for (const targetKey of application.targetKeys) {
+        blockedTargetKeys.add(targetKey);
+      }
       continue;
     }
     if (
@@ -565,6 +590,7 @@ function flushBufferedApplications<TAuthoritative, TLiveEvent>(
   let nextState = withDerivedTrust({
     ...state,
     bufferedApplications: remaining,
+    applyingLiveEvents,
   });
   if (staleTargets.length === 0) return { state: nextState, commands };
   nextState = markTargetsDirty(nextState, staleTargets, false);
@@ -615,13 +641,13 @@ function deriveTrustedUpToDate<TAuthoritative, TLiveEvent>(
       ? [getReconciliationTargetKey(state.activeScope)]
       : []),
   ]);
-  const hasBufferedAuthoritative = state.bufferedApplications.some(
-    (application) =>
-      application.type === "authoritative" &&
-      application.targetKeys.some((targetKey) =>
-        requiredTargetKeys.has(targetKey),
-      ),
-  );
+  const hasPendingRequiredApplication =
+    state.bufferedApplications.some((application) =>
+      targetKeysOverlap(application.targetKeys, requiredTargetKeys),
+    ) ||
+    Object.values(state.applyingLiveEvents).some((targetKeys) =>
+      targetKeysOverlap(targetKeys, requiredTargetKeys),
+    );
   return Boolean(
     state.cacheUsableAt !== null &&
     state.latestFullEpoch?.established &&
@@ -630,7 +656,7 @@ function deriveTrustedUpToDate<TAuthoritative, TLiveEvent>(
     [...requiredTargetKeys].every(
       (targetKey) => state.dirtyTargets[targetKey] === undefined,
     ) &&
-    !hasBufferedAuthoritative,
+    !hasPendingRequiredApplication,
   );
 }
 
@@ -725,9 +751,9 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
         );
       }
       const targetKeys = [getReconciliationTargetKey(event.target)];
-      const hasEarlierBlockedTarget = state.bufferedApplications.some(
-        (application) =>
-          targetKeysOverlap(application.targetKeys, new Set(targetKeys)),
+      const hasEarlierBlockedTarget = hasPendingTargetOverlap(
+        state,
+        targetKeys,
       );
       if (
         !isHydrated(state, event.requiresHydration) ||
@@ -797,12 +823,9 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
         return { state: withDerivedTrust(nextState), commands };
       }
       const targetKeys = event.targets.map(getReconciliationTargetKey);
-      const targetKeySet = new Set(targetKeys);
-      const hasEarlierBlockedTarget = nextState.bufferedApplications.some(
-        (application) =>
-          application.targetKeys.some((targetKey) =>
-            targetKeySet.has(targetKey),
-          ),
+      const hasEarlierBlockedTarget = hasPendingTargetOverlap(
+        nextState,
+        targetKeys,
       );
       if (
         !isHydrated(nextState, event.requiresHydration) ||
@@ -820,7 +843,13 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
         };
       }
       return {
-        state: nextState,
+        state: withDerivedTrust({
+          ...nextState,
+          applyingLiveEvents: {
+            ...nextState.applyingLiveEvents,
+            [event.eventId]: targetKeys,
+          },
+        }),
         commands: [
           ...commands,
           {
@@ -830,6 +859,11 @@ export function transitionReconciliation<TAuthoritative, TLiveEvent>(
           },
         ],
       };
+    }
+    case "live-event-applied": {
+      const applyingLiveEvents = { ...state.applyingLiveEvents };
+      delete applyingLiveEvents[event.eventId];
+      return flushBufferedApplications({ ...state, applyingLiveEvents });
     }
     case "request-settled": {
       let nextState = state;

--- a/apps/app/src/lib/reconciliation/runtime.ts
+++ b/apps/app/src/lib/reconciliation/runtime.ts
@@ -50,6 +50,15 @@ export type ReconciliationRuntimeDependencies<TLiveEvent> = {
         repairIntent?: ReconciliationRequestIntent;
       }
     | void;
+  getLiveEventTargets: (
+    payload: TLiveEvent,
+    context: {
+      hydratedDomains: ReconciliationCoordinatorState["hydratedDomains"];
+    },
+  ) => {
+    targets: ReconciliationTarget[];
+    affectsAllScopes?: boolean;
+  };
   getCurrentSelection: () => ReconciliationScopeTarget | null;
   isVisible?: () => boolean;
   isOnline?: () => boolean;
@@ -575,11 +584,15 @@ export function createReconciliationRuntime<TLiveEvent>(
       send({ type: "request-reconciliation", intent: pending });
     },
     receiveLiveEvent(payload: TLiveEvent) {
-      const selectedScope = dependencies.getCurrentSelection();
+      const { targets, affectsAllScopes } = dependencies.getLiveEventTargets(
+        payload,
+        { hydratedDomains: state.hydratedDomains },
+      );
       send({
         type: "live-event-received",
         eventId: `live:${++liveSequence}`,
-        targets: selectedScope ? [selectedScope] : [],
+        targets,
+        affectsAllScopes,
         requiresHydration: ["organization", "active-scope", "bookmarks"],
         payload,
       });

--- a/apps/app/src/lib/reconciliation/runtime.ts
+++ b/apps/app/src/lib/reconciliation/runtime.ts
@@ -267,6 +267,7 @@ export function createReconciliationRuntime<TLiveEvent>(
             requiresHydration: [],
           });
         }
+        send({ type: "live-event-applied", eventId: command.eventId });
         continue;
       }
       const applied = dependencies.applyAuthoritative(command.payload, {

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -150,6 +150,8 @@ export const updateState = protectedProcedure
       userId: context.user.id,
       bookmarkId: bookmark.id,
       previousBookmark,
+      affectsListProjection:
+        input.isSaved !== undefined || input.isRead !== undefined,
     });
     return applicationBookmark ?? bookmark;
   });

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -11,6 +11,7 @@ import {
 } from "~/server/bookmarks/service";
 import { normalizeBookmarkUrl } from "~/server/bookmarks/url";
 import {
+  publishBookmarkConsolidationDeletions,
   publishBookmarkDeletion,
   publishBookmarkUpsert,
   publishBookmarkUpsertBatch,
@@ -67,16 +68,11 @@ export const save = protectedProcedure
     const removedBookmarkIds =
       result.removedBookmarkIds ??
       (result.removedBookmarkId ? [result.removedBookmarkId] : []);
-    await Promise.all(
-      removedBookmarkIds.map((removedBookmarkId) =>
-        publishBookmarkDeletion({
-          userId: context.user.id,
-          id: removedBookmarkId,
-          canonicalUrl: result.bookmark.canonicalUrl,
-          invalidation: null,
-        }),
-      ),
-    );
+    await publishBookmarkConsolidationDeletions({
+      userId: context.user.id,
+      bookmarkIds: removedBookmarkIds,
+      canonicalUrl: result.bookmark.canonicalUrl,
+    });
     const applicationBookmark = await publishBookmarkUpsert({
       database: context.db,
       userId: context.user.id,

--- a/apps/app/src/server/mixed-content/events.ts
+++ b/apps/app/src/server/mixed-content/events.ts
@@ -13,7 +13,11 @@ import { buildBookmarkInvalidationSummary } from "~/lib/reconciliation";
 type MixedContentDatabase = typeof defaultDatabase;
 
 export type BookmarkPublishedChunk =
-  | { type: "bookmark-upsert"; bookmark: ApplicationBookmark }
+  | {
+      type: "bookmark-upsert";
+      bookmark: ApplicationBookmark;
+      affectsListProjection?: boolean;
+    }
   | { type: "bookmark-upsert-batch"; bookmarks: ApplicationBookmark[] }
   | { type: "bookmark-delete"; id: string; canonicalUrl: string };
 
@@ -36,12 +40,17 @@ export async function publishBookmarkUpsert(input: {
   previousBookmark?: BookmarkInvalidationState | null;
   contentStatusKeys?: ContentStatusKey[];
   invalidation?: ReconciliationInvalidationSummary;
+  affectsListProjection?: boolean;
 }) {
   const bookmark = await loadApplicationBookmark(input);
   if (!bookmark) return null;
   await publisher.publish(getUserChannel(input.userId), {
     source: "bookmark",
-    chunk: { type: "bookmark-upsert", bookmark },
+    chunk: {
+      type: "bookmark-upsert",
+      bookmark,
+      affectsListProjection: input.affectsListProjection,
+    },
     invalidation:
       input.invalidation ??
       buildBookmarkInvalidationSummary({

--- a/apps/app/src/server/mixed-content/events.ts
+++ b/apps/app/src/server/mixed-content/events.ts
@@ -92,7 +92,7 @@ export async function publishBookmarkDeletion(input: {
   id: string;
   canonicalUrl: string;
   bookmark?: BookmarkInvalidationState;
-  invalidation?: ReconciliationInvalidationSummary | null;
+  invalidation?: ReconciliationInvalidationSummary;
 }) {
   await publisher.publish(getUserChannel(input.userId), {
     source: "bookmark",
@@ -101,18 +101,30 @@ export async function publishBookmarkDeletion(input: {
       id: input.id,
       canonicalUrl: input.canonicalUrl,
     },
-    ...(input.invalidation === null
-      ? {}
-      : {
-          invalidation:
-            input.invalidation ??
-            (input.bookmark
-              ? buildBookmarkInvalidationSummary({ before: input.bookmark })
-              : {
-                  type: "reconciliation-invalidation" as const,
-                  domains: ["navigation" as const],
-                  scopeImpact: { type: "unknown" as const },
-                }),
-        }),
+    invalidation:
+      input.invalidation ??
+      (input.bookmark
+        ? buildBookmarkInvalidationSummary({ before: input.bookmark })
+        : {
+            type: "reconciliation-invalidation" as const,
+            domains: ["navigation" as const],
+            scopeImpact: { type: "unknown" as const },
+          }),
   });
+}
+
+export function publishBookmarkConsolidationDeletions(input: {
+  userId: string;
+  bookmarkIds: string[];
+  canonicalUrl: string;
+}) {
+  return Promise.all(
+    input.bookmarkIds.map((bookmarkId) =>
+      publishBookmarkDeletion({
+        userId: input.userId,
+        id: bookmarkId,
+        canonicalUrl: input.canonicalUrl,
+      }),
+    ),
+  );
 }

--- a/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
+++ b/apps/app/tests/unit/bookmarks/change-aware-projection.test.ts
@@ -16,6 +16,7 @@ import {
 } from "~/lib/data/mixed-content/store";
 import { viewsStore } from "~/lib/data/views/store";
 import { processPublishedChunks } from "~/lib/data/subscriptionCoordinator";
+import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
 import {
   buildContentStatusKey,
   CONTENT_STATUS_FILTERS,
@@ -120,10 +121,17 @@ function loadScope(
   });
 }
 
-function upsertPayload(nextBookmark: ApplicationBookmark): PublishedChunk {
+function upsertPayload(
+  nextBookmark: ApplicationBookmark,
+  affectsListProjection?: boolean,
+): PublishedChunk {
   return {
     source: "bookmark",
-    chunk: { type: "bookmark-upsert", bookmark: nextBookmark },
+    chunk: {
+      type: "bookmark-upsert",
+      bookmark: nextBookmark,
+      affectsListProjection,
+    },
   };
 }
 
@@ -153,29 +161,37 @@ describe("change-aware Bookmark projection", () => {
 
     let mixedNotifications = 0;
     const unsubscribe = mixedContentStore.subscribe(() => mixedNotifications++);
+    const membershipRevision = getMixedContentMembershipRevision();
     const progressAt = new Date(NOW.getTime() + 1);
     const progressResult = processPublishedChunks([
-      upsertPayload({
-        ...saved,
-        progress: 8,
-        progressUpdatedAt: progressAt,
-        updatedAt: progressAt,
-      }),
+      upsertPayload(
+        {
+          ...saved,
+          progress: 8,
+          progressUpdatedAt: progressAt,
+          updatedAt: progressAt,
+        },
+        false,
+      ),
     ]);
     const captureAt = new Date(NOW.getTime() + 2);
     const captureResult = processPublishedChunks([
-      upsertPayload({
-        ...bookmarksStore.getState().getBookmark(saved.id)!,
-        title: "Fresh capture",
-        captureHash: "fresh-hash",
-        capturedAt: captureAt,
-        updatedAt: captureAt,
-      }),
+      upsertPayload(
+        {
+          ...bookmarksStore.getState().getBookmark(saved.id)!,
+          title: "Fresh capture",
+          captureHash: "fresh-hash",
+          capturedAt: captureAt,
+          updatedAt: captureAt,
+        },
+        false,
+      ),
     ]);
     unsubscribe();
 
     expect(progressResult).toEqual([]);
     expect(captureResult).toEqual([]);
+    expect(getMixedContentMembershipRevision()).toBe(membershipRevision);
     expect(mixedNotifications).toBe(0);
     expect(bookmarksStore.getState().getBookmark(saved.id)).toMatchObject({
       progress: 8,

--- a/apps/app/tests/unit/bookmarks/consolidation-publication.test.ts
+++ b/apps/app/tests/unit/bookmarks/consolidation-publication.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { publishBookmarkConsolidationDeletions } from "~/server/mixed-content/events";
+
+const publisherMocks = vi.hoisted(() => ({
+  publish: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("~/server/api/publisher", () => ({
+  publisher: { publish: publisherMocks.publish },
+}));
+
+describe("Bookmark consolidation publication", () => {
+  beforeEach(() => {
+    publisherMocks.publish.mockClear();
+  });
+
+  it("publishes each removed Bookmark with independent invalidation authority", async () => {
+    await publishBookmarkConsolidationDeletions({
+      userId: "user-one",
+      bookmarkIds: ["removed-one", "removed-two"],
+      canonicalUrl: "https://example.com/article",
+    });
+
+    expect(publisherMocks.publish).toHaveBeenCalledTimes(2);
+    expect(publisherMocks.publish.mock.calls).toEqual([
+      [
+        "user:user-one",
+        {
+          source: "bookmark",
+          chunk: {
+            type: "bookmark-delete",
+            id: "removed-one",
+            canonicalUrl: "https://example.com/article",
+          },
+          invalidation: {
+            type: "reconciliation-invalidation",
+            domains: ["navigation"],
+            scopeImpact: { type: "unknown" },
+          },
+        },
+      ],
+      [
+        "user:user-one",
+        {
+          source: "bookmark",
+          chunk: {
+            type: "bookmark-delete",
+            id: "removed-two",
+            canonicalUrl: "https://example.com/article",
+          },
+          invalidation: {
+            type: "reconciliation-invalidation",
+            domains: ["navigation"],
+            scopeImpact: { type: "unknown" },
+          },
+        },
+      ],
+    ]);
+  });
+});

--- a/apps/app/tests/unit/bookmarks/membership-revision.test.ts
+++ b/apps/app/tests/unit/bookmarks/membership-revision.test.ts
@@ -204,6 +204,56 @@ describe("Bookmark mixed-content membership revision", () => {
     expect(revision()).toBe(initialRevision);
   });
 
+  it("drops a delayed progress response after the final body owner is released", () => {
+    const original = bookmark({ tagIds: [20] });
+    bookmarksStore.getState().upsert(original);
+    setRetainedEntityPins("membership-revision:test", {
+      bookmarkIds: [original.id],
+    });
+    mixedContentStore.getState().applyPage({
+      scope: { type: "tag", tagId: 20 },
+      contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
+      page: {
+        references: [],
+        bookmarks: [],
+        feedItems: [],
+        cursor: null,
+        hasMore: false,
+      },
+      replacesScope: true,
+    });
+    const mutation = useUpdateBookmarkStateMutation(
+      original.id,
+    ) as unknown as MutationCallbacks<
+      { bookmarkId: string; progress: number; duration: number },
+      ApplicationBookmark,
+      { previousBookmark?: ApplicationBookmark; token?: object }
+    >;
+    const input = { bookmarkId: original.id, progress: 8, duration: 12 };
+    const initialRevision = revision();
+
+    clearRetainedEntityPins("membership-revision:test");
+    expect(bookmarksStore.getState().getBookmark(original.id)).toBeUndefined();
+    const context = mutation.onMutate(input);
+    mutation.onSuccess(
+      bookmark({
+        tagIds: [20],
+        progress: 8,
+        duration: 12,
+        progressUpdatedAt: new Date(NOW.getTime() + 1),
+        updatedAt: new Date(NOW.getTime() + 1),
+      }),
+      input,
+      context,
+    );
+
+    expect(revision()).toBe(initialRevision);
+    expect(bookmarksStore.getState().getBookmark(original.id)).toBeUndefined();
+    expect(
+      mixedContentStore.getState().scopes["tag:20:saved:unread"]?.references,
+    ).toEqual([]);
+  });
+
   it("pins a Bookmark body until an optimistic membership mutation settles", () => {
     const original = bookmark();
     bookmarksStore.getState().upsert(original);

--- a/apps/app/tests/unit/bookmarks/membership-revision.test.ts
+++ b/apps/app/tests/unit/bookmarks/membership-revision.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+import { mixedContentStore } from "~/lib/data/mixed-content/store";
+import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
+import {
+  clearRetainedEntityPins,
+  getRetainedEntityPins,
+  setRetainedEntityPins,
+} from "~/lib/data/page-retention";
+import {
+  useDeleteBookmarkMutation,
+  useSaveBookmarkMutation,
+  useSetBookmarkTagMutation,
+  useSetBookmarkViewMutation,
+  useUpdateBookmarkStateMutation,
+} from "~/lib/data/bookmarks/mutations";
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: (options: unknown) => options,
+}));
+
+vi.mock("~/lib/orpc", () => {
+  const mutationOptions = (options: unknown) => options;
+  return {
+    orpc: {
+      bookmark: {
+        remove: { mutationOptions },
+        save: { mutationOptions },
+        setTag: { mutationOptions },
+        setView: { mutationOptions },
+        updateState: { mutationOptions },
+      },
+    },
+  };
+});
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+function bookmark(
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  return {
+    id: "bookmark-one",
+    userId: "user-one",
+    sourceUrl: "https://example.com/article",
+    effectiveUrl: "https://example.com/article",
+    canonicalUrl: "https://example.com/article",
+    platform: "website",
+    contentType: "text",
+    orientation: null,
+    contentId: null,
+    classificationSource: "url",
+    classifierVersion: 1,
+    isSaved: true,
+    isRead: false,
+    progress: 4,
+    duration: 10,
+    savedUpdatedAt: NOW,
+    readUpdatedAt: NOW,
+    progressUpdatedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    title: "Article",
+    description: null,
+    author: "Writer",
+    siteName: "example.com",
+    publishedAt: null,
+    iconUrl: null,
+    thumbnailUrl: null,
+    previewSource: "url",
+    captureHash: "capture-hash",
+    capturedAt: NOW,
+    viewIds: [10],
+    tagIds: [],
+    ...overrides,
+  };
+}
+
+type MutationCallbacks<TInput, TResult, TContext> = {
+  onMutate: (input: TInput) => TContext;
+  onSuccess: (result: TResult, input: TInput, context: TContext) => void;
+  onError: (error: unknown, input: TInput, context: TContext) => void;
+};
+
+function revision() {
+  return getMixedContentMembershipRevision();
+}
+
+beforeEach(() => {
+  bookmarksStore.getState().reset();
+  mixedContentStore.getState().reset();
+});
+
+afterEach(() => {
+  clearRetainedEntityPins("membership-revision:test");
+});
+
+describe("Bookmark mixed-content membership revision", () => {
+  it("advances for save, status, View, Tag, delete, and rollback projection changes", () => {
+    const original = bookmark();
+    bookmarksStore.getState().upsert(original);
+    setRetainedEntityPins("membership-revision:test", {
+      bookmarkIds: [original.id],
+    });
+    let expectedRevision = revision();
+
+    const stateMutation = useUpdateBookmarkStateMutation(
+      original.id,
+    ) as unknown as MutationCallbacks<
+      { bookmarkId: string; isSaved: boolean },
+      ApplicationBookmark,
+      { previousBookmark?: ApplicationBookmark; token?: object }
+    >;
+    const stateInput = { bookmarkId: original.id, isSaved: false };
+    const stateContext = stateMutation.onMutate(stateInput);
+    expect(revision()).toBe(++expectedRevision);
+    stateMutation.onError(new Error("failed"), stateInput, stateContext);
+    expect(revision()).toBe(++expectedRevision);
+
+    const viewMutation =
+      useSetBookmarkViewMutation() as unknown as MutationCallbacks<
+        { bookmarkId: string; viewId: number; assigned: boolean },
+        ApplicationBookmark,
+        { previousBookmark?: ApplicationBookmark; token?: object }
+      >;
+    const viewInput = { bookmarkId: original.id, viewId: 11, assigned: true };
+    const viewContext = viewMutation.onMutate(viewInput);
+    expect(revision()).toBe(++expectedRevision);
+    viewMutation.onError(new Error("failed"), viewInput, viewContext);
+    expect(revision()).toBe(++expectedRevision);
+
+    const tagMutation =
+      useSetBookmarkTagMutation() as unknown as MutationCallbacks<
+        { bookmarkId: string; tagId: number; assigned: boolean },
+        ApplicationBookmark,
+        { previousBookmark?: ApplicationBookmark; token?: object }
+      >;
+    const tagInput = { bookmarkId: original.id, tagId: 20, assigned: true };
+    const tagContext = tagMutation.onMutate(tagInput);
+    expect(revision()).toBe(++expectedRevision);
+    tagMutation.onError(new Error("failed"), tagInput, tagContext);
+    expect(revision()).toBe(++expectedRevision);
+
+    const deleteMutation =
+      useDeleteBookmarkMutation() as unknown as MutationCallbacks<
+        { bookmarkId: string },
+        unknown,
+        { previousBookmark?: ApplicationBookmark }
+      >;
+    const deleteInput = { bookmarkId: original.id };
+    const deleteContext = deleteMutation.onMutate(deleteInput);
+    expect(revision()).toBe(++expectedRevision);
+    deleteMutation.onError(new Error("failed"), deleteInput, deleteContext);
+    expect(revision()).toBe(++expectedRevision);
+
+    const saveMutation =
+      useSaveBookmarkMutation() as unknown as MutationCallbacks<
+        unknown,
+        {
+          bookmark: ApplicationBookmark;
+          removedBookmarkIds?: string[];
+          removedBookmarkId?: string;
+        },
+        unknown
+      >;
+    saveMutation.onSuccess(
+      { bookmark: bookmark({ id: "bookmark-two" }) },
+      {},
+      undefined,
+    );
+    expect(revision()).toBe(expectedRevision + 1);
+  });
+
+  it("does not advance for a progress-only write or response", () => {
+    const original = bookmark();
+    bookmarksStore.getState().upsert(original);
+    setRetainedEntityPins("membership-revision:test", {
+      bookmarkIds: [original.id],
+    });
+    const initialRevision = revision();
+    const mutation = useUpdateBookmarkStateMutation(
+      original.id,
+    ) as unknown as MutationCallbacks<
+      { bookmarkId: string; progress: number; duration: number },
+      ApplicationBookmark,
+      { previousBookmark?: ApplicationBookmark; token?: object }
+    >;
+    const input = { bookmarkId: original.id, progress: 8, duration: 12 };
+
+    const context = mutation.onMutate(input);
+    expect(revision()).toBe(initialRevision);
+    mutation.onSuccess(
+      bookmark({
+        progress: 8,
+        duration: 12,
+        progressUpdatedAt: new Date(NOW.getTime() + 1),
+        updatedAt: new Date(NOW.getTime() + 1),
+      }),
+      input,
+      context,
+    );
+
+    expect(revision()).toBe(initialRevision);
+  });
+
+  it("pins a Bookmark body until an optimistic membership mutation settles", () => {
+    const original = bookmark();
+    bookmarksStore.getState().upsert(original);
+    mixedContentStore.getState().applyPage({
+      scope: { type: "view", viewId: 10 },
+      contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
+      page: {
+        references: [
+          {
+            entityKind: "bookmark",
+            entityId: original.id,
+            sectionPlacement: null,
+            normalizedAt: original.savedUpdatedAt,
+          },
+        ],
+        bookmarks: [original],
+        feedItems: [],
+        cursor: null,
+        hasMore: false,
+      },
+      replacesScope: true,
+    });
+    const mutation = useUpdateBookmarkStateMutation(
+      original.id,
+    ) as unknown as MutationCallbacks<
+      { bookmarkId: string; isSaved: boolean },
+      ApplicationBookmark,
+      { previousBookmark?: ApplicationBookmark; token?: object }
+    >;
+    const input = { bookmarkId: original.id, isSaved: false };
+
+    const context = mutation.onMutate(input);
+    expect(getRetainedEntityPins("bookmark")).toContain(original.id);
+    expect(bookmarksStore.getState().getBookmark(original.id)).toBeDefined();
+
+    mutation.onSuccess(
+      bookmark({
+        isSaved: false,
+        savedUpdatedAt: new Date(NOW.getTime() + 1),
+        updatedAt: new Date(NOW.getTime() + 1),
+      }),
+      input,
+      context,
+    );
+    expect(getRetainedEntityPins("bookmark")).not.toContain(original.id);
+    expect(bookmarksStore.getState().getBookmark(original.id)).toBeUndefined();
+  });
+});

--- a/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
@@ -155,6 +155,127 @@ beforeEach(() => {
 });
 
 describe("Bookmark projection events and direct mixed pages", () => {
+  it("rejects an in-flight page after a list-changing Bookmark event", async () => {
+    const savedBookmark = bookmark();
+    const scope = { type: "view" as const, viewId: 10 };
+    const contentStatus = {
+      saveStatus: "saved" as const,
+      archiveStatus: "unread" as const,
+    };
+    const references = [reference("bookmark", savedBookmark.id)];
+    applyRequestedMixedContentPage({
+      scope,
+      contentStatus,
+      page: { ...page(references), bookmarks: [savedBookmark] },
+      replacesScope: true,
+    });
+
+    let resolvePage:
+      | ((value: MixedContentPage | PromiseLike<MixedContentPage>) => void)
+      | undefined;
+    orpcMocks.requestPage.mockReturnValue(
+      new Promise<MixedContentPage>((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    const request = dataRequestActions.requestMixedContentPage(
+      scope,
+      contentStatus,
+    );
+    const revisionBeforeEvent = getMixedContentMembershipRevision();
+    const archivedBookmark = bookmark({
+      isRead: true,
+      readUpdatedAt: new Date(NOW.getTime() + 1),
+      updatedAt: new Date(NOW.getTime() + 1),
+    });
+    const affectedScopes = processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-upsert",
+          bookmark: archivedBookmark,
+          affectsListProjection: true,
+        },
+      },
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-upsert",
+          bookmark: archivedBookmark,
+          affectsListProjection: true,
+        },
+      },
+    ]);
+    resolvePage?.({
+      ...page(references),
+      bookmarks: [savedBookmark],
+    });
+    await request;
+
+    expect(affectedScopes).toHaveLength(1);
+    expect(getMixedContentMembershipRevision()).toBe(revisionBeforeEvent + 1);
+    expect(
+      mixedContentStore.getState().scopes[
+        getMixedScopeKey(scope, contentStatus)
+      ]?.references,
+    ).toEqual([]);
+  });
+
+  it("advances membership once for retained Bookmark batches and deletions", () => {
+    const first = bookmark({ id: "batch-one" });
+    const second = bookmark({ id: "batch-two" });
+    const scope = { type: "view" as const, viewId: 10 };
+    const contentStatus = {
+      saveStatus: "saved" as const,
+      archiveStatus: "unread" as const,
+    };
+    applyRequestedMixedContentPage({
+      scope,
+      contentStatus,
+      page: {
+        ...page([
+          reference("bookmark", first.id),
+          reference("bookmark", second.id),
+        ]),
+        bookmarks: [first, second],
+      },
+      replacesScope: true,
+    });
+    const revisionBeforeBatch = getMixedContentMembershipRevision();
+
+    const affectedByBatch = processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-upsert-batch",
+          bookmarks: [
+            bookmark({ id: first.id, isRead: true }),
+            bookmark({ id: second.id, isRead: true }),
+          ],
+        },
+      },
+    ]);
+
+    expect(affectedByBatch).toHaveLength(1);
+    expect(getMixedContentMembershipRevision()).toBe(revisionBeforeBatch + 1);
+
+    const revisionBeforeDeletion = getMixedContentMembershipRevision();
+    processPublishedChunks([
+      {
+        source: "bookmark",
+        chunk: {
+          type: "bookmark-delete",
+          id: first.id,
+          canonicalUrl: first.canonicalUrl,
+        },
+      },
+    ]);
+
+    expect(getMixedContentMembershipRevision()).toBe(
+      revisionBeforeDeletion + 1,
+    );
+  });
+
   it("rejects an in-flight page after a mixed Bookmark read mutation", async () => {
     const savedBookmark = bookmark();
     const scope = { type: "view" as const, viewId: 10 };

--- a/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
@@ -22,12 +22,16 @@ import {
   partitionMixedReadTargets,
   setMixedReadValue,
 } from "~/lib/data/mixed-content/mutations";
+import { dataRequestActions } from "~/lib/data/directRequests";
+import { applyReconciliationFirstPage } from "~/lib/data/reconciliationPage";
+import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
 
 const NOW = new Date("2026-07-30T12:00:00.000Z");
 
 const orpcMocks = vi.hoisted(() => ({
   setBookmarkBulkReadValue: vi.fn(),
   setFeedBulkWatchedValue: vi.fn(),
+  requestPage: vi.fn(),
 }));
 
 vi.mock("~/lib/orpc", () => ({
@@ -35,6 +39,7 @@ vi.mock("~/lib/orpc", () => ({
   orpcRouterClient: {
     bookmark: { setBulkReadValue: orpcMocks.setBookmarkBulkReadValue },
     feedItem: { setBulkWatchedValue: orpcMocks.setFeedBulkWatchedValue },
+    mixedContent: { requestPage: orpcMocks.requestPage },
   },
 }));
 
@@ -150,6 +155,102 @@ beforeEach(() => {
 });
 
 describe("Bookmark projection events and direct mixed pages", () => {
+  it("rejects an in-flight page after a mixed Bookmark read mutation", async () => {
+    const savedBookmark = bookmark();
+    const scope = { type: "view" as const, viewId: 10 };
+    const contentStatus = {
+      saveStatus: "saved" as const,
+      archiveStatus: "unread" as const,
+    };
+    const references = [reference("bookmark", savedBookmark.id)];
+    applyRequestedMixedContentPage({
+      scope,
+      contentStatus,
+      page: { ...page(references), bookmarks: [savedBookmark] },
+      replacesScope: true,
+    });
+
+    let resolvePage:
+      | ((value: MixedContentPage | PromiseLike<MixedContentPage>) => void)
+      | undefined;
+    orpcMocks.requestPage.mockReturnValue(
+      new Promise<MixedContentPage>((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    let resolveBulkRead: ((value: unknown[]) => void) | undefined;
+    orpcMocks.setBookmarkBulkReadValue.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveBulkRead = resolve;
+      }),
+    );
+
+    const request = dataRequestActions.requestMixedContentPage(
+      scope,
+      contentStatus,
+    );
+    const mutation = setMixedReadValue({ references, isRead: true });
+    resolvePage?.({
+      ...page(references),
+      bookmarks: [savedBookmark],
+    });
+    await request;
+    const bookmarkAfterRequest = bookmarksStore
+      .getState()
+      .getBookmark(savedBookmark.id);
+    const referencesAfterRequest =
+      mixedContentStore.getState().scopes[
+        getMixedScopeKey(scope, contentStatus)
+      ]?.references;
+    resolveBulkRead?.([]);
+    await mutation;
+
+    expect(bookmarkAfterRequest?.isRead).toBe(true);
+    expect(referencesAfterRequest).toEqual([]);
+  });
+
+  it("rejects stale reconciliation authority after a Bookmark read mutation", async () => {
+    const savedBookmark = bookmark();
+    const scope = { type: "view" as const, viewId: 10 };
+    const contentStatus = {
+      saveStatus: "saved" as const,
+      archiveStatus: "unread" as const,
+    };
+    const references = [reference("bookmark", savedBookmark.id)];
+    applyRequestedMixedContentPage({
+      scope,
+      contentStatus,
+      page: { ...page(references), bookmarks: [savedBookmark] },
+      replacesScope: true,
+    });
+    const membershipRevision = getMixedContentMembershipRevision();
+    let resolveBulkRead: ((value: unknown[]) => void) | undefined;
+    orpcMocks.setBookmarkBulkReadValue.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveBulkRead = resolve;
+      }),
+    );
+
+    const mutation = setMixedReadValue({ references, isRead: true });
+    const applied = applyReconciliationFirstPage({
+      target: { type: "scope", scope, contentStatus },
+      membershipRevision,
+      orderedRefs: references,
+      bookmarkDiffs: [{ status: "upsert", entity: savedBookmark }],
+      feedItemDiffs: [],
+      cursor: null,
+      hasMore: false,
+    });
+    const bookmarkAfterRequest = bookmarksStore
+      .getState()
+      .getBookmark(savedBookmark.id);
+    resolveBulkRead?.([]);
+    await mutation;
+
+    expect(applied).toBe(false);
+    expect(bookmarkAfterRequest?.isRead).toBe(true);
+  });
+
   it("projects locally cached Bookmarks only into their owned Views", () => {
     const assigned = bookmark({ id: "assigned", viewIds: [10] });
     const unassigned = bookmark({ id: "unassigned", viewIds: [] });
@@ -307,7 +408,7 @@ describe("Bookmark projection events and direct mixed pages", () => {
       scope: { type: "view", viewId: 10 },
       contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
       page: {
-        ...page([]),
+        ...page(bookmarks.map((item) => reference("bookmark", item.id))),
         bookmarks,
         feedItems: items,
       },
@@ -464,11 +565,14 @@ describe("Bookmark projection events and direct mixed pages", () => {
     for (const item of [matchingOne, matchingTwo, other]) {
       feedItemsStore.getState().setFeedItem(item.id, item);
     }
+    const existing = bookmark({ isSaved: false });
+    bookmarksStore.getState().upsert(existing);
     const scope = { type: "view" as const, viewId: 10 };
     mixedContentStore.getState().applyPage({
       scope,
       contentStatus: { saveStatus: "inbox", archiveStatus: "unread" },
       page: page([
+        reference("bookmark", existing.id),
         reference("feed-item", matchingOne.id),
         reference("feed-item", matchingTwo.id),
         reference("feed-item", other.id),
@@ -495,7 +599,7 @@ describe("Bookmark projection events and direct mixed pages", () => {
         chunk: { type: "bookmark-upsert", bookmark: saved },
       },
     ]);
-    expect(affectedOnSave).toHaveLength(1);
+    expect(affectedOnSave).toHaveLength(2);
     expect(
       mixedContentStore.getState().scopes[
         getMixedScopeKey(scope, {
@@ -556,6 +660,15 @@ describe("Bookmark projection events and direct mixed pages", () => {
   it("commits a bulk Bookmark upsert with one entity-store notification", () => {
     const first = bookmark({ id: "batch-one" });
     const second = bookmark({ id: "batch-two" });
+    mixedContentStore.getState().applyPage({
+      scope: { type: "view", viewId: 10 },
+      contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
+      page: page([
+        reference("bookmark", first.id),
+        reference("bookmark", second.id),
+      ]),
+      replacesScope: true,
+    });
     let notifications = 0;
     const unsubscribe = bookmarksStore.subscribe(() => notifications++);
 

--- a/apps/app/tests/unit/data/bookmark-normalized-persistence.test.ts
+++ b/apps/app/tests/unit/data/bookmark-normalized-persistence.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+
+const indexedDb = vi.hoisted(() => ({
+  entries: new Map<IDBValidKey, unknown>(),
+}));
+
+function cloneStoredValue<T>(value: T): T {
+  return value === undefined ? value : structuredClone(value);
+}
+
+vi.mock("idb-keyval", () => ({
+  clear: vi.fn(() => Promise.resolve(indexedDb.entries.clear())),
+  del: vi.fn((key: IDBValidKey) =>
+    Promise.resolve(indexedDb.entries.delete(key)),
+  ),
+  delMany: vi.fn((keys: IDBValidKey[]) => {
+    for (const key of keys) indexedDb.entries.delete(key);
+    return Promise.resolve();
+  }),
+  get: vi.fn((key: IDBValidKey) =>
+    Promise.resolve(cloneStoredValue(indexedDb.entries.get(key))),
+  ),
+  getMany: vi.fn((keys: IDBValidKey[]) =>
+    Promise.resolve(
+      keys.map((key) => cloneStoredValue(indexedDb.entries.get(key))),
+    ),
+  ),
+  keys: vi.fn(() => Promise.resolve([...indexedDb.entries.keys()])),
+  set: vi.fn((key: IDBValidKey, value: unknown) => {
+    indexedDb.entries.set(key, cloneStoredValue(value));
+    return Promise.resolve();
+  }),
+  setMany: vi.fn((entries: Array<[IDBValidKey, unknown]>) => {
+    for (const [key, value] of entries) {
+      indexedDb.entries.set(key, cloneStoredValue(value));
+    }
+    return Promise.resolve();
+  }),
+}));
+
+type PersistedStore = {
+  persist: {
+    hasHydrated: () => boolean;
+    rehydrate: () => Promise<void> | void;
+  };
+};
+
+function bookmark(
+  id: string,
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  const now = new Date(Date.UTC(2026, 0, 1));
+  return {
+    id,
+    userId: "user-one",
+    sourceUrl: `https://example.com/${id}`,
+    effectiveUrl: `https://example.com/${id}`,
+    canonicalUrl: `https://example.com/${id}`,
+    platform: "website",
+    contentType: "text",
+    orientation: null,
+    contentId: null,
+    classificationSource: "url",
+    classifierVersion: 1,
+    isSaved: true,
+    isRead: false,
+    progress: 0,
+    duration: 0,
+    savedUpdatedAt: now,
+    readUpdatedAt: now,
+    progressUpdatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    title: id,
+    description: null,
+    author: null,
+    siteName: "example.com",
+    publishedAt: null,
+    iconUrl: null,
+    thumbnailUrl: null,
+    previewSource: "url",
+    captureHash: null,
+    capturedAt: null,
+    viewIds: [],
+    tagIds: [],
+    ...overrides,
+  };
+}
+
+async function importHydratedBookmarkStore() {
+  const { bookmarksStore } = await import("~/lib/data/bookmarks/store");
+  const persistence = bookmarksStore as typeof bookmarksStore & PersistedStore;
+  await persistence.persist.rehydrate();
+  expect(persistence.persist.hasHydrated()).toBe(true);
+  return bookmarksStore;
+}
+
+function flushOnPageHide() {
+  window.dispatchEvent(new Event("pagehide"));
+}
+
+afterEach(() => {
+  indexedDb.entries.clear();
+  vi.resetModules();
+});
+
+describe("Bookmark normalized persistence", () => {
+  it("reloads retained upserts after an earlier flush and omits evicted bodies", async () => {
+    const bookmarksStore = await importHydratedBookmarkStore();
+    const retained = bookmark("retained");
+    const retainedMany = bookmark("retained-many");
+    const evicted = bookmark("evicted");
+
+    bookmarksStore.getState().upsertMany([retained, retainedMany, evicted]);
+    flushOnPageHide();
+    await vi.waitFor(() =>
+      expect(
+        [...indexedDb.entries.keys()].filter(
+          (key) =>
+            typeof key === "string" && key.includes("record:bookmarksDict:"),
+        ),
+      ).toHaveLength(3),
+    );
+
+    bookmarksStore.getState().upsert(bookmark(retained.id, { progress: 10 }));
+    bookmarksStore
+      .getState()
+      .upsertMany([
+        bookmark(retainedMany.id, { progress: 20 }),
+        bookmark("pinned", { progress: 30 }),
+      ]);
+    bookmarksStore
+      .getState()
+      .pruneExcept(new Set([retained.id, retainedMany.id, "pinned"]));
+    flushOnPageHide();
+    await vi.waitFor(() =>
+      expect(
+        [...indexedDb.entries.keys()].some(
+          (key) => typeof key === "string" && key.endsWith("evicted"),
+        ),
+      ).toBe(false),
+    );
+
+    vi.resetModules();
+    const reloadedStore = await importHydratedBookmarkStore();
+
+    expect(reloadedStore.getState().getBookmark(retained.id)?.progress).toBe(
+      10,
+    );
+    expect(
+      reloadedStore.getState().getBookmark(retainedMany.id)?.progress,
+    ).toBe(20);
+    expect(reloadedStore.getState().getBookmark("pinned")?.progress).toBe(30);
+    expect(reloadedStore.getState().getBookmark(evicted.id)).toBeUndefined();
+  });
+});

--- a/apps/app/tests/unit/data/direct-request-transport.test.ts
+++ b/apps/app/tests/unit/data/direct-request-transport.test.ts
@@ -7,7 +7,7 @@ import {
 } from "~/lib/data/mixed-content/store";
 import { feedItemsStore } from "~/lib/data/store";
 import { loadingActor } from "~/lib/data/loading-machine";
-import { advanceFeedItemMembershipRevision } from "~/lib/data/feed-items/membershipRevision";
+import { advanceMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
 
 const mocks = vi.hoisted(() => ({
   invalidateQueries: vi.fn(),
@@ -124,7 +124,7 @@ describe("direct request transport", () => {
       scope,
       contentStatus,
     );
-    advanceFeedItemMembershipRevision();
+    advanceMixedContentMembershipRevision();
     resolvePage?.({
       references: [],
       bookmarks: [],

--- a/apps/app/tests/unit/data/mixed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/mixed-page-retention.test.ts
@@ -1,16 +1,20 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import type {
+  ApplicationBookmark,
   MixedContentCursor,
   MixedContentReference,
 } from "~/server/mixed-content/projection";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import {
   clearRetainedEntityPins,
+  cursorRetentionKey,
   setRetainedEntityPins,
 } from "~/lib/data/page-retention";
 import {
   getMixedScopeKey,
   mixedContentStore,
+  synchronizeBookmarkBodyRetention,
 } from "~/lib/data/mixed-content/store";
 import { CONTENT_STATUS_FILTERS } from "~/lib/content-status";
 
@@ -34,6 +38,56 @@ function references(pageIndex: number): MixedContentReference[] {
   }));
 }
 
+function bookmark(id: string): ApplicationBookmark {
+  const now = new Date(Date.UTC(2026, 0, 1));
+  return {
+    id,
+    userId: "user-one",
+    sourceUrl: `https://example.com/${id}`,
+    effectiveUrl: `https://example.com/${id}`,
+    canonicalUrl: `https://example.com/${id}`,
+    platform: "website",
+    contentType: "text",
+    orientation: null,
+    contentId: null,
+    classificationSource: "url",
+    classifierVersion: 1,
+    isSaved: true,
+    isRead: false,
+    progress: 0,
+    duration: 0,
+    savedUpdatedAt: now,
+    readUpdatedAt: now,
+    progressUpdatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    title: id,
+    description: null,
+    author: null,
+    siteName: "example.com",
+    publishedAt: null,
+    iconUrl: null,
+    thumbnailUrl: null,
+    previewSource: "url",
+    captureHash: null,
+    capturedAt: null,
+    viewIds: [],
+    tagIds: [],
+  };
+}
+
+function bookmarkReference(
+  id: string,
+  pageIndex: number,
+): MixedContentReference {
+  return {
+    entityKind: "bookmark",
+    entityId: id,
+    sectionPlacement: null,
+    normalizedAt: new Date(Date.UTC(2026, 0, 1, 0, pageIndex)),
+  };
+}
+
 function applyPages(count: number) {
   for (let pageIndex = 0; pageIndex < count; pageIndex++) {
     mixedContentStore.getState().applyPage({
@@ -53,6 +107,7 @@ function applyPages(count: number) {
 
 afterEach(() => {
   mixedContentStore.getState().reset();
+  bookmarksStore.getState().reset();
   clearRetainedEntityPins("reader:test");
 });
 
@@ -171,5 +226,132 @@ describe("mixed-content page retention", () => {
       1,
     );
     expect(mixedContentStore.getState().scopes[scopeKey]?.hasMore).toBe(false);
+  });
+
+  it("updates first-page pagination authority while retaining an unchanged provisional tail", () => {
+    applyPages(3);
+    const contentStatus = {
+      saveStatus: "inbox",
+      archiveStatus: "unread",
+    } as const;
+    const scopeKey = getMixedScopeKey(SCOPE, contentStatus);
+    const nextCursor = cursor(20);
+
+    expect(
+      mixedContentStore.getState().reconcileFirstPage({
+        scope: SCOPE,
+        contentStatus,
+        page: {
+          references: references(0),
+          bookmarks: [],
+          feedItems: [],
+          cursor: nextCursor,
+          hasMore: false,
+        },
+      }),
+    ).toEqual({ firstPageChanged: false });
+
+    const scope = mixedContentStore.getState().scopes[scopeKey];
+    expect(scope?.references).toHaveLength(90);
+    expect(scope?.cursor).toEqual(nextCursor);
+    expect(scope?.hasMore).toBe(false);
+    expect(
+      scope?.pages.filter((page) => page.requestCursorKey === "root"),
+    ).toHaveLength(1);
+    expect(
+      scope?.pages.find((page) => page.requestCursorKey === "root")
+        ?.nextCursorKey,
+    ).toBe(cursorRetentionKey(nextCursor));
+  });
+
+  it("evicts Bookmark bodies after their last retained page or pin releases them", () => {
+    const contentStatus = {
+      saveStatus: "inbox",
+      archiveStatus: "unread",
+    } as const;
+    const sharedBookmark = bookmark("shared-bookmark");
+    const pinnedBookmark = bookmark("pinned-bookmark");
+    bookmarksStore.getState().upsert(pinnedBookmark);
+    setRetainedEntityPins("reader:test", {
+      bookmarkIds: [pinnedBookmark.id],
+    });
+
+    for (let pageIndex = 0; pageIndex < 9; pageIndex++) {
+      const pageBookmark = bookmark(`page-${pageIndex}-bookmark`);
+      const pageBookmarks = [
+        pageBookmark,
+        ...(pageIndex === 0 || pageIndex === 8 ? [sharedBookmark] : []),
+      ];
+      bookmarksStore.getState().upsertMany(pageBookmarks);
+      mixedContentStore.getState().applyPage({
+        scope: SCOPE,
+        contentStatus,
+        page: {
+          references: pageBookmarks.map((item) =>
+            bookmarkReference(item.id, pageIndex),
+          ),
+          bookmarks: pageBookmarks,
+          feedItems: [],
+          cursor: cursor(pageIndex),
+          hasMore: true,
+        },
+        replacesScope: pageIndex === 0,
+      });
+    }
+
+    expect(
+      bookmarksStore.getState().getBookmark("page-0-bookmark"),
+    ).toBeUndefined();
+    expect(bookmarksStore.getState().getBookmark(sharedBookmark.id)).toBe(
+      sharedBookmark,
+    );
+    expect(bookmarksStore.getState().getBookmark(pinnedBookmark.id)).toBe(
+      pinnedBookmark,
+    );
+
+    clearRetainedEntityPins("reader:test");
+    expect(
+      bookmarksStore.getState().getBookmark(pinnedBookmark.id),
+    ).toBeUndefined();
+  });
+
+  it("does not retain a Bookmark upsert with no loaded page or pin owner", () => {
+    const orphan = bookmark("orphan-bookmark");
+    bookmarksStore.getState().upsert(orphan);
+
+    expect(
+      mixedContentStore.getState().reprojectUpsert({
+        bookmark: orphan,
+        previousBookmark: undefined,
+        views: [],
+      }),
+    ).toEqual([]);
+    expect(bookmarksStore.getState().getBookmark(orphan.id)).toBeUndefined();
+  });
+
+  it("prunes bodies restored after mixed-page ownership is already known", () => {
+    const owned = bookmark("owned-bookmark");
+    const stale = bookmark("late-hydration-orphan");
+    mixedContentStore.getState().applyPage({
+      scope: SCOPE,
+      contentStatus: { saveStatus: "saved", archiveStatus: "unread" },
+      page: {
+        references: [bookmarkReference(owned.id, 0)],
+        bookmarks: [owned],
+        feedItems: [],
+        cursor: null,
+        hasMore: false,
+      },
+      replacesScope: true,
+    });
+
+    bookmarksStore.getState().replace({
+      [owned.id]: owned,
+      [stale.id]: stale,
+    });
+    synchronizeBookmarkBodyRetention();
+
+    expect(bookmarksStore.getState().getBookmark(owned.id)).toBe(owned);
+    expect(bookmarksStore.getState().getBookmark(stale.id)).toBeUndefined();
   });
 });

--- a/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
+++ b/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
@@ -17,6 +17,7 @@ import {
 import { viewsStore } from "~/lib/data/views/store";
 import { feedCategoriesStore } from "~/lib/data/feed-categories/store";
 import { bookmarksStore } from "~/lib/data/bookmarks/store";
+import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
 
 function makeItem(
   overrides: Partial<ApplicationFeedItem> = {},
@@ -127,9 +128,16 @@ describe("optimistic feed item mutations", () => {
     feedItemsStore
       .getState()
       .setFeedItem(previousFeedItem.id, previousFeedItem);
+    const initialMembershipRevision = getMixedContentMembershipRevision();
     const context = applyOptimisticWatchedValue(previousFeedItem.id, true);
+    expect(getMixedContentMembershipRevision()).toBe(
+      initialMembershipRevision + 1,
+    );
 
     rollbackOptimisticWatchedValue(context);
+    expect(getMixedContentMembershipRevision()).toBe(
+      initialMembershipRevision + 2,
+    );
 
     const rolledBackItem =
       feedItemsStore.getState().feedItemsDict[previousFeedItem.id];

--- a/apps/app/tests/unit/performance/client-audit-model.test.ts
+++ b/apps/app/tests/unit/performance/client-audit-model.test.ts
@@ -33,15 +33,20 @@ describe("client performance audit model", () => {
       ).toBe(2);
       expect(result.operations.bookmarkDelete.authoritativeRefills).toBe(1);
       expect(result.operations.bookmarkBurstSingleFrame).toMatchObject({
-        bookmarkStoreNotifications: 100,
         mixedStoreNotifications: 0,
         authoritativeRefills: 0,
       });
+      expect(
+        result.operations.bookmarkBurstSingleFrame.bookmarkStoreNotifications,
+      ).toBeLessThanOrEqual(100);
       expect(result.operations.bookmarkBurstSeparateFrames).toMatchObject({
-        bookmarkStoreNotifications: 100,
         mixedStoreNotifications: 0,
         authoritativeRefills: 0,
       });
+      expect(
+        result.operations.bookmarkBurstSeparateFrames
+          .bookmarkStoreNotifications,
+      ).toBeLessThanOrEqual(100);
       expect(result.operations.localViewProjection).toMatchObject({
         bookmarkStoreNotifications: 0,
         feedItemStoreNotifications: 0,

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -147,6 +147,40 @@ function completeTargetedOrganization(
   ];
 }
 
+function completeTargetedScopeAndNavigation(
+  reconciliationId: string,
+): ReconciliationStreamEvent[] {
+  return [
+    {
+      reconciliationId,
+      chunk: { type: "active-first-page", page: PAGE },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "domain-complete",
+        domain: "active-scope",
+        target: ACTIVE_SCOPE,
+      },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "navigation-snapshot", snapshot: NAVIGATION },
+    },
+    {
+      reconciliationId,
+      chunk: { type: "domain-complete", domain: "navigation" },
+    },
+    {
+      reconciliationId,
+      chunk: {
+        type: "epoch-complete",
+        requiredDomains: ["active-scope", "navigation"],
+      },
+    },
+  ];
+}
+
 function harness(
   events: (
     request: ReconciliationRequestDescriptor,
@@ -161,10 +195,21 @@ function harness(
         repairIntent?: ReconciliationRequestDescriptor["intent"];
       }
     | void,
-  options: { isVisible?: () => boolean; isOnline?: () => boolean } = {},
+  options: {
+    isVisible?: () => boolean;
+    isOnline?: () => boolean;
+    liveEventTargets?: (payload: string[]) => {
+      targets: ReconciliationTarget[];
+      affectsAllScopes?: boolean;
+    };
+  } = {},
 ) {
   const requests: ReconciliationRequestDescriptor[] = [];
   const applications: string[] = [];
+  const authoritativeApplications: Array<{
+    reconciliationId: string;
+    type: string;
+  }> = [];
   const liveApplications: string[][] = [];
   let currentSelection: ReconciliationScopeTarget | null = null;
   let now = 0;
@@ -193,14 +238,22 @@ function harness(
         }
       },
     }),
-    applyAuthoritative: (payload) => {
+    applyAuthoritative: (payload, context) => {
       applications.push(payload.type);
+      authoritativeApplications.push({
+        reconciliationId: context.reconciliationId,
+        type: payload.type,
+      });
       return true;
     },
     applyLiveEvent: (payload) => {
       liveApplications.push(payload);
       return applyLiveEvent?.(payload);
     },
+    getLiveEventTargets: (payload) =>
+      options.liveEventTargets?.(payload) ?? {
+        targets: currentSelection ? [currentSelection] : [],
+      },
     getCurrentSelection: () => currentSelection,
     isVisible: options.isVisible,
     isOnline: options.isOnline,
@@ -209,6 +262,7 @@ function harness(
     runtime,
     requests,
     applications,
+    authoritativeApplications,
     liveApplications,
     setSelection(selection: ReconciliationScopeTarget | null) {
       currentSelection = selection;
@@ -635,6 +689,128 @@ describe("client reconciliation runtime", () => {
     test.runtime.hydrationComplete("bookmarks");
     expect(test.liveApplications).toEqual([["membership-change"]]);
     expect(test.runtime.getState().trustedUpToDate).toBe(true);
+  });
+
+  it("keeps cold navigation authority behind a buffered live invalidation", async () => {
+    let releaseRepair!: () => void;
+    const repairReleased = new Promise<void>((resolve) => {
+      releaseRepair = resolve;
+    });
+    const navigationTarget = { type: "navigation" } as const;
+    const test = harness(
+      async function* (request) {
+        if (request.intent.type === "full") {
+          yield* completeEpoch(request.reconciliationId);
+          return;
+        }
+        await repairReleased;
+        yield* completeTargetedScopeAndNavigation(request.reconciliationId);
+      },
+      () => ({
+        repairTargets: [navigationTarget, ACTIVE_SCOPE],
+        repairIntent: {
+          type: "targeted",
+          targets: [navigationTarget, ACTIVE_SCOPE],
+        },
+      }),
+      {
+        liveEventTargets: () => ({
+          targets: [navigationTarget],
+          affectsAllScopes: true,
+        }),
+      },
+    );
+
+    test.runtime.receiveLiveEvent(["navigation-membership-change"]);
+    for (const domain of [
+      "organization",
+      "active-scope",
+      "navigation",
+    ] as const) {
+      test.runtime.hydrationComplete(domain);
+    }
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+
+    await vi.waitFor(() => expect(test.requests).toHaveLength(1));
+    await vi.waitFor(() => expect(test.applications).toEqual(["organization"]));
+    expect(test.runtime.getState().trustedUpToDate).toBe(false);
+
+    test.runtime.hydrationComplete("bookmarks");
+    await vi.waitFor(() => expect(test.liveApplications).toHaveLength(1));
+    await vi.waitFor(() => expect(test.requests).toHaveLength(2));
+    expect(
+      test.runtime.getState().targets.navigation?.revision,
+    ).toBeGreaterThan(0);
+    expect(
+      test.runtime.getState().targets[getReconciliationTargetKey(ACTIVE_SCOPE)]
+        ?.revision,
+    ).toBeGreaterThan(0);
+    expect(test.applications).toEqual(["organization"]);
+
+    releaseRepair();
+    await vi.waitFor(() =>
+      expect(
+        test.authoritativeApplications
+          .filter((application) => application.type !== "organization")
+          .map((application) => application.reconciliationId),
+      ).toEqual([
+        test.requests[1]?.reconciliationId,
+        test.requests[1]?.reconciliationId,
+      ]),
+    );
+    await vi.waitFor(() =>
+      expect(test.runtime.getState().trustedUpToDate).toBe(true),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(test.requests).toHaveLength(2);
+    expect(
+      test.authoritativeApplications.filter(
+        (application) => application.type !== "organization",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("withholds cold trust while RSS feed items wait for hydration", async () => {
+    const navigationTarget = { type: "navigation" } as const;
+    const test = harness(
+      (request) => completeEpoch(request.reconciliationId),
+      () => ({ dirtyTargets: [navigationTarget, ACTIVE_SCOPE] }),
+      {
+        liveEventTargets: () => ({
+          targets: [navigationTarget],
+          affectsAllScopes: true,
+        }),
+      },
+    );
+
+    test.runtime.receiveLiveEvent(["rss-feed-items"]);
+    for (const domain of [
+      "organization",
+      "active-scope",
+      "navigation",
+    ] as const) {
+      test.runtime.hydrationComplete(domain);
+    }
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+
+    await vi.waitFor(() => expect(test.requests).toHaveLength(1));
+    await vi.waitFor(() => expect(test.applications).toEqual(["organization"]));
+    expect(test.runtime.getState().trustedUpToDate).toBe(false);
+
+    test.runtime.hydrationComplete("bookmarks");
+    await vi.waitFor(() => expect(test.liveApplications).toHaveLength(1));
+    expect(
+      test.runtime.getState().targets.navigation?.revision,
+    ).toBeGreaterThan(0);
+    expect(
+      test.runtime.getState().targets[getReconciliationTargetKey(ACTIVE_SCOPE)]
+        ?.revision,
+    ).toBeGreaterThan(0);
+    test.runtime.stop();
   });
 
   it("keeps RSS detail events repair-silent and schedules one summary repair", async () => {

--- a/apps/app/tests/unit/reconciliation/client-runtime.test.ts
+++ b/apps/app/tests/unit/reconciliation/client-runtime.test.ts
@@ -611,6 +611,32 @@ describe("client reconciliation runtime", () => {
     expect(test.liveApplications).toEqual([["newer-live-state"]]);
   });
 
+  it("withholds established trust until a buffered live event finishes", async () => {
+    const test = harness((request) => completeEpoch(request.reconciliationId));
+    test.setSelection(ACTIVE_SCOPE);
+    for (const domain of [
+      "organization",
+      "active-scope",
+      "navigation",
+    ] as const) {
+      test.runtime.hydrationComplete(domain);
+    }
+    test.runtime.cacheUsable();
+    test.runtime.sseConnectionChanged(true);
+    test.runtime.start();
+    await vi.waitFor(() =>
+      expect(test.runtime.getState().trustedUpToDate).toBe(true),
+    );
+
+    test.runtime.receiveLiveEvent(["membership-change"]);
+    expect(test.runtime.getState().trustedUpToDate).toBe(false);
+    expect(test.liveApplications).toEqual([]);
+
+    test.runtime.hydrationComplete("bookmarks");
+    expect(test.liveApplications).toEqual([["membership-change"]]);
+    expect(test.runtime.getState().trustedUpToDate).toBe(true);
+  });
+
   it("keeps RSS detail events repair-silent and schedules one summary repair", async () => {
     const test = harness(
       (request) =>

--- a/apps/app/tests/unit/reconciliation/reconciliation.test.ts
+++ b/apps/app/tests/unit/reconciliation/reconciliation.test.ts
@@ -527,12 +527,115 @@ describe("reconciliation coordinator", () => {
         eventId: "scope-first",
         payload: "scope-first",
       },
+    ]);
+    expect(
+      harness.send({
+        type: "live-event-applied",
+        eventId: "scope-first",
+      }),
+    ).toEqual([
       {
         type: "apply-live-event",
         eventId: "scope-second",
         payload: "scope-second",
       },
     ]);
+  });
+
+  it("withholds trust and same-target authority while a buffered live event applies", () => {
+    const harness = coordinatorHarness();
+    harness.send({ type: "cache-usable", at: 1 });
+    harness.send({ type: "active-scope-changed", target: ACTIVE_SCOPE });
+    for (const domain of [
+      "organization",
+      "active-scope",
+      "navigation",
+    ] satisfies ReconciliationHydrationDomain[]) {
+      harness.send({ type: "hydration-complete", domain });
+    }
+
+    const fullRequest = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "full", selectedScope: ACTIVE_SCOPE },
+      }),
+    );
+    for (const target of requiredTargets()) {
+      harness.send({
+        type: "authoritative-received",
+        reconciliationId: fullRequest.reconciliationId,
+        target,
+        requiresHydration: hydrationFor(target),
+        payload: `initial:${getReconciliationTargetKey(target)}`,
+      });
+      harness.send({
+        type: "authoritative-applied",
+        reconciliationId: fullRequest.reconciliationId,
+        target,
+        at: 2,
+      });
+    }
+    harness.send({
+      type: "request-settled",
+      reconciliationId: fullRequest.reconciliationId,
+      at: 3,
+      epochComplete: true,
+    });
+    harness.send({ type: "sse-connection-changed", connected: true });
+    expect(harness.state.trustedUpToDate).toBe(true);
+
+    harness.send({
+      type: "live-event-received",
+      eventId: "buffered-membership-change",
+      targets: [ACTIVE_SCOPE],
+      requiresHydration: ["bookmarks"],
+      payload: "newer-live-state",
+    });
+    expect(harness.state.trustedUpToDate).toBe(false);
+
+    const targetedRequest = startedRequest(
+      harness.send({
+        type: "request-reconciliation",
+        intent: { type: "targeted", targets: [ACTIVE_SCOPE] },
+      }),
+    );
+    harness.send({
+      type: "authoritative-received",
+      reconciliationId: targetedRequest.reconciliationId,
+      target: ACTIVE_SCOPE,
+      requiresHydration: ["active-scope"],
+      payload: "older-authoritative-page",
+    });
+
+    expect(
+      harness.send({ type: "hydration-complete", domain: "bookmarks" }),
+    ).toEqual([
+      {
+        type: "apply-live-event",
+        eventId: "buffered-membership-change",
+        payload: "newer-live-state",
+      },
+    ]);
+    expect(harness.state.bufferedApplications).toEqual([
+      expect.objectContaining({
+        type: "authoritative",
+        payload: "older-authoritative-page",
+      }),
+    ]);
+    expect(harness.state.trustedUpToDate).toBe(false);
+
+    harness.send({ type: "targets-dirtied", targets: [ACTIVE_SCOPE] });
+    expect(
+      harness.send({
+        type: "live-event-applied",
+        eventId: "buffered-membership-change",
+      }),
+    ).toEqual([]);
+    expect(harness.state.bufferedApplications).toEqual([]);
+    expect(harness.state.trailingIntent).toEqual({
+      type: "targeted",
+      targets: [ACTIVE_SCOPE],
+    });
   });
 
   it("marks an inactive target dirty without eagerly scheduling repair", () => {


### PR DESCRIPTION
- reject mixed pages started before Bookmark membership mutations
- keep buffered live events ahead of same-target authority and trust
- evict unowned Bookmark bodies while preserving page and pin owners
- refresh unchanged first-page pagination authority while retaining provisional tails