### PR TITLE
Preserve reader image order

### DIFF
--- a/apps/app/src/components/content-reader/flattenReaderImages.tsx
+++ b/apps/app/src/components/content-reader/flattenReaderImages.tsx
@@ -1,6 +1,17 @@
 import React from "react";
 import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
 
+type ElementWithChildren = React.ReactElement<{
+  children?: React.ReactNode;
+}>;
+
+type AnchorSegmentKind = "image" | "linked";
+
+interface AnchorSegment {
+  kind: AnchorSegmentKind;
+  nodes: React.ReactNode[];
+}
+
 function isImageLightbox(node: React.ReactNode): boolean {
   return React.isValidElement(node) && node.type === ArticleImageLightbox;
 }
@@ -13,48 +24,124 @@ function hasLinkedContent(node: React.ReactNode): boolean {
   return React.Children.toArray(node.props.children).some(hasLinkedContent);
 }
 
-function extractImages(node: React.ReactNode): {
-  images: React.ReactNode[];
-  rest: React.ReactNode | null;
-} {
-  if (!React.isValidElement(node)) return { images: [], rest: node };
+function mergeAdjacentSegments(segments: AnchorSegment[]): AnchorSegment[] {
+  const mergedSegments: AnchorSegment[] = [];
 
-  if (isImageLightbox(node)) return { images: [node], rest: null };
-
-  const element = node as React.ReactElement<{ children?: React.ReactNode }>;
-  const children = React.Children.toArray(element.props.children);
-  if (children.length === 0) return { images: [], rest: node };
-
-  const collectedImages: React.ReactNode[] = [];
-  const remainingChildren: React.ReactNode[] = [];
-
-  for (const child of children) {
-    const { images, rest } = extractImages(child);
-    collectedImages.push(...images);
-    if (rest !== null) remainingChildren.push(rest);
+  for (const segment of segments) {
+    const previousSegment = mergedSegments.at(-1);
+    if (previousSegment?.kind === segment.kind) {
+      previousSegment.nodes.push(...segment.nodes);
+    } else {
+      mergedSegments.push({ kind: segment.kind, nodes: [...segment.nodes] });
+    }
   }
 
-  if (collectedImages.length === 0) return { images: [], rest: node };
+  return mergedSegments;
+}
 
-  const anchorHasLinkedContent = remainingChildren.some(hasLinkedContent);
-  const keepWrapper =
-    remainingChildren.length > 0 &&
-    (element.type !== "a" || anchorHasLinkedContent);
-  const rest = keepWrapper
-    ? React.cloneElement(element, undefined, ...remainingChildren)
-    : null;
+function containsImage(segments: AnchorSegment[]): boolean {
+  return segments.some(({ kind }) => kind === "image");
+}
 
-  return { images: collectedImages, rest };
+function createSegmentKey(
+  element: ElementWithChildren,
+  segmentIndex: number,
+): string {
+  return `${String(element.key ?? "reader")}-segment-${segmentIndex}`;
+}
+
+function splitAnchorNode(node: React.ReactNode): AnchorSegment[] {
+  if (isImageLightbox(node)) {
+    return [{ kind: "image", nodes: [node] }];
+  }
+
+  if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return [{ kind: "linked", nodes: [node] }];
+  }
+
+  const element = node as ElementWithChildren;
+  const children = React.Children.toArray(element.props.children);
+  if (children.length === 0) {
+    return [{ kind: "linked", nodes: [node] }];
+  }
+
+  const childSegments = mergeAdjacentSegments(
+    children.flatMap(splitAnchorNode),
+  );
+  if (!containsImage(childSegments)) {
+    return [{ kind: "linked", nodes: [node] }];
+  }
+
+  return childSegments.map((segment, segmentIndex) => ({
+    kind: segment.kind,
+    nodes: [
+      React.cloneElement(
+        element,
+        { key: createSegmentKey(element, segmentIndex) },
+        ...segment.nodes,
+      ),
+    ],
+  }));
+}
+
+function transformAnchor(
+  element: ElementWithChildren,
+): React.ReactNode[] | null {
+  const children = React.Children.toArray(element.props.children);
+  const segments = mergeAdjacentSegments(children.flatMap(splitAnchorNode));
+  if (!containsImage(segments)) return null;
+
+  if (!children.some(hasLinkedContent)) {
+    return children;
+  }
+
+  return segments.flatMap((segment, segmentIndex) => {
+    const segmentHasLinkedContent = segment.nodes.some(hasLinkedContent);
+    if (segment.kind === "image" || !segmentHasLinkedContent) {
+      return segment.nodes;
+    }
+
+    return [
+      React.cloneElement(
+        element,
+        { key: createSegmentKey(element, segmentIndex) },
+        ...segment.nodes,
+      ),
+    ];
+  });
+}
+
+function transformReaderNode(node: React.ReactNode): React.ReactNode[] | null {
+  if (
+    isImageLightbox(node) ||
+    !React.isValidElement<{ children?: React.ReactNode }>(node)
+  ) {
+    return null;
+  }
+
+  const element = node as ElementWithChildren;
+  const children = React.Children.toArray(element.props.children);
+  if (children.length === 0) return null;
+
+  if (element.type === "a") return transformAnchor(element);
+
+  const transformedChildren = children.map(transformReaderNode);
+  if (transformedChildren.every((child) => child === null)) return null;
+
+  return [
+    React.cloneElement(
+      element,
+      undefined,
+      ...transformedChildren.flatMap(
+        (transformedChild, childIndex) =>
+          transformedChild ?? [children[childIndex]],
+      ),
+    ),
+  ];
 }
 
 export function flattenReaderImages(
   nodes: React.ReactNode[],
 ): React.ReactNode[] {
-  const result: React.ReactNode[] = [];
-  for (const node of nodes) {
-    const { images, rest } = extractImages(node);
-    result.push(...images);
-    if (rest !== null) result.push(rest);
-  }
-  return result;
+  return nodes.flatMap((node) => transformReaderNode(node) ?? [node]);
 }

--- a/apps/app/tests/unit/components/reader-content-images.test.ts
+++ b/apps/app/tests/unit/components/reader-content-images.test.ts
@@ -7,13 +7,72 @@ import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbo
 
 function renderReaderNodes(...nodes: ReactNode[]) {
   return renderToStaticMarkup(
-    createElement("main", null, ...flattenReaderImages(nodes)),
+    createElement("div", null, ...flattenReaderImages(nodes)),
   );
 }
 
+function expectInOrder(markup: string, ...values: string[]) {
+  const positions = values.map((value) => markup.indexOf(value));
+
+  expect(positions.every((position) => position >= 0)).toBe(true);
+  expect(positions).toEqual([...positions].sort((left, right) => left - right));
+}
+
 describe("reader content images", () => {
+  it("preserves an image between paragraphs in a wrapped article", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "article",
+        null,
+        createElement("p", null, "Paragraph before image"),
+        createElement(ArticleImageLightbox, {
+          src: "https://example.com/image.jpg",
+          alt: "Article illustration",
+        }),
+        createElement("p", null, "Paragraph after image"),
+      ),
+    );
+
+    expectInOrder(
+      markup,
+      "Paragraph before image",
+      "Open image preview: Article illustration",
+      "Paragraph after image",
+    );
+  });
+
+  it("preserves multiple images among content in a main wrapper", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "main",
+        null,
+        createElement("p", null, "Introduction"),
+        createElement(ArticleImageLightbox, {
+          src: "https://example.com/first.jpg",
+          alt: "First illustration",
+        }),
+        createElement("p", null, "Discussion"),
+        createElement(ArticleImageLightbox, {
+          src: "https://example.com/second.jpg",
+          alt: "Second illustration",
+        }),
+        createElement("p", null, "Conclusion"),
+      ),
+    );
+
+    expectInOrder(
+      markup,
+      "Introduction",
+      "Open image preview: First illustration",
+      "Discussion",
+      "Open image preview: Second illustration",
+      "Conclusion",
+    );
+  });
+
   it("removes navigation wrapped around an image", () => {
     const markup = renderReaderNodes(
+      createElement("p", null, "Before linked image"),
       createElement(
         "a",
         { href: "https://example.com/image-target" },
@@ -30,30 +89,45 @@ describe("reader content images", () => {
         ),
         "\n",
       ),
+      createElement("p", null, "After linked image"),
     );
 
     expect(markup).toContain('aria-label="Open image preview: Linked preview"');
     expect(markup).not.toContain("image-target");
+    expect(markup.match(/Open image preview: Linked preview/g)).toHaveLength(1);
+    expectInOrder(
+      markup,
+      "Before linked image",
+      "Open image preview: Linked preview",
+      "After linked image",
+    );
   });
 
-  it("preserves linked text next to a non-navigating image", () => {
+  it("splits a mixed anchor around a non-navigating image", () => {
     const markup = renderReaderNodes(
       createElement(
         "a",
         { href: "https://example.com/article" },
+        "Read before the image",
         createElement(ArticleImageLightbox, {
           src: "https://example.com/image.jpg",
           alt: "Mixed preview",
         }),
-        "Read the article",
+        "Read after the image",
       ),
     );
 
-    expect(markup.indexOf("Open image preview: Mixed preview")).toBeLessThan(
-      markup.indexOf("Read the article"),
+    expectInOrder(
+      markup,
+      "Read before the image",
+      "Open image preview: Mixed preview",
+      "Read after the image",
     );
     expect(markup).toContain(
-      '<a href="https://example.com/article">Read the article</a>',
+      '<a href="https://example.com/article">Read before the image</a>',
+    );
+    expect(markup).toContain(
+      '<a href="https://example.com/article">Read after the image</a>',
     );
   });
 
@@ -68,6 +142,32 @@ describe("reader content images", () => {
 
     expect(markup).toContain(
       '<a href="https://example.com/article">Read the article</a>',
+    );
+  });
+
+  it("keeps a figure and its caption together", () => {
+    const markup = renderReaderNodes(
+      createElement(
+        "article",
+        null,
+        createElement(
+          "figure",
+          null,
+          createElement(ArticleImageLightbox, {
+            src: "https://example.com/diagram.jpg",
+            alt: "System diagram",
+          }),
+          createElement("figcaption", null, "How the system fits together"),
+        ),
+      ),
+    );
+
+    expect(markup).toContain("<figure>");
+    expect(markup).toContain("</figcaption></figure>");
+    expectInOrder(
+      markup,
+      "Open image preview: System diagram",
+      "How the system fits together",
     );
   });
 });


### PR DESCRIPTION
- Preserve captured image positions through reader wrappers
- Remove image navigation without moving images or unlinking adjacent text
- Cover wrapped articles, mixed links, multiple images, and figure captions