### PR TITLE
Prototype authenticated feed item capture

### DIFF
--- a/apps/app/src/app/_app.read.$id.tsx
+++ b/apps/app/src/app/_app.read.$id.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
+import { Loader2Icon, ScanTextIcon } from "lucide-react";
 import rehypeParse from "rehype-parse";
 import rehypeSanitize from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
@@ -48,6 +49,18 @@ import {
   contentDestination,
   resolveContentItem,
 } from "~/lib/data/content-items/resolver";
+import { BookmarkArticleContent } from "~/components/bookmarks/BookmarkArticleContent";
+import { requestPrototypeFeedItemCapture } from "~/lib/prototype-feed-item-capture";
+
+type PrototypeCaptureState =
+  | { status: "idle" }
+  | { status: "capturing" }
+  | {
+      status: "captured";
+      contentHtml: string;
+      effectiveUrl: string;
+    }
+  | { status: "error"; message: string };
 
 const parser = unified()
   .use(rehypeParse, { fragment: true })
@@ -80,7 +93,11 @@ function ReadPage() {
     return <BookmarkReader id={params.id} />;
   }
   return (
-    <FeedReader id={params.id} hasRefreshedFeedItem={hasRefreshedFeedItem} />
+    <FeedReader
+      key={params.id}
+      id={params.id}
+      hasRefreshedFeedItem={hasRefreshedFeedItem}
+    />
   );
 }
 
@@ -96,6 +113,8 @@ function FeedReader({
   const [articleStyle] = useFlagState("ARTICLE_STYLE");
 
   const feedItem = useFeedItemValue(id);
+  const [prototypeCapture, setPrototypeCapture] =
+    useState<PrototypeCaptureState>({ status: "idle" });
 
   const { feeds } = useFeeds();
   const feedCategories = useFeedCategories();
@@ -111,6 +130,26 @@ function FeedReader({
   if (articleStyle === "simplified") {
     content = String(parser.processSync(feedItem?.content ?? ""));
   }
+
+  const displayedContent =
+    prototypeCapture.status === "captured"
+      ? prototypeCapture.contentHtml
+      : content;
+
+  const captureSourcePage = async () => {
+    if (!feedItem?.url || prototypeCapture.status === "capturing") return;
+    setPrototypeCapture({ status: "capturing" });
+    const response = await requestPrototypeFeedItemCapture(feedItem.url);
+    setPrototypeCapture(
+      response.ok
+        ? {
+            status: "captured",
+            contentHtml: response.capture.contentHtml,
+            effectiveUrl: response.capture.effectiveUrl,
+          }
+        : { status: "error", message: response.error },
+    );
+  };
 
   const articleRef = useRef<HTMLDivElement>(null);
   const [articleElement, setArticleElement] = useState<HTMLDivElement | null>(
@@ -236,7 +275,7 @@ function FeedReader({
       <div key={id} className="relative w-full">
         <ArticleSidebars
           article={articleElement}
-          contentKey={`${id}:${articleStyle}:${zoom}:${content}`}
+          contentKey={`${id}:${articleStyle}:${zoom}:${displayedContent}`}
           scrollToElement={scrollToElement}
         />
         <div
@@ -245,7 +284,9 @@ function FeedReader({
         >
           <h1 data-serial-header>{feedItem?.title}</h1>
           <h6 data-serial-header>{feedItem?.author || feed?.name || ""}</h6>
-          {articleStyle === "simplified" ? (
+          {prototypeCapture.status === "captured" ? (
+            <BookmarkArticleContent content={prototypeCapture.contentHtml} />
+          ) : articleStyle === "simplified" ? (
             // Content is sanitized by the module-level rehype pipeline above.
             // react-doctor-disable-next-line react-doctor/dangerous-html-sink
             <div
@@ -281,6 +322,18 @@ function FeedReader({
           </Alert>
         </div>
       )}
+      {prototypeCapture.status !== "idle" && (
+        <p
+          className="text-muted-foreground w-full px-6 text-center font-sans text-sm"
+          role="status"
+        >
+          {prototypeCapture.status === "capturing"
+            ? "Capturing the authenticated source page in a background tab…"
+            : prototypeCapture.status === "captured"
+              ? `Showing an ephemeral capture from ${new URL(prototypeCapture.effectiveUrl).host}. Reload to restore the Feed body.`
+              : prototypeCapture.message}
+        </p>
+      )}
       <div
         className={clsx(
           "sticky inset-x-0 bottom-0 left-0 grid place-items-center transition-transform duration-300",
@@ -289,7 +342,33 @@ function FeedReader({
           },
         )}
       >
-        <ContentActions contentID={id} />
+        <ContentActions
+          contentID={id}
+          prototypeCaptureAction={
+            <Button
+              data-prototype-capture-state={prototypeCapture.status}
+              variant={
+                prototypeCapture.status === "captured" ? "secondary" : "outline"
+              }
+              size="icon md:default"
+              disabled={
+                !feedItem?.url || prototypeCapture.status === "capturing"
+              }
+              onClick={() => void captureSourcePage()}
+            >
+              {prototypeCapture.status === "capturing" ? (
+                <Loader2Icon className="animate-spin" size={16} />
+              ) : (
+                <ScanTextIcon size={16} />
+              )}
+              <span className="hidden pl-1.5 md:block">
+                {prototypeCapture.status === "capturing"
+                  ? "Capturing"
+                  : "Capture"}
+              </span>
+            </Button>
+          }
+        />
       </div>
     </div>
   );

--- a/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
+++ b/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
@@ -7,6 +7,7 @@ import {
   SendIcon,
 } from "lucide-react";
 import { useView } from "./useView";
+import type { ReactNode } from "react";
 import { ButtonWithShortcut } from "~/components/ButtonWithShortcut";
 import { Button } from "~/components/ui/button";
 import {
@@ -22,7 +23,13 @@ import { useMediaQuery } from "~/lib/hooks/use-media-query";
 import { useShortcut } from "~/lib/hooks/useShortcut";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 
-export function ContentActions({ contentID }: { contentID: string }) {
+export function ContentActions({
+  contentID,
+  prototypeCaptureAction,
+}: {
+  contentID: string;
+  prototypeCaptureAction?: ReactNode;
+}) {
   const { view } = useView();
 
   const video = useFeedItemValue(contentID);
@@ -83,6 +90,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
 
     return (
       <div className="absolute inset-x-0 bottom-0 z-0 flex w-full items-center justify-center gap-2 p-6">
+        {prototypeCaptureAction}
         {showInstapaperAction && (
           <Button
             variant="outline"
@@ -121,6 +129,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
 
   return (
     <div className="flex w-full items-center justify-center gap-2 p-6">
+      {prototypeCaptureAction}
       {showInstapaperAction && (
         <ButtonWithShortcut
           shortcut={SHORTCUT_KEYS.SEND_TO_INSTAPAPER}

--- a/apps/app/src/lib/prototype-feed-item-capture.ts
+++ b/apps/app/src/lib/prototype-feed-item-capture.ts
@@ -1,0 +1,53 @@
+import {
+  parsePrototypeFeedItemCaptureResponse,
+  PROTOTYPE_FEED_ITEM_CAPTURE_REQUEST,
+  PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+} from "@serial/bookmark-capture";
+import type { PrototypeFeedItemCaptureResponse } from "@serial/bookmark-capture";
+
+const PROTOTYPE_CAPTURE_TIMEOUT_MS = 30_000;
+
+// PROTOTYPE: Sends a one-off in-page request to the Serial extension bridge.
+export async function requestPrototypeFeedItemCapture(sourceUrl: string) {
+  const requestId = crypto.randomUUID();
+
+  return new Promise<PrototypeFeedItemCaptureResponse>((resolve) => {
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      resolve({
+        type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+        requestId,
+        ok: false,
+        error:
+          "The Serial extension did not respond. Open this page in the extension-enabled Chrome profile.",
+      });
+    }, PROTOTYPE_CAPTURE_TIMEOUT_MS);
+
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener("message", handleResponse);
+    };
+    const handleResponse = (event: MessageEvent<unknown>) => {
+      if (event.source !== window || event.origin !== window.location.origin) {
+        return;
+      }
+      const response = parsePrototypeFeedItemCaptureResponse(
+        event.data,
+        requestId,
+      );
+      if (!response) return;
+      cleanup();
+      resolve(response);
+    };
+
+    window.addEventListener("message", handleResponse);
+    window.postMessage(
+      {
+        type: PROTOTYPE_FEED_ITEM_CAPTURE_REQUEST,
+        requestId,
+        sourceUrl,
+      },
+      window.location.origin,
+    );
+  });
+}

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -11,7 +11,11 @@ import {
   SELECTED_INSTANCE_STORAGE_KEY,
   updateSessionFromResponse,
 } from "../lib/auth";
-import { EXTENSION_INSTANCE_REQUEST_TIMEOUT_MS } from "@serial/bookmark-capture";
+import {
+  EXTENSION_INSTANCE_REQUEST_TIMEOUT_MS,
+  isPrototypeFeedItemCaptureRequest,
+} from "@serial/bookmark-capture";
+import type { PrototypeFeedItemCaptureRequest } from "@serial/bookmark-capture";
 import type {
   AuthMessage,
   AuthMessageResponse,
@@ -20,6 +24,7 @@ import type {
 import { handleBookmarkMessage } from "../lib/background-bookmarks";
 import { isBookmarkMessage } from "../lib/bookmarks";
 import type { BookmarkMessage } from "../lib/bookmarks";
+import { capturePrototypeFeedItem } from "../lib/prototype-feed-item-capture";
 
 async function fetchFromInstance(
   input: string | URL | Request,
@@ -239,14 +244,20 @@ async function handleAuthMessage(
 
 export default defineBackground(() => {
   browser.runtime.onMessage.addListener(
-    (message: AuthMessage | BookmarkMessage, _sender, sendResponse) => {
-      const response = isBookmarkMessage(message)
-        ? handleBookmarkMessage(message, {
-            readStoredSession,
-            clearSession,
-            fetchFromInstance,
-          })
-        : handleAuthMessage(message);
+    (
+      message: AuthMessage | BookmarkMessage | PrototypeFeedItemCaptureRequest,
+      sender,
+      sendResponse,
+    ) => {
+      const response = isPrototypeFeedItemCaptureRequest(message)
+        ? capturePrototypeFeedItem(message, sender.tab?.url)
+        : isBookmarkMessage(message)
+          ? handleBookmarkMessage(message, {
+              readStoredSession,
+              clearSession,
+              fetchFromInstance,
+            })
+          : handleAuthMessage(message);
       void response.then(sendResponse);
       return true;
     },

--- a/apps/extension/entrypoints/prototype-app-bridge.content.ts
+++ b/apps/extension/entrypoints/prototype-app-bridge.content.ts
@@ -1,0 +1,45 @@
+import {
+  PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+  isPrototypeFeedItemCaptureRequest,
+} from "@serial/bookmark-capture";
+
+// PROTOTYPE: This is the app-to-extension bridge Firefox would also use.
+export default defineContentScript({
+  matches: [
+    "http://localhost/*",
+    "http://127.0.0.1/*",
+    "https://*.serial.tube/*",
+  ],
+  main() {
+    window.addEventListener("message", (event) => {
+      if (
+        event.source !== window ||
+        event.origin !== window.location.origin ||
+        !isPrototypeFeedItemCaptureRequest(event.data)
+      ) {
+        return;
+      }
+
+      const request = event.data;
+      void browser.runtime
+        .sendMessage(request)
+        .then((response: unknown) => {
+          window.postMessage(response, window.location.origin);
+        })
+        .catch((error: unknown) => {
+          window.postMessage(
+            {
+              type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+              requestId: request.requestId,
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Unable to contact the Serial extension",
+            },
+            window.location.origin,
+          );
+        });
+    });
+  },
+});

--- a/apps/extension/lib/prototype-feed-item-capture.test.ts
+++ b/apps/extension/lib/prototype-feed-item-capture.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { capturePrototypeFeedItem } from "./prototype-feed-item-capture";
+
+const request = {
+  type: "prototype.feed-item-capture.request" as const,
+  requestId: "capture-one",
+  sourceUrl: "https://publisher.example/private-article",
+};
+
+function stubBrowser(captureResult: unknown) {
+  const create = vi.fn(() => Promise.resolve({ id: 42, status: "loading" }));
+  const get = vi.fn(() => Promise.resolve({ id: 42, status: "complete" }));
+  const remove = vi.fn(() => Promise.resolve());
+  const executeScript = vi.fn((input: { files?: string[] }) =>
+    Promise.resolve(
+      input.files ? [{ result: captureResult }] : [{ result: undefined }],
+    ),
+  );
+  const event = {
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+
+  vi.stubGlobal("browser", {
+    tabs: {
+      create,
+      get,
+      remove,
+      onRemoved: event,
+      onUpdated: event,
+    },
+    scripting: { executeScript },
+  });
+
+  return { create, executeScript, remove };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("prototype Feed-item page capture", () => {
+  it("opens an inactive profile tab, extracts the rendered page, and closes it", async () => {
+    const browser = stubBrowser({
+      sourceUrl: request.sourceUrl,
+      capture: {
+        contentHtml: "<p>Authenticated full article</p>",
+        effectiveUrl: request.sourceUrl,
+        title: "Private article",
+      },
+      feeds: [],
+    });
+
+    const response = await capturePrototypeFeedItem(
+      request,
+      "http://localhost:3000/read/item-one",
+    );
+
+    expect(browser.create).toHaveBeenCalledWith({
+      active: false,
+      url: request.sourceUrl,
+    });
+    expect(browser.executeScript).toHaveBeenLastCalledWith({
+      target: { tabId: 42 },
+      files: ["/content-scripts/bookmark-capture.js"],
+    });
+    expect(browser.remove).toHaveBeenCalledWith(42);
+    expect(response).toEqual({
+      type: "prototype.feed-item-capture.response",
+      requestId: request.requestId,
+      ok: true,
+      capture: {
+        contentHtml: "<p>Authenticated full article</p>",
+        effectiveUrl: request.sourceUrl,
+        title: "Private article",
+      },
+    });
+  });
+
+  it("rejects requests outside Serial without opening a page", async () => {
+    const browser = stubBrowser(undefined);
+
+    const response = await capturePrototypeFeedItem(
+      request,
+      "https://attacker.example/read/item-one",
+    );
+
+    expect(response).toMatchObject({ ok: false });
+    expect(browser.create).not.toHaveBeenCalled();
+  });
+
+  it("closes the temporary tab when extraction fails", async () => {
+    const browser = stubBrowser({ captureFailureReason: "unextractable" });
+
+    const response = await capturePrototypeFeedItem(
+      request,
+      "https://app.serial.tube/read/item-one",
+    );
+
+    expect(response).toMatchObject({
+      ok: false,
+      error:
+        "The page loaded, but the Bookmark extractor found no readable article",
+    });
+    expect(browser.remove).toHaveBeenCalledWith(42);
+  });
+});

--- a/apps/extension/lib/prototype-feed-item-capture.test.ts
+++ b/apps/extension/lib/prototype-feed-item-capture.test.ts
@@ -8,32 +8,51 @@ const request = {
   sourceUrl: "https://publisher.example/private-article",
 };
 
+function stubEvent<Args extends unknown[]>() {
+  const listeners = new Set<(...args: Args) => void>();
+  return {
+    addListener: vi.fn((listener: (...args: Args) => void) => {
+      listeners.add(listener);
+    }),
+    removeListener: vi.fn((listener: (...args: Args) => void) => {
+      listeners.delete(listener);
+    }),
+    emit: (...args: Args) => {
+      for (const listener of listeners) listener(...args);
+    },
+  };
+}
+
 function stubBrowser(captureResult: unknown) {
   const create = vi.fn(() => Promise.resolve({ id: 42, status: "loading" }));
-  const get = vi.fn(() => Promise.resolve({ id: 42, status: "complete" }));
+  const get = vi.fn(() =>
+    Promise.resolve({
+      id: 42,
+      status: "complete",
+      url: request.sourceUrl,
+    }),
+  );
   const remove = vi.fn(() => Promise.resolve());
   const executeScript = vi.fn((input: { files?: string[] }) =>
     Promise.resolve(
       input.files ? [{ result: captureResult }] : [{ result: undefined }],
     ),
   );
-  const event = {
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-  };
+  const onRemoved = stubEvent<[number]>();
+  const onUpdated = stubEvent<[number, { status?: string }]>();
 
   vi.stubGlobal("browser", {
     tabs: {
       create,
       get,
       remove,
-      onRemoved: event,
-      onUpdated: event,
+      onRemoved,
+      onUpdated,
     },
     scripting: { executeScript },
   });
 
-  return { create, executeScript, remove };
+  return { create, executeScript, get, onUpdated, remove };
 }
 
 afterEach(() => {
@@ -88,6 +107,33 @@ describe("prototype Feed-item page capture", () => {
 
     expect(response).toMatchObject({ ok: false });
     expect(browser.create).not.toHaveBeenCalled();
+  });
+
+  it("waits past Firefox's completed about:blank state before injecting", async () => {
+    const browser = stubBrowser({
+      capture: {
+        contentHtml: "<p>Authenticated full article</p>",
+        effectiveUrl: request.sourceUrl,
+        title: "Private article",
+      },
+    });
+    browser.get.mockResolvedValueOnce({
+      id: 42,
+      status: "complete",
+      url: "about:blank",
+    });
+
+    const response = capturePrototypeFeedItem(
+      request,
+      "http://localhost:3000/read/item-one",
+    );
+    await vi.waitFor(() => expect(browser.get).toHaveBeenCalledTimes(1));
+    expect(browser.executeScript).not.toHaveBeenCalled();
+
+    browser.onUpdated.emit(42, { status: "complete" });
+
+    await expect(response).resolves.toMatchObject({ ok: true });
+    expect(browser.executeScript).toHaveBeenCalledTimes(2);
   });
 
   it("closes the temporary tab when extraction fails", async () => {

--- a/apps/extension/lib/prototype-feed-item-capture.ts
+++ b/apps/extension/lib/prototype-feed-item-capture.ts
@@ -1,0 +1,188 @@
+import {
+  PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+  type PrototypeFeedItemCaptureRequest,
+  type PrototypeFeedItemCaptureResponse,
+  type ExtensionPageObservation,
+} from "@serial/bookmark-capture";
+
+const PAGE_LOAD_TIMEOUT_MS = 20_000;
+const DOM_QUIET_MS = 750;
+const DOM_SETTLE_TIMEOUT_MS = 3_000;
+
+function eligibleHttpUrl(value: string) {
+  const url = new URL(value);
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error("This page is not eligible for capture");
+  }
+  return url.toString();
+}
+
+function isPrototypeSerialPage(value: string | undefined) {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return (
+      (url.protocol === "http:" &&
+        (url.hostname === "localhost" || url.hostname === "127.0.0.1")) ||
+      (url.protocol === "https:" &&
+        (url.hostname === "serial.tube" ||
+          url.hostname.endsWith(".serial.tube")))
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function waitForTabLoad(tabId: number) {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("The source page did not finish loading in time"));
+    }, PAGE_LOAD_TIMEOUT_MS);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      browser.tabs.onUpdated.removeListener(handleUpdated);
+      browser.tabs.onRemoved.removeListener(handleRemoved);
+    };
+    const finish = () => {
+      cleanup();
+      resolve();
+    };
+    const handleUpdated = (
+      updatedTabId: number,
+      changeInfo: { status?: string },
+    ) => {
+      if (updatedTabId === tabId && changeInfo.status === "complete") finish();
+    };
+    const handleRemoved = (removedTabId: number) => {
+      if (removedTabId !== tabId) return;
+      cleanup();
+      reject(new Error("The capture tab was closed before extraction"));
+    };
+
+    browser.tabs.onUpdated.addListener(handleUpdated);
+    browser.tabs.onRemoved.addListener(handleRemoved);
+    void browser.tabs
+      .get(tabId)
+      .then((tab) => {
+        if (tab.status === "complete") finish();
+      })
+      .catch((error: unknown) => {
+        cleanup();
+        reject(error);
+      });
+  });
+}
+
+async function waitForDomQuiet(tabId: number) {
+  await browser.scripting.executeScript({
+    target: { tabId },
+    args: [DOM_QUIET_MS, DOM_SETTLE_TIMEOUT_MS],
+    func: async (quietMs: number, maximumMs: number) => {
+      await new Promise<void>((resolve) => {
+        let quietTimer = 0;
+        const maximumTimer = window.setTimeout(finish, maximumMs);
+        const observer = new MutationObserver(scheduleFinish);
+
+        function finish() {
+          window.clearTimeout(quietTimer);
+          window.clearTimeout(maximumTimer);
+          observer.disconnect();
+          resolve();
+        }
+
+        function scheduleFinish() {
+          window.clearTimeout(quietTimer);
+          quietTimer = window.setTimeout(finish, quietMs);
+        }
+
+        observer.observe(document.documentElement, {
+          attributes: true,
+          childList: true,
+          subtree: true,
+        });
+        scheduleFinish();
+      });
+    },
+  });
+}
+
+function captureFromObservation(value: unknown) {
+  if (!value || typeof value !== "object") return null;
+  const observation = value as Partial<ExtensionPageObservation>;
+  const capture = observation.capture;
+  if (
+    !capture ||
+    typeof capture.contentHtml !== "string" ||
+    capture.contentHtml.length === 0 ||
+    typeof capture.effectiveUrl !== "string" ||
+    typeof capture.title !== "string"
+  ) {
+    return null;
+  }
+  return {
+    contentHtml: capture.contentHtml,
+    effectiveUrl: capture.effectiveUrl,
+    title: capture.title,
+  };
+}
+
+export async function capturePrototypeFeedItem(
+  request: PrototypeFeedItemCaptureRequest,
+  senderUrl: string | undefined,
+): Promise<PrototypeFeedItemCaptureResponse> {
+  if (!isPrototypeSerialPage(senderUrl)) {
+    return {
+      type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+      requestId: request.requestId,
+      ok: false,
+      error: "The capture request did not come from a trusted Serial page",
+    };
+  }
+
+  let tabId: number | undefined;
+  try {
+    const sourceUrl = eligibleHttpUrl(request.sourceUrl);
+    const tab = await browser.tabs.create({ active: false, url: sourceUrl });
+    if (typeof tab.id !== "number") {
+      throw new Error("Chrome did not return a capture tab ID");
+    }
+    tabId = tab.id;
+
+    await waitForTabLoad(tabId);
+    await waitForDomQuiet(tabId);
+    const results = await browser.scripting.executeScript({
+      target: { tabId },
+      files: ["/content-scripts/bookmark-capture.js"],
+    });
+    const capture = captureFromObservation(results[0]?.result);
+    if (!capture) {
+      throw new Error(
+        "The page loaded, but the Bookmark extractor found no readable article",
+      );
+    }
+    return {
+      type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+      requestId: request.requestId,
+      ok: true,
+      capture,
+    };
+  } catch (error) {
+    return {
+      type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+      requestId: request.requestId,
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Unable to capture this page",
+    };
+  } finally {
+    if (tabId !== undefined) {
+      await browser.tabs.remove(tabId).catch(() => undefined);
+    }
+  }
+}

--- a/apps/extension/lib/prototype-feed-item-capture.ts
+++ b/apps/extension/lib/prototype-feed-item-capture.ts
@@ -39,7 +39,10 @@ function isPrototypeSerialPage(value: string | undefined) {
 
 async function waitForTabLoad(tabId: number) {
   await new Promise<void>((resolve, reject) => {
+    let settled = false;
     const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
       cleanup();
       reject(new Error("The source page did not finish loading in time"));
     }, PAGE_LOAD_TIMEOUT_MS);
@@ -50,32 +53,47 @@ async function waitForTabLoad(tabId: number) {
       browser.tabs.onRemoved.removeListener(handleRemoved);
     };
     const finish = () => {
+      if (settled) return;
+      settled = true;
       cleanup();
       resolve();
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const finishIfHttpDocumentLoaded = async () => {
+      try {
+        const tab = await browser.tabs.get(tabId);
+        if (
+          tab.status === "complete" &&
+          typeof tab.url === "string" &&
+          (tab.url.startsWith("http://") || tab.url.startsWith("https://"))
+        ) {
+          finish();
+        }
+      } catch (error) {
+        fail(error);
+      }
     };
     const handleUpdated = (
       updatedTabId: number,
       changeInfo: { status?: string },
     ) => {
-      if (updatedTabId === tabId && changeInfo.status === "complete") finish();
+      if (updatedTabId === tabId && changeInfo.status === "complete") {
+        void finishIfHttpDocumentLoaded();
+      }
     };
     const handleRemoved = (removedTabId: number) => {
       if (removedTabId !== tabId) return;
-      cleanup();
-      reject(new Error("The capture tab was closed before extraction"));
+      fail(new Error("The capture tab was closed before extraction"));
     };
 
     browser.tabs.onUpdated.addListener(handleUpdated);
     browser.tabs.onRemoved.addListener(handleRemoved);
-    void browser.tabs
-      .get(tabId)
-      .then((tab) => {
-        if (tab.status === "complete") finish();
-      })
-      .catch((error: unknown) => {
-        cleanup();
-        reject(error);
-      });
+    void finishIfHttpDocumentLoaded();
   });
 }
 
@@ -150,7 +168,7 @@ export async function capturePrototypeFeedItem(
     const sourceUrl = eligibleHttpUrl(request.sourceUrl);
     const tab = await browser.tabs.create({ active: false, url: sourceUrl });
     if (typeof tab.id !== "number") {
-      throw new Error("Chrome did not return a capture tab ID");
+      throw new Error("The browser did not return a capture tab ID");
     }
     tabId = tab.id;
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -20,6 +20,7 @@
     "format:fix": "prettier --write .",
     "lint": "eslint .",
     "lint:firefox": "web-ext lint --source-dir .output/firefox-mv2 --output=json --boring --no-input | node scripts/check-firefox-lint.mjs",
+    "test:prototype:capture:firefox": "node scripts/test-prototype-firefox-capture.mjs",
     "lint:fix": "eslint --fix .",
     "test:unit": "vitest run",
     "postinstall": "wxt prepare"

--- a/apps/extension/scripts/test-prototype-firefox-capture.mjs
+++ b/apps/extension/scripts/test-prototype-firefox-capture.mjs
@@ -1,0 +1,588 @@
+// PROTOTYPE: disposable Firefox validation for authenticated feed-item capture.
+import { spawn } from "node:child_process";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STARTUP_TIMEOUT_MS = 45_000;
+const ASSERTION_TIMEOUT_MS = 20_000;
+const AUTH_COOKIE = "serial_firefox_fixture=authenticated";
+const ITEM_ID = "prototype-firefox-auth-item";
+const AUTH_MARKER = "FIREFOX_AUTH_ONLY_CAPTURE_BODY";
+const FEED_TEASER = "FIREFOX_FEED_TEASER";
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const extensionDirectory = path.resolve(scriptDirectory, "..");
+const repositoryRoot = path.resolve(extensionDirectory, "../..");
+const extensionBuildDirectory = path.join(
+  extensionDirectory,
+  ".output/firefox-mv2",
+);
+
+const children = new Set();
+let interrupted = false;
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function track(child) {
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
+}
+
+async function stopChild(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    delay(3_000),
+  ]);
+  if (child.exitCode === null && child.signalCode === null)
+    child.kill("SIGKILL");
+}
+
+async function stopChildren() {
+  await Promise.all([...children].map(stopChild));
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    interrupted = true;
+    void stopChildren().finally(() => process.exit(130));
+  });
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = track(
+      spawn(command, args, {
+        cwd: repositoryRoot,
+        env: process.env,
+        stdio: "inherit",
+        ...options,
+      }),
+    );
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(
+            `${command} exited ${signal ? `with ${signal}` : `with code ${code}`}`,
+          ),
+        );
+    });
+  });
+}
+
+async function findAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Unable to allocate a local port"));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function findFirefoxBinary() {
+  const candidates = [
+    process.env.FIREFOX_BINARY,
+    "/Applications/Firefox.app/Contents/MacOS/firefox",
+    "/usr/bin/firefox",
+    "/usr/local/bin/firefox",
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Try the next conventional location.
+    }
+  }
+  throw new Error(
+    "Firefox was not found. Install Firefox or set FIREFOX_BINARY to its executable.",
+  );
+}
+
+function fixtureHtml(authenticated) {
+  if (!authenticated) {
+    return `<!doctype html><html><body><main>
+      <h1>Protected Firefox fixture</h1>
+      <p>Sign in to read the complete article.</p>
+      <a id="sign-in" href="/authenticate">Sign in</a>
+    </main></body></html>`;
+  }
+
+  const paragraphs = Array.from(
+    { length: 8 },
+    (_, index) =>
+      `<p>${AUTH_MARKER} paragraph ${index + 1}. This authenticated article contains enough complete prose for the shared Bookmark readability extractor to select the article body reliably in Firefox. The sentence is deliberately descriptive so a successful capture cannot be confused with the short signed-out teaser.</p>`,
+  ).join("");
+  return `<!doctype html><html><head><title>Authenticated Firefox Capture</title></head><body>
+    <article><h1>Authenticated Firefox Capture</h1><p>By Serial Fixture</p>${paragraphs}</article>
+  </body></html>`;
+}
+
+async function startFixtureServer() {
+  const server = http.createServer(async (request, response) => {
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (requestUrl.pathname === "/authenticate") {
+      response.writeHead(302, {
+        Location: "/article",
+        "Set-Cookie": `${AUTH_COOKIE}; Path=/; HttpOnly; SameSite=Lax`,
+      });
+      response.end();
+      return;
+    }
+
+    const authenticated =
+      request.headers.cookie?.includes(AUTH_COOKIE) ?? false;
+    if (requestUrl.pathname === "/article" && authenticated) await delay(300);
+    response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    response.end(
+      fixtureHtml(requestUrl.pathname === "/article" && authenticated),
+    );
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Protected fixture did not expose a TCP port");
+  }
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+function startDemoApp(databasePath) {
+  const child = track(
+    spawn("pnpm", ["--filter", "@serial/app", "dev:demo"], {
+      cwd: repositoryRoot,
+      env: { ...process.env, SERIAL_DEMO_DB_FILE: databasePath },
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+  let output = "";
+  child.stdout.on("data", (chunk) => (output += chunk.toString()));
+  child.stderr.on("data", (chunk) => (output += chunk.toString()));
+  return { child, getOutput: () => output };
+}
+
+async function waitForDemoUrl(app) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < STARTUP_TIMEOUT_MS) {
+    if (app.child.exitCode !== null || app.child.signalCode !== null) {
+      throw new Error("Demo app stopped before startup");
+    }
+    const match = app.getOutput().match(/Demo app:\s+(https?:\/\/\S+)/);
+    if (match) {
+      try {
+        const response = await fetch(match[1], { redirect: "manual" });
+        if (response.status > 0) return match[1];
+      } catch {
+        // The URL is announced before Vite is ready.
+      }
+    }
+    await delay(100);
+  }
+  throw new Error("Timed out waiting for the demo app");
+}
+
+function startFirefox(binary, profilePath, remotePort) {
+  const child = track(
+    spawn(
+      binary,
+      [
+        "-headless",
+        "-profile",
+        profilePath,
+        "--remote-debugging-port",
+        String(remotePort),
+        "about:blank",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ),
+  );
+  child.stdout.on("data", (chunk) => process.stdout.write(chunk));
+  child.stderr.on("data", (chunk) => process.stderr.write(chunk));
+  return child;
+}
+
+async function waitForPort(port, child) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < STARTUP_TIMEOUT_MS) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error("Firefox stopped before WebDriver BiDi became available");
+    }
+    const connected = await new Promise((resolve) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (connected) return;
+    await delay(100);
+  }
+  throw new Error("Timed out waiting for Firefox WebDriver BiDi");
+}
+
+class BidiClient {
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 1;
+    this.pending = new Map();
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (message.type === "event") return;
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      clearTimeout(pending.timeout);
+      if (message.type === "success") pending.resolve(message.result);
+      else
+        pending.reject(
+          new Error(`${message.method ?? "BiDi command"}: ${message.message}`),
+        );
+    });
+  }
+
+  static async connect(url) {
+    return new Promise((resolve, reject) => {
+      const socket = new WebSocket(url);
+      socket.addEventListener("open", () => resolve(new BidiClient(socket)), {
+        once: true,
+      });
+      socket.addEventListener(
+        "error",
+        () => reject(new Error(`Unable to connect to ${url}`)),
+        { once: true },
+      );
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out running ${method}`));
+      }, ASSERTION_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timeout });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+async function evaluate(client, context, expression) {
+  const result = await client.send("script.evaluate", {
+    expression,
+    target: { context },
+    awaitPromise: true,
+    resultOwnership: "none",
+  });
+  if (result.type === "exception") {
+    throw new Error(result.exceptionDetails.text ?? "Firefox script failed");
+  }
+  return result.result?.value;
+}
+
+async function eventually(description, check) {
+  const startedAt = Date.now();
+  let lastError;
+  while (Date.now() - startedAt < ASSERTION_TIMEOUT_MS) {
+    try {
+      if (await check()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(100);
+  }
+  throw new Error(
+    `${description}${lastError instanceof Error ? `: ${lastError.message}` : ""}`,
+  );
+}
+
+async function navigate(client, context, url) {
+  try {
+    await client.send("browsingContext.navigate", {
+      context,
+      url,
+      wait: "complete",
+    });
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes("NS_BINDING_ABORTED")
+    ) {
+      throw error;
+    }
+  }
+  try {
+    await eventually(`Firefox did not navigate to ${url}`, async () => {
+      const contexts = await topLevelContexts(client);
+      return contexts
+        .find((candidate) => candidate.context === context)
+        ?.url.startsWith(url);
+    });
+  } catch (error) {
+    const contexts = await topLevelContexts(client);
+    const actualUrl = contexts.find(
+      (candidate) => candidate.context === context,
+    )?.url;
+    throw new Error(
+      `${error instanceof Error ? error.message : error}; current URL is ${actualUrl ?? "unknown"}`,
+      { cause: error },
+    );
+  }
+}
+
+function sqlite(databasePath, statement) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("sqlite3", [databasePath, statement], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else
+        reject(new Error(stderr.trim() || `sqlite3 exited with code ${code}`));
+    });
+  });
+}
+
+function sqlString(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+async function seedFeedItem(databasePath, fixtureOrigin) {
+  let userId = "";
+  await eventually("Demo user was not provisioned", async () => {
+    userId = await sqlite(
+      databasePath,
+      "SELECT id FROM serial_user ORDER BY created_at DESC LIMIT 1;",
+    );
+    return userId.length > 0;
+  });
+
+  const sourceUrl = `${fixtureOrigin}/article`;
+  const now = Math.floor(Date.now() / 1_000);
+  await sqlite(
+    databasePath,
+    `PRAGMA foreign_keys=ON;
+      INSERT INTO serial_feed
+        (user_id, name, url, image_url, platform, open_location, created_at, updated_at, is_active)
+      VALUES
+        (${sqlString(userId)}, 'Firefox capture fixture', ${sqlString(`${fixtureOrigin}/feed`)}, '', 'website', 'serial', ${now}, ${now}, 1);
+      INSERT INTO serial_feed_item
+        (id, feed_id, content_id, title, author, url, content, content_snippet, content_type, posted_at, created_at, updated_at)
+      VALUES
+        (${sqlString(ITEM_ID)}, last_insert_rowid(), ${sqlString(ITEM_ID)}, 'Firefox authenticated capture', 'Serial Fixture', ${sqlString(sourceUrl)}, '<p>${FEED_TEASER}</p>', ${sqlString(FEED_TEASER)}, 'text', ${now}, ${now}, ${now});`,
+  );
+}
+
+async function topLevelContexts(client) {
+  const tree = await client.send("browsingContext.getTree");
+  return tree.contexts;
+}
+
+let temporaryDirectory;
+let fixture;
+let app;
+let firefox;
+let bidi;
+
+try {
+  temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "serial-firefox-capture-"),
+  );
+  const databasePath = path.join(temporaryDirectory, "serial-demo.db");
+  const firefoxProfile = path.join(temporaryDirectory, "firefox-profile");
+  const firefoxBinary = await findFirefoxBinary();
+
+  console.log("Building the Firefox extension artifact...");
+  await run("pnpm", ["--filter", "@serial/extension", "build:firefox"]);
+
+  fixture = await startFixtureServer();
+  app = startDemoApp(databasePath);
+  const appUrl = await waitForDemoUrl(app);
+
+  const remotePort = await findAvailablePort();
+  firefox = startFirefox(firefoxBinary, firefoxProfile, remotePort);
+  await waitForPort(remotePort, firefox);
+  bidi = await BidiClient.connect(`ws://127.0.0.1:${remotePort}/session`);
+  await bidi.send("session.new", {
+    capabilities: { alwaysMatch: { acceptInsecureCerts: true } },
+  });
+  const installed = await bidi.send("webExtension.install", {
+    extensionData: { type: "path", path: extensionBuildDirectory },
+  });
+  if (!installed.extension)
+    throw new Error("Firefox did not install the extension");
+
+  const contexts = await topLevelContexts(bidi);
+  const appContext = contexts[0]?.context;
+  if (!appContext) throw new Error("Firefox did not create a browser context");
+
+  console.log(
+    "Signing the disposable Firefox profile into the protected fixture...",
+  );
+  await navigate(bidi, appContext, `${fixture.origin}/login`);
+  await evaluate(
+    bidi,
+    appContext,
+    `document.querySelector("#sign-in")?.click(); true`,
+  );
+  await eventually("Protected fixture login did not complete", () =>
+    evaluate(
+      bidi,
+      appContext,
+      `document.body.innerText.includes(${JSON.stringify(AUTH_MARKER)})`,
+    ),
+  );
+
+  console.log("Provisioning the disposable Serial demo account...");
+  await bidi.send("browsingContext.navigate", {
+    context: appContext,
+    url: appUrl,
+    wait: "complete",
+  });
+  await eventually("Serial demo account did not finish provisioning", () =>
+    evaluate(
+      bidi,
+      appContext,
+      `location.origin === ${JSON.stringify(appUrl)} && !location.pathname.startsWith("/api/demo/provision")`,
+    ),
+  );
+  await seedFeedItem(databasePath, fixture.origin);
+
+  console.log("Opening /read and initiating Capture from the app...");
+  // Leave the provisioning page before the app's initial router hydration can
+  // race the direct deep-link navigation below.
+  await navigate(bidi, appContext, "about:blank");
+  await navigate(bidi, appContext, `${appUrl}/read/${ITEM_ID}`);
+  await eventually("Capture button did not appear", () =>
+    evaluate(
+      bidi,
+      appContext,
+      `Array.from(document.querySelectorAll("button")).some((button) => button.textContent?.trim() === "Capture")`,
+    ),
+  );
+
+  let monitoring = true;
+  let maximumContextCount = 1;
+  const monitorContexts = (async () => {
+    while (monitoring) {
+      maximumContextCount = Math.max(
+        maximumContextCount,
+        (await topLevelContexts(bidi)).length,
+      );
+      await delay(25);
+    }
+  })();
+  await evaluate(
+    bidi,
+    appContext,
+    `Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.trim() === "Capture")?.click(); true`,
+  );
+  try {
+    await eventually("Authenticated article was not rendered in Serial", () =>
+      evaluate(
+        bidi,
+        appContext,
+        `document.body.innerText.includes(${JSON.stringify(AUTH_MARKER)})`,
+      ),
+    );
+  } catch (error) {
+    const diagnostics = await evaluate(
+      bidi,
+      appContext,
+      `JSON.stringify({
+        captureState: document.querySelector("[data-prototype-capture-state]")?.getAttribute("data-prototype-capture-state"),
+        body: document.body.innerText.slice(-1000)
+      })`,
+    );
+    throw new Error(
+      `${error instanceof Error ? error.message : error}; reader diagnostics: ${diagnostics}`,
+      { cause: error },
+    );
+  }
+  monitoring = false;
+  await monitorContexts;
+
+  const bodyState = await evaluate(
+    bidi,
+    appContext,
+    `JSON.stringify({
+      hasAuthBody: document.body.innerText.includes(${JSON.stringify(AUTH_MARKER)}),
+      hasFeedTeaser: document.body.innerText.includes(${JSON.stringify(FEED_TEASER)}),
+      captureState: document.querySelector("[data-prototype-capture-state]")?.getAttribute("data-prototype-capture-state")
+    })`,
+  );
+  const assertion = JSON.parse(bodyState);
+  if (!assertion.hasAuthBody || assertion.hasFeedTeaser) {
+    throw new Error(`Unexpected captured reader state: ${bodyState}`);
+  }
+  if (assertion.captureState !== "captured") {
+    throw new Error(`Capture finished in state ${assertion.captureState}`);
+  }
+  if (maximumContextCount < 2) {
+    throw new Error("The extension did not open a temporary capture tab");
+  }
+  await eventually(
+    "Temporary capture tab did not close",
+    async () => (await topLevelContexts(bidi)).length === 1,
+  );
+
+  console.log(
+    "PASS: Firefox returned the signed-in article to /read and closed its capture tab.",
+  );
+} catch (error) {
+  const appOutput = app?.getOutput().trim();
+  if (appOutput) {
+    console.error(`Demo app log tail:\n${appOutput.slice(-4_000)}`);
+  }
+  throw error;
+} finally {
+  if (bidi) {
+    await bidi.send("session.end").catch(() => undefined);
+    bidi.close();
+  }
+  await stopChild(firefox);
+  await stopChild(app?.child);
+  await fixture?.close();
+  await stopChildren();
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+  if (interrupted) process.exitCode = 130;
+}

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -16,6 +16,7 @@ const developmentInstanceOrigins = [
   "http://127.0.0.1/*",
   "http://[::1]/*",
 ];
+const prototypeCaptureOrigins = ["http://*/*", "https://*/*"];
 const extensionIcons = {
   16: "icon/16.png",
   32: "icon/32.png",
@@ -74,7 +75,15 @@ export default defineConfig({
       ...(manifestVersion === 2
         ? { browser_action: { default_icon: extensionIcons } }
         : { action: { default_icon: extensionIcons } }),
-      permissions: ["identity", "storage", "activeTab", "scripting"],
+      permissions: [
+        "identity",
+        "storage",
+        "activeTab",
+        "scripting",
+        ...(manifestVersion === 2 ? prototypeCaptureOrigins : []),
+      ],
+      host_permissions:
+        manifestVersion === 3 ? prototypeCaptureOrigins : undefined,
       optional_permissions: manifestVersion === 2 ? instanceOrigins : undefined,
       optional_host_permissions:
         manifestVersion === 3 ? instanceOrigins : undefined,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:demo": "node apps/extension/scripts/dev-demo.mjs",
     "dev:demo:chrome": "node apps/extension/scripts/dev-demo.mjs chrome",
     "dev:demo:firefox": "node apps/extension/scripts/dev-demo.mjs firefox",
+    "test:prototype:capture:firefox": "pnpm --filter @serial/extension test:prototype:capture:firefox",
     "dev:extension": "pnpm --filter @serial/extension dev",
     "build": "turbo run build:artifact",
     "build:artifact": "turbo run build:artifact",

--- a/packages/bookmark-capture/src/index.ts
+++ b/packages/bookmark-capture/src/index.ts
@@ -2,6 +2,7 @@ export * from "./capabilities";
 export * from "./contracts";
 export * from "./mutations";
 export * from "./policy";
+export * from "./prototype-feed-item-capture";
 export * from "./thumbnail";
 export type {
   ExtensionCaptureCandidate,

--- a/packages/bookmark-capture/src/prototype-feed-item-capture.ts
+++ b/packages/bookmark-capture/src/prototype-feed-item-capture.ts
@@ -1,0 +1,87 @@
+// PROTOTYPE: Ephemeral Feed-item capture. Keep this contract off production
+// branches until the inactive-tab experiment has a clear verdict.
+
+export const PROTOTYPE_FEED_ITEM_CAPTURE_REQUEST =
+  "prototype.feed-item-capture.request" as const;
+export const PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE =
+  "prototype.feed-item-capture.response" as const;
+
+export type PrototypeFeedItemCaptureRequest = {
+  type: typeof PROTOTYPE_FEED_ITEM_CAPTURE_REQUEST;
+  requestId: string;
+  sourceUrl: string;
+};
+
+export type PrototypeFeedItemCaptureResponse =
+  | {
+      type: typeof PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE;
+      requestId: string;
+      ok: true;
+      capture: {
+        contentHtml: string;
+        effectiveUrl: string;
+        title: string;
+      };
+    }
+  | {
+      type: typeof PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE;
+      requestId: string;
+      ok: false;
+      error: string;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isPrototypeFeedItemCaptureRequest(
+  value: unknown,
+): value is PrototypeFeedItemCaptureRequest {
+  return (
+    isRecord(value) &&
+    value.type === PROTOTYPE_FEED_ITEM_CAPTURE_REQUEST &&
+    typeof value.requestId === "string" &&
+    value.requestId.length > 0 &&
+    typeof value.sourceUrl === "string"
+  );
+}
+
+export function parsePrototypeFeedItemCaptureResponse(
+  value: unknown,
+  requestId: string,
+): PrototypeFeedItemCaptureResponse | null {
+  if (
+    !isRecord(value) ||
+    value.type !== PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE ||
+    value.requestId !== requestId ||
+    typeof value.ok !== "boolean"
+  ) {
+    return null;
+  }
+  if (!value.ok) {
+    return typeof value.error === "string"
+      ? {
+          type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+          requestId,
+          ok: false,
+          error: value.error,
+        }
+      : null;
+  }
+  if (!isRecord(value.capture)) return null;
+  const { contentHtml, effectiveUrl, title } = value.capture;
+  if (
+    typeof contentHtml !== "string" ||
+    contentHtml.length === 0 ||
+    typeof effectiveUrl !== "string" ||
+    typeof title !== "string"
+  ) {
+    return null;
+  }
+  return {
+    type: PROTOTYPE_FEED_ITEM_CAPTURE_RESPONSE,
+    requestId,
+    ok: true,
+    capture: { contentHtml, effectiveUrl, title },
+  };
+}


### PR DESCRIPTION
- add an ephemeral Capture action to Feed-item `/read` pages
- bridge in-app requests through the extension to an inactive same-profile tab
- reuse the Bookmark extractor and render returned sanitized HTML in memory
- add a disposable authenticated Firefox end-to-end test driven through WebDriver BiDi
- wait for Firefox capture tabs to commit an HTTP(S) document before script injection
- keep capture state ephemeral with no schema or persistence changes