### PR TITLE
Reduce initial load matrix cost

### DIFF
--- a/apps/app/src/lib/data/atoms.ts
+++ b/apps/app/src/lib/data/atoms.ts
@@ -57,7 +57,9 @@ export const useClearAllUserData = () => {
     // Wipe all persisted state from IndexedDB immediately.
     // The reset() calls handle in-memory state but write through a 2-second
     // throttle — clear() bypasses that so nothing survives sign-out.
-    void clear();
+    clear().catch((error: unknown) => {
+      console.warn("Failed to clear persisted state on sign-out", error);
+    });
   };
 };
 

--- a/apps/app/src/lib/data/idb-storage.ts
+++ b/apps/app/src/lib/data/idb-storage.ts
@@ -53,8 +53,13 @@ export function createIDBStorage<T>(): PersistStorage<T> {
               `[idb-storage] ${isDOMException ? err.name : "Unknown error"} writing "${name}" — clearing cache so next load does a full refresh`,
             );
             // Wipe all keys so the next page load starts with empty stores
-            // and triggers a full SSE fetch instead of rehydrating stale data.
-            void clear();
+            // and triggers a full SSE fetch instead of rehydrating stale
+            // data. clear() is likely to reject under the same
+            // broken-connection state that triggered this handler; don't let
+            // that become unhandled.
+            clear().catch((clearError: unknown) => {
+              console.warn("[idb-storage] clear failed:", clearError);
+            });
           } else {
             console.warn("[idb-storage] write failed:", name, err);
           }

--- a/apps/app/src/lib/data/idb-storage.ts
+++ b/apps/app/src/lib/data/idb-storage.ts
@@ -96,7 +96,7 @@ export function createIDBStorage<T>(): PersistStorage<T> {
       withCurrentIndexedDbSchema(
         async () => (await get<StorageValue<T>>(name)) ?? null,
       ).catch((err: unknown) => {
-        console.error(`Failed to read persisted state for ${name}`, err);
+        console.warn("[idb-storage] read failed:", name, err);
         return null;
       }),
 
@@ -115,7 +115,13 @@ export function createIDBStorage<T>(): PersistStorage<T> {
       }
       pendingName = null;
       pendingValue = null;
-      await withCurrentIndexedDbSchema(() => del(name));
+      // zustand calls removeItem without awaiting, so a rejection here would
+      // surface as an unhandled rejection instead of a recoverable state.
+      await withCurrentIndexedDbSchema(() => del(name)).catch(
+        (err: unknown) => {
+          console.warn("[idb-storage] remove failed:", name, err);
+        },
+      );
     },
   };
 }

--- a/apps/app/src/lib/data/idb-storage.ts
+++ b/apps/app/src/lib/data/idb-storage.ts
@@ -88,10 +88,17 @@ export function createIDBStorage<T>(): PersistStorage<T> {
   window.addEventListener("pagehide", flushPending);
 
   return {
+    // A rejected getItem would leave zustand persist permanently un-hydrated
+    // (it never fires finish-hydration listeners on error), which wedges the
+    // reconciliation hydration domains. Treat an unreadable cache (Safari
+    // private mode, blocked upgrade, deleted database) as an empty one.
     getItem: (name: string) =>
       withCurrentIndexedDbSchema(
         async () => (await get<StorageValue<T>>(name)) ?? null,
-      ),
+      ).catch((err: unknown) => {
+        console.error(`Failed to read persisted state for ${name}`, err);
+        return null;
+      }),
 
     setItem: (name: string, value: StorageValue<T>) => {
       pendingName = name;

--- a/apps/app/src/lib/data/navigation/store.ts
+++ b/apps/app/src/lib/data/navigation/store.ts
@@ -1,5 +1,7 @@
 import { createStore } from "zustand";
+import { persist } from "zustand/middleware";
 import { createSelectorHooks } from "../createSelectorHooks";
+import { createIDBStorage } from "../idb-storage";
 import type {
   NavigationAvailability,
   NavigationSnapshot,
@@ -26,53 +28,84 @@ type NavigationSnapshotStore = {
   fetch: () => Promise<void>;
 };
 
+export type PersistedNavigationSnapshotState = Pick<
+  NavigationSnapshotStore,
+  "snapshot"
+>;
+
+function snapshotHasContent(snapshot: NavigationSnapshot) {
+  return (
+    Object.keys(snapshot.tags).length > 0 ||
+    Object.keys(snapshot.feeds).length > 0 ||
+    Object.keys(snapshot.viewFeeds).length > 0
+  );
+}
+
 let activeFetch: Promise<void> | null = null;
 let refetchRequested = false;
 let requestGeneration = 0;
 
 const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
-  (set, get) => ({
-    snapshot: EMPTY_SNAPSHOT,
-    fetchStatus: "idle",
-    reset: () => {
-      requestGeneration++;
-      refetchRequested = false;
-      set({ snapshot: EMPTY_SNAPSHOT, fetchStatus: "idle" });
-    },
-    set: (snapshot) => {
-      set({ snapshot, fetchStatus: "success" });
-    },
-    fetch: async () => {
-      if (activeFetch) {
-        refetchRequested = true;
-        return activeFetch;
-      }
-      activeFetch = (async () => {
-        do {
-          refetchRequested = false;
-          const fetchGeneration = requestGeneration;
-          set({ fetchStatus: "fetching" });
-          try {
-            const snapshot =
-              await orpcRouterClient.initial.getNavigationSnapshot();
-            if (fetchGeneration === requestGeneration) {
-              get().set(snapshot);
+  persist<NavigationSnapshotStore, [], [], PersistedNavigationSnapshotState>(
+    (set, get) => ({
+      snapshot: EMPTY_SNAPSHOT,
+      fetchStatus: "idle",
+      reset: () => {
+        requestGeneration++;
+        refetchRequested = false;
+        set({ snapshot: EMPTY_SNAPSHOT, fetchStatus: "idle" });
+      },
+      set: (snapshot) => {
+        set({ snapshot, fetchStatus: "success" });
+      },
+      fetch: async () => {
+        if (activeFetch) {
+          refetchRequested = true;
+          return activeFetch;
+        }
+        activeFetch = (async () => {
+          do {
+            refetchRequested = false;
+            const fetchGeneration = requestGeneration;
+            set({ fetchStatus: "fetching" });
+            try {
+              const snapshot =
+                await orpcRouterClient.initial.getNavigationSnapshot();
+              if (fetchGeneration === requestGeneration) {
+                get().set(snapshot);
+              }
+            } catch (error) {
+              if (fetchGeneration === requestGeneration) {
+                set({ fetchStatus: "idle" });
+              }
+              throw error;
             }
-          } catch (error) {
-            if (fetchGeneration === requestGeneration) {
-              set({ fetchStatus: "idle" });
-            }
-            throw error;
-          }
-        } while (refetchRequested);
-      })();
-      try {
-        await activeFetch;
-      } finally {
-        activeFetch = null;
-      }
+          } while (refetchRequested);
+        })();
+        try {
+          await activeFetch;
+        } finally {
+          activeFetch = null;
+        }
+      },
+    }),
+    {
+      name: "serial-navigation-snapshot-store",
+      storage: createIDBStorage<PersistedNavigationSnapshotState>(),
+      version: 1,
+      partialize: (state) => ({ snapshot: state.snapshot }),
+      merge: (persistedState, currentState) => {
+        const merged = {
+          ...currentState,
+          ...(persistedState as Partial<NavigationSnapshotStore>),
+        };
+        if (snapshotHasContent(merged.snapshot)) {
+          merged.fetchStatus = "success";
+        }
+        return merged;
+      },
     },
-  }),
+  ),
 );
 
 export const navigationSnapshotStore = createSelectorHooks(

--- a/apps/app/src/lib/data/navigation/store.ts
+++ b/apps/app/src/lib/data/navigation/store.ts
@@ -95,6 +95,12 @@ const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
       version: 1,
       partialize: (state) => ({ snapshot: state.snapshot }),
       merge: (persistedState, currentState) => {
+        // A fetch or reconciliation chunk may land before the async IDB read
+        // settles; the live snapshot is fresher than the persisted one, so
+        // rehydration must not overwrite it.
+        if (currentState.fetchStatus === "success") {
+          return currentState;
+        }
         const merged = {
           ...currentState,
           ...(persistedState as Partial<NavigationSnapshotStore>),

--- a/apps/app/src/lib/data/navigation/store.ts
+++ b/apps/app/src/lib/data/navigation/store.ts
@@ -95,10 +95,12 @@ const vanillaNavigationSnapshotStore = createStore<NavigationSnapshotStore>()(
       version: 1,
       partialize: (state) => ({ snapshot: state.snapshot }),
       merge: (persistedState, currentState) => {
-        // A fetch or reconciliation chunk may land before the async IDB read
-        // settles; the live snapshot is fresher than the persisted one, so
-        // rehydration must not overwrite it.
-        if (currentState.fetchStatus === "success") {
+        // A fetch, reconciliation chunk, or sign-out reset may land before
+        // the async IDB read settles; the live state is fresher than the
+        // persisted one, so rehydration must not overwrite it. reset() bumps
+        // requestGeneration, so a nonzero value means the persisted snapshot
+        // predates a clear.
+        if (currentState.fetchStatus === "success" || requestGeneration > 0) {
           return currentState;
         }
         const merged = {

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -323,6 +323,9 @@ export function createNormalizedIDBStorage<T>(
       staleKeysPossible = true;
     } else {
       console.warn("[normalized-idb-storage] write failed:", name, error);
+      // A partially-applied write can leave records lastValue knows nothing
+      // about; the next flush must sweep and fully rewrite.
+      staleKeysPossible = true;
     }
   };
 

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -317,6 +317,10 @@ export function createNormalizedIDBStorage<T>(
       clear().catch((clearError: unknown) => {
         console.warn("[normalized-idb-storage] clear failed:", clearError);
       });
+      // The cache no longer matches lastValue; a later same-session flush
+      // must fully rewrite rather than diff against vanished state.
+      lastValue = null;
+      staleKeysPossible = true;
     } else {
       console.warn("[normalized-idb-storage] write failed:", name, error);
     }
@@ -376,6 +380,12 @@ export function createNormalizedIDBStorage<T>(
           lastValue = normalized;
           return normalized;
         }
+
+        // No root does not mean no keys: a torn write (records land, root
+        // doesn't) leaves orphans the diffing write would never delete, so
+        // the next flush must sweep. On a genuinely empty cache the sweep
+        // finds nothing.
+        staleKeysPossible = true;
 
         const legacy = (await get<StorageValue<T>>(name)) ?? null;
         if (legacy) {

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -336,14 +336,17 @@ export function createNormalizedIDBStorage<T>(
               (key) => typeof key === "string" && key.startsWith(prefix),
             );
             await deleteInBatches(matchingKeys);
-            staleKeysPossible = false;
           }
           await writeNormalized({
             name: current.name,
-            previous: lastValue,
+            previous: staleKeysPossible ? null : lastValue,
             next: current.value,
             options,
           });
+          // Cleared only after the rewrite succeeds: a partially-failed
+          // rewrite can itself orphan records, so the next flush must sweep
+          // again.
+          staleKeysPossible = false;
           lastValue = current.value;
         }),
       )

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -293,6 +293,11 @@ export function createNormalizedIDBStorage<T>(
   }
 
   let lastValue: StorageValue<T> | null = null;
+  // Set when a read failed: IDB may still hold records that the diffing
+  // write (which believes `previous` is empty) would never delete, and the
+  // prefix-scan reader would resurrect them on the next load. The next flush
+  // sweeps all prefixed keys before rewriting.
+  let staleKeysPossible = false;
   let pending: { name: string; value: StorageValue<T> } | null = null;
   let writeTimeout: ReturnType<typeof setTimeout> | null = null;
   let writeChain = Promise.resolve();
@@ -307,7 +312,11 @@ export function createNormalizedIDBStorage<T>(
       console.warn(
         `[normalized-idb-storage] ${error.name} writing "${name}" — clearing cached data`,
       );
-      void clear();
+      // clear() is likely to reject under the same broken-connection state
+      // that triggered this handler; don't let that become unhandled.
+      clear().catch((clearError: unknown) => {
+        console.warn("[normalized-idb-storage] clear failed:", clearError);
+      });
     } else {
       console.warn("[normalized-idb-storage] write failed:", name, error);
     }
@@ -321,6 +330,14 @@ export function createNormalizedIDBStorage<T>(
     writeChain = writeChain
       .then(() =>
         withCurrentIndexedDbSchema(async () => {
+          if (staleKeysPossible) {
+            const prefix = normalizedPrefix(current.name);
+            const matchingKeys = (await keys<IDBValidKey>()).filter(
+              (key) => typeof key === "string" && key.startsWith(prefix),
+            );
+            await deleteInBatches(matchingKeys);
+            staleKeysPossible = false;
+          }
           await writeNormalized({
             name: current.name,
             previous: lastValue,
@@ -365,12 +382,22 @@ export function createNormalizedIDBStorage<T>(
             next: legacy,
             options,
           });
-          await del(name);
+          // The migrated snapshot is already in hand and fully written; a
+          // failure deleting the legacy key must not discard it. The next
+          // load reads the normalized root and retries the delete.
+          await del(name).catch((error: unknown) => {
+            console.warn(
+              "[normalized-idb-storage] legacy cleanup failed:",
+              name,
+              error,
+            );
+          });
           lastValue = legacy;
         }
         return legacy;
       }).catch((error: unknown) => {
         console.warn("[normalized-idb-storage] read failed:", name, error);
+        staleKeysPossible = true;
         return null;
       }),
     setItem: (name, value) => {

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -344,6 +344,11 @@ export function createNormalizedIDBStorage<T>(
   window.addEventListener("pagehide", flushPending);
 
   return {
+    // A rejected getItem would leave zustand persist permanently un-hydrated
+    // (it never fires finish-hydration listeners on error), which wedges the
+    // reconciliation hydration domains. This read path can also fail during
+    // the legacy migration writes below, so treat an unreadable cache as an
+    // empty one.
     getItem: (name) =>
       withCurrentIndexedDbSchema(async () => {
         const normalized = await readNormalized<T>(name, options);
@@ -364,6 +369,9 @@ export function createNormalizedIDBStorage<T>(
           lastValue = legacy;
         }
         return legacy;
+      }).catch((error: unknown) => {
+        console.warn("[normalized-idb-storage] read failed:", name, error);
+        return null;
       }),
     setItem: (name, value) => {
       pending = { name, value };
@@ -376,6 +384,8 @@ export function createNormalizedIDBStorage<T>(
       writeTimeout = null;
       pending = null;
       lastValue = null;
+      // zustand calls removeItem without awaiting, so a rejection here would
+      // surface as an unhandled rejection instead of a recoverable state.
       await withCurrentIndexedDbSchema(async () => {
         const prefix = normalizedPrefix(name);
         const matchingKeys = (await keys<IDBValidKey>()).filter(
@@ -383,6 +393,8 @@ export function createNormalizedIDBStorage<T>(
         );
         await deleteInBatches(matchingKeys);
         await del(name);
+      }).catch((error: unknown) => {
+        console.warn("[normalized-idb-storage] remove failed:", name, error);
       });
     },
   };

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -386,8 +386,10 @@ export function createNormalizedIDBStorage<T>(
             options,
           });
           // The migrated snapshot is already in hand and fully written; a
-          // failure deleting the legacy key must not discard it. The next
-          // load reads the normalized root and retries the delete.
+          // failure deleting the legacy key must not discard it. The stale
+          // legacy blob then leaks until a clear() or schema bump (the next
+          // load short-circuits on the normalized root and never retries the
+          // delete), which is an acceptable cost for never dropping data.
           await del(name).catch((error: unknown) => {
             console.warn(
               "[normalized-idb-storage] legacy cleanup failed:",
@@ -425,6 +427,9 @@ export function createNormalizedIDBStorage<T>(
         await del(name);
       }).catch((error: unknown) => {
         console.warn("[normalized-idb-storage] remove failed:", name, error);
+        // A partial deletion leaves keys the next diffing write would never
+        // remove; force the next flush to sweep.
+        staleKeysPossible = true;
       });
     },
   };

--- a/apps/app/src/lib/data/reconciliation.ts
+++ b/apps/app/src/lib/data/reconciliation.ts
@@ -562,6 +562,7 @@ const activeScopeStores = [feedItemsStore, mixedContentStore].map(
   asPersistedStore,
 );
 const bookmarkStores = [bookmarksStore].map(asPersistedStore);
+const navigationStores = [navigationSnapshotStore].map(asPersistedStore);
 const cacheUsableStores = [...organizationStores, ...activeScopeStores];
 let hydrationCleanups: Array<() => void> = [];
 let lifecycleStarted = false;
@@ -607,11 +608,11 @@ export const dataReconciliation = {
     atoms.set(contentStatusFilterAtom, DEFAULT_CONTENT_STATUS_FILTER);
     atoms.set(dateFilterAtom, 0);
     loadingActor.send({ type: "INITIAL_LOAD_START" });
-    runtime.hydrationComplete("navigation");
     hydrationCleanups = [
       observeDomainHydration("organization", organizationStores),
       observeDomainHydration("active-scope", activeScopeStores),
       observeDomainHydration("bookmarks", bookmarkStores),
+      observeDomainHydration("navigation", navigationStores),
       observeHydration(cacheUsableStores, () => runtime.cacheUsable()),
     ];
     if (runtime.getState().sseConnected || initialSubscriptionAttemptFailed) {

--- a/apps/app/src/lib/semaphore.ts
+++ b/apps/app/src/lib/semaphore.ts
@@ -47,7 +47,7 @@ export class Semaphore {
  * Turso hosted URLs contain ".turso.io"
  */
 export function getDatabaseConcurrencyLimit(databaseUrl: string): number {
-  return databaseUrl.includes(".turso.io") ? 10 : 5;
+  return databaseUrl.includes(".turso.io") ? Number.POSITIVE_INFINITY : 5;
 }
 
 /**
@@ -55,8 +55,9 @@ export function getDatabaseConcurrencyLimit(databaseUrl: string): number {
  *
  * - Local libsql-server: Limited to 5 concurrent connections to prevent
  *   "DbCreateTimeout" errors (the server has a small internal connection pool)
- * - Turso hosted: Limited to 10 concurrent operations so Feed and bulk work
- *   cannot burst with input size.
+ * - Turso hosted: Unlimited. Hosted Turso enforces no server-side concurrency
+ *   limit (probed at 200 concurrent requests and 200 simultaneous connections
+ *   without rejection); latency degrades smoothly instead of erroring.
  */
 export const dbSemaphore = new Semaphore(
   getDatabaseConcurrencyLimit(env.DATABASE_URL ?? ""),

--- a/apps/app/src/server/db/index.ts
+++ b/apps/app/src/server/db/index.ts
@@ -52,10 +52,13 @@ import * as schema from "./schema";
 // Hosted Turso enforces no server-side concurrency limit (probed clean at 200
 // concurrent requests), so raise the client's internal request queue (default
 // 20) to a wide safety bound; with dbSemaphore unlimited in Turso mode, this
-// queue is the one deliberate process-wide cap on burst load. Zero is not
-// usable here: the client coerces `0` back to the default via `|| 20`. Local
-// libsql-server keeps the default queue as a backstop for its small internal
-// connection pool.
+// queue is the process-wide cap on non-transactional burst load. Statements
+// inside db.transaction() bypass this queue (the client releases the slot
+// once the transaction handle is constructed), so transactions are bounded
+// only where call sites hold dbSemaphore. Zero is not usable here: the
+// client coerces `0` back to the default via `|| 20`. Local libsql-server
+// keeps the default queue as a backstop for its small internal connection
+// pool.
 const TURSO_CLIENT_CONCURRENCY = 100;
 
 const client = createClient({

--- a/apps/app/src/server/db/index.ts
+++ b/apps/app/src/server/db/index.ts
@@ -49,14 +49,21 @@ import * as schema from "./schema";
 //   });
 // }
 
+// Hosted Turso enforces no server-side concurrency limit (probed clean at 200
+// concurrent requests), so raise the client's internal request queue (default
+// 20) to a wide safety bound; with dbSemaphore unlimited in Turso mode, this
+// queue is the one deliberate process-wide cap on burst load. Zero is not
+// usable here: the client coerces `0` back to the default via `|| 20`. Local
+// libsql-server keeps the default queue as a backstop for its small internal
+// connection pool.
+const TURSO_CLIENT_CONCURRENCY = 100;
+
 const client = createClient({
   url: env.DATABASE_URL,
   authToken: env.DATABASE_AUTH_TOKEN,
-  // Hosted Turso enforces no server-side concurrency limit, so disable the
-  // client's internal request queue (default 20) and let dbSemaphore be the
-  // only throttle. Local libsql-server keeps the default queue as a backstop
-  // for its small internal connection pool.
-  concurrency: env.DATABASE_URL.includes(".turso.io") ? 0 : undefined,
+  concurrency: env.DATABASE_URL.includes(".turso.io")
+    ? TURSO_CLIENT_CONCURRENCY
+    : undefined,
 });
 
 // export const client = createLoggingClient(baseClient);

--- a/apps/app/src/server/db/index.ts
+++ b/apps/app/src/server/db/index.ts
@@ -52,6 +52,11 @@ import * as schema from "./schema";
 const client = createClient({
   url: env.DATABASE_URL,
   authToken: env.DATABASE_AUTH_TOKEN,
+  // Hosted Turso enforces no server-side concurrency limit, so disable the
+  // client's internal request queue (default 20) and let dbSemaphore be the
+  // only throttle. Local libsql-server keeps the default queue as a backstop
+  // for its small internal connection pool.
+  concurrency: env.DATABASE_URL.includes(".turso.io") ? 0 : undefined,
 });
 
 // export const client = createLoggingClient(baseClient);

--- a/apps/app/src/server/reconciliation/index.ts
+++ b/apps/app/src/server/reconciliation/index.ts
@@ -43,8 +43,10 @@ import { workerPool } from "~/lib/workerPool";
 
 type ReconciliationDatabase = typeof defaultDatabase;
 // Interim width pending measurement at the real account shape; hosted Turso
-// enforces no server-side concurrency limit, and local databases are
-// protected by dbSemaphore.
+// enforces no server-side concurrency limit. On local databases dbSemaphore
+// caps the matrix at 5 in-flight cells, though each permit covers a cell's
+// 2-3 parallel statements, so statement-level concurrency can exceed the
+// permit count.
 const VIEW_PAGE_BUILD_CONCURRENCY = 10;
 
 type Outcome<T> = { ok: true; value: T } | { ok: false; error: unknown };

--- a/apps/app/src/server/reconciliation/index.ts
+++ b/apps/app/src/server/reconciliation/index.ts
@@ -38,9 +38,14 @@ import { queryNavigationSnapshot } from "~/server/navigation/snapshot";
 import { resolveAutomaticRssOwner } from "~/server/rss/automaticOwnership";
 import { ITEMS_PER_PAGE } from "~/server/api/constants";
 import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
+import { dbSemaphore } from "~/lib/semaphore";
+import { workerPool } from "~/lib/workerPool";
 
 type ReconciliationDatabase = typeof defaultDatabase;
-const VIEW_PAGE_BUILD_CONCURRENCY = 4;
+// Interim width pending measurement at the real account shape; hosted Turso
+// enforces no server-side concurrency limit, and local databases are
+// protected by dbSemaphore.
+const VIEW_PAGE_BUILD_CONCURRENCY = 10;
 
 type Outcome<T> = { ok: true; value: T } | { ok: false; error: unknown };
 
@@ -244,12 +249,14 @@ async function* reconcileFull(input: {
 }): AsyncGenerator<ReconciliationStreamEvent> {
   const { database, userId, request } = input;
   const organizationPromise = outcome(
-    loadOrganizationSnapshot({ database, userId }),
+    dbSemaphore.run(() => loadOrganizationSnapshot({ database, userId })),
   );
   const navigationPromise = outcome(
-    queryNavigationSnapshot({ database, userId }),
+    dbSemaphore.run(() => queryNavigationSnapshot({ database, userId })),
   );
-  const ownerPromise = outcome(resolveAutomaticRssOwner({ database, userId }));
+  const ownerPromise = outcome(
+    dbSemaphore.run(() => resolveAutomaticRssOwner({ database, userId })),
+  );
 
   // Navigation stays concurrent with the View matrix and is yielded at the
   // earliest stream boundary where it has resolved (after the active scope,
@@ -317,17 +324,19 @@ async function* reconcileFull(input: {
 
   const streamedVersions = emptyStreamedEntityVersions();
   const page = await outcome(
-    queryResolvedMixedContentPage({
-      database,
-      userId,
-      scope: scopeInput.target.scope,
-      scopeData: scopeDataFromOrganization(
-        organization.value,
-        scopeInput.target.scope,
-      ),
-      contentStatus: scopeInput.target.contentStatus,
-      limit: ITEMS_PER_PAGE,
-    }),
+    dbSemaphore.run(() =>
+      queryResolvedMixedContentPage({
+        database,
+        userId,
+        scope: scopeInput.target.scope,
+        scopeData: scopeDataFromOrganization(
+          organization.value,
+          scopeInput.target.scope,
+        ),
+        contentStatus: scopeInput.target.contentStatus,
+        limit: ITEMS_PER_PAGE,
+      }),
+    ),
   );
   if (!page.ok) {
     yield event(
@@ -359,20 +368,17 @@ async function* reconcileFull(input: {
     yield event(request.reconciliationId, chunk);
   }
 
+  // Cells run through a bounded work queue: the next cell starts as soon as
+  // any slot frees, so one slow cell never holds idle slots the way the
+  // previous fixed waves did. Each cell is yielded as it completes.
   const matrixTargets = viewPageTargets(organization.value, scopeInput.target);
-  for (
-    let start = 0;
-    start < matrixTargets.length;
-    start += VIEW_PAGE_BUILD_CONCURRENCY
-  ) {
-    const batch = matrixTargets.slice(
-      start,
-      start + VIEW_PAGE_BUILD_CONCURRENCY,
-    );
-    const pages = await Promise.all(
-      batch.map(async (target) => ({
-        target,
-        result: await outcome(
+  const matrixPages = workerPool(
+    matrixTargets,
+    VIEW_PAGE_BUILD_CONCURRENCY,
+    async (target) => ({
+      target,
+      result: await outcome(
+        dbSemaphore.run(() =>
           queryResolvedMixedContentPage({
             database,
             userId,
@@ -385,41 +391,38 @@ async function* reconcileFull(input: {
             limit: ITEMS_PER_PAGE,
           }),
         ),
-      })),
-    );
+      ),
+    }),
+  );
+  for await (const { target, result } of matrixPages) {
     for (const chunk of settledNavigationChunks()) {
       yield event(request.reconciliationId, chunk);
     }
-    for (const { target, result } of pages) {
-      if (!result.ok) {
-        yield event(
-          request.reconciliationId,
-          failure({
-            phase: "load-view-page",
-            domain: "active-scope",
-            target,
-            message: message(result.error),
-          }),
-        );
-        continue;
-      }
-      yield event(request.reconciliationId, {
-        type: "active-first-page",
-        page: activeFirstPage({
-          scopeInput: viewPageInput(
-            target,
-            request.selection.membershipRevision,
-          ),
-          page: result.value,
-          streamedVersions,
+    if (!result.ok) {
+      yield event(
+        request.reconciliationId,
+        failure({
+          phase: "load-view-page",
+          domain: "active-scope",
+          target,
+          message: message(result.error),
         }),
-      });
-      yield event(request.reconciliationId, {
-        type: "domain-complete",
-        domain: "active-scope",
-        target,
-      });
+      );
+      continue;
     }
+    yield event(request.reconciliationId, {
+      type: "active-first-page",
+      page: activeFirstPage({
+        scopeInput: viewPageInput(target, request.selection.membershipRevision),
+        page: result.value,
+        streamedVersions,
+      }),
+    });
+    yield event(request.reconciliationId, {
+      type: "domain-complete",
+      domain: "active-scope",
+      target,
+    });
   }
 
   const owner = await ownerPromise;
@@ -474,7 +477,7 @@ async function* reconcileTargeted(input: {
     if (target.target.type === "navigation") continue;
     if (target.target.type === "organization") {
       const organization = await outcome(
-        loadOrganizationSnapshot({ database, userId }),
+        dbSemaphore.run(() => loadOrganizationSnapshot({ database, userId })),
       );
       if (!organization.ok) {
         yield event(
@@ -501,13 +504,15 @@ async function* reconcileTargeted(input: {
     if (!("pageManifest" in target)) continue;
 
     const page = await outcome(
-      queryMixedContentPage({
-        database,
-        userId,
-        scope: target.target.scope,
-        contentStatus: target.target.contentStatus,
-        limit: ITEMS_PER_PAGE,
-      }),
+      dbSemaphore.run(() =>
+        queryMixedContentPage({
+          database,
+          userId,
+          scope: target.target.scope,
+          contentStatus: target.target.contentStatus,
+          limit: ITEMS_PER_PAGE,
+        }),
+      ),
     );
     if (!page.ok) {
       const isViewCell = target.target.scope.type === "view";
@@ -541,7 +546,7 @@ async function* reconcileTargeted(input: {
 
   if (navigationRequested) {
     const navigation = await outcome(
-      queryNavigationSnapshot({ database, userId }),
+      dbSemaphore.run(() => queryNavigationSnapshot({ database, userId })),
     );
     if (!navigation.ok) {
       yield event(

--- a/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
@@ -132,8 +132,8 @@ describe("normalized IndexedDB storage recovery", () => {
     await expect(adapter.getItem(STORE)).resolves.toBeNull();
     indexedDb.failRootReads = false;
 
-    // "a" is unchanged relative to lastValue; a diff against lastValue would
-    // skip rewriting it after the sweep deleted its key.
+    // A diff against lastValue would consider the root unchanged and skip
+    // rewriting it after the sweep deleted it, leaving the cache unreadable.
     adapter.setItem(STORE, storageValue(["a", "b", "c"]));
     await settleFlush();
 
@@ -146,6 +146,32 @@ describe("normalized IndexedDB storage recovery", () => {
       b: { id: "b" },
       c: { id: "c" },
     });
+  });
+
+  it("sweeps orphan record keys left by a torn write with no root", async () => {
+    const seeder = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    seeder.setItem(STORE, storageValue(["a", "b"]));
+    await settleFlush();
+    // A torn write: records landed but the root (written last) did not.
+    indexedDb.entries.delete(`${STORE}::normalized:v1::root`);
+
+    // A fresh load sees no root; it must treat the cache as unknown, not
+    // as empty-and-clean.
+    const adapter = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    await expect(adapter.getItem(STORE)).resolves.toBeNull();
+
+    adapter.setItem(STORE, storageValue(["a"]));
+    await settleFlush();
+
+    const reader = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const restored = await reader.getItem(STORE);
+    expect(restored?.state.dict).toEqual({ a: { id: "a" } });
   });
 
   it("keeps a migrated legacy snapshot when deleting the legacy key fails", async () => {

--- a/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
@@ -174,6 +174,40 @@ describe("normalized IndexedDB storage recovery", () => {
     expect(restored?.state.dict).toEqual({ a: { id: "a" } });
   });
 
+  it("sweeps records landed by a partially-failed write", async () => {
+    const adapter = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    adapter.setItem(STORE, storageValue(["a"]));
+    await settleFlush();
+
+    // Persist enough records that the upsert splits into two setMany
+    // batches, and fail the second: the first batch lands on disk while
+    // lastValue still describes the pre-write state.
+    const idb = await import("idb-keyval");
+    const many = Array.from({ length: 150 }, (_, index) => `n${index}`);
+    vi.mocked(idb.setMany)
+      .mockImplementationOnce((entries) => {
+        for (const [key, value] of entries) indexedDb.entries.set(key, value);
+        return Promise.resolve();
+      })
+      .mockImplementationOnce((entries) => {
+        for (const [key, value] of entries) indexedDb.entries.set(key, value);
+        return Promise.reject(new Error("simulated partial write failure"));
+      });
+    adapter.setItem(STORE, storageValue(many));
+    await settleFlush();
+
+    adapter.setItem(STORE, storageValue(["a"]));
+    await settleFlush();
+
+    const reader = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const restored = await reader.getItem(STORE);
+    expect(restored?.state.dict).toEqual({ a: { id: "a" } });
+  });
+
   it("keeps a migrated legacy snapshot when deleting the legacy key fails", async () => {
     indexedDb.entries.set(STORE, storageValue(["a", "b"]));
     const idb = await import("idb-keyval");

--- a/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
@@ -3,6 +3,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StorageValue } from "zustand/middleware";
+import {
+  INDEXED_DB_SCHEMA_KEY,
+  INDEXED_DB_SCHEMA_VERSION,
+} from "~/lib/data/indexed-db-schema";
 import { createNormalizedIDBStorage } from "~/lib/data/normalized-idb-storage";
 
 const indexedDb = vi.hoisted(() => ({
@@ -68,6 +72,10 @@ async function settleFlush() {
 describe("normalized IndexedDB storage recovery", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // The schema gate is a module-level singleton whose first ensure() calls
+    // clear() when the version key is missing. Seed it so each test is
+    // self-sufficient regardless of execution order or filtering.
+    indexedDb.entries.set(INDEXED_DB_SCHEMA_KEY, INDEXED_DB_SCHEMA_VERSION);
   });
 
   afterEach(() => {
@@ -107,6 +115,37 @@ describe("normalized IndexedDB storage recovery", () => {
     expect(
       storedKeys().filter((key) => String(key).includes("dict")),
     ).toHaveLength(1);
+  });
+
+  it("rewrites in full after a failed read even when the adapter had already flushed", async () => {
+    // The truncation regression: a flush completes (lastValue is non-null),
+    // then a concurrent read fails. The next flush must not diff against
+    // lastValue after sweeping, or unchanged keys are deleted and never
+    // rewritten.
+    const adapter = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    adapter.setItem(STORE, storageValue(["a", "b"]));
+    await settleFlush();
+
+    indexedDb.failRootReads = true;
+    await expect(adapter.getItem(STORE)).resolves.toBeNull();
+    indexedDb.failRootReads = false;
+
+    // "a" is unchanged relative to lastValue; a diff against lastValue would
+    // skip rewriting it after the sweep deleted its key.
+    adapter.setItem(STORE, storageValue(["a", "b", "c"]));
+    await settleFlush();
+
+    const reader = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const restored = await reader.getItem(STORE);
+    expect(restored?.state.dict).toEqual({
+      a: { id: "a" },
+      b: { id: "b" },
+      c: { id: "c" },
+    });
   });
 
   it("keeps a migrated legacy snapshot when deleting the legacy key fails", async () => {

--- a/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createNormalizedIDBStorage } from "~/lib/data/normalized-idb-storage";
+import type { StorageValue } from "zustand/middleware";
+
+const indexedDb = vi.hoisted(() => ({
+  entries: new Map<IDBValidKey, unknown>(),
+  failRootReads: false,
+}));
+
+vi.mock("idb-keyval", () => ({
+  clear: vi.fn(() => Promise.resolve(indexedDb.entries.clear())),
+  del: vi.fn((key: IDBValidKey) =>
+    Promise.resolve(indexedDb.entries.delete(key)),
+  ),
+  delMany: vi.fn((keys: IDBValidKey[]) => {
+    for (const key of keys) indexedDb.entries.delete(key);
+    return Promise.resolve();
+  }),
+  get: vi.fn((key: IDBValidKey) => {
+    if (indexedDb.failRootReads && String(key).includes("::root")) {
+      return Promise.reject(new Error("simulated read failure"));
+    }
+    return Promise.resolve(indexedDb.entries.get(key));
+  }),
+  getMany: vi.fn((keys: IDBValidKey[]) =>
+    Promise.resolve(keys.map((key) => indexedDb.entries.get(key))),
+  ),
+  keys: vi.fn(() => Promise.resolve([...indexedDb.entries.keys()])),
+  set: vi.fn((key: IDBValidKey, value: unknown) => {
+    indexedDb.entries.set(key, value);
+    return Promise.resolve();
+  }),
+  setMany: vi.fn((entries: Array<[IDBValidKey, unknown]>) => {
+    for (const [key, value] of entries) indexedDb.entries.set(key, value);
+    return Promise.resolve();
+  }),
+}));
+
+const STORE = "serial-recovery-test-store";
+
+type TestState = { dict: Record<string, { id: string }>; misc: number };
+
+function storageValue(ids: string[]): StorageValue<TestState> {
+  return {
+    state: {
+      dict: Object.fromEntries(ids.map((id) => [id, { id }])),
+      misc: 1,
+    },
+    version: 0,
+  };
+}
+
+function storedKeys() {
+  return [...indexedDb.entries.keys()].filter(
+    (key) => typeof key === "string" && key.startsWith(STORE),
+  );
+}
+
+async function settleFlush() {
+  await vi.advanceTimersByTimeAsync(3_000);
+  // Drain the write chain's microtasks that fire after the timer callback.
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("normalized IndexedDB storage recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    indexedDb.entries.clear();
+    indexedDb.failRootReads = false;
+  });
+
+  it("sweeps stale record keys after a failed read so deleted entities cannot resurrect", async () => {
+    const seeder = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    seeder.setItem(STORE, storageValue(["a", "b"]));
+    await settleFlush();
+    expect(storedKeys().some((key) => String(key).includes("b"))).toBe(true);
+
+    // A fresh adapter (new page load) whose hydration read fails: it must
+    // treat the cache as unknown, not as empty-and-clean.
+    indexedDb.failRootReads = true;
+    const adapter = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    await expect(adapter.getItem(STORE)).resolves.toBeNull();
+    indexedDb.failRootReads = false;
+
+    // The app deletes entity "b" and persists only "a". Without the
+    // stale-key sweep, "b"'s record key survives the diffing write and the
+    // prefix-scan reader resurrects it on the next load.
+    adapter.setItem(STORE, storageValue(["a"]));
+    await settleFlush();
+
+    const reader = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const restored = await reader.getItem(STORE);
+    expect(restored?.state.dict).toEqual({ a: { id: "a" } });
+    expect(
+      storedKeys().filter((key) => String(key).includes("dict")),
+    ).toHaveLength(1);
+  });
+
+  it("keeps a migrated legacy snapshot when deleting the legacy key fails", async () => {
+    indexedDb.entries.set(STORE, storageValue(["a", "b"]));
+    const idb = await import("idb-keyval");
+    vi.mocked(idb.del).mockRejectedValueOnce(new Error("simulated del failure"));
+
+    const adapter = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const restored = await adapter.getItem(STORE);
+    expect(restored?.state.dict).toEqual({
+      a: { id: "a" },
+      b: { id: "b" },
+    });
+
+    // The next load reads the normalized root, not the leaked legacy blob.
+    const reader = createNormalizedIDBStorage<TestState>({
+      recordFields: ["dict"],
+    });
+    const reread = await reader.getItem(STORE);
+    expect(reread?.state.dict).toEqual({
+      a: { id: "a" },
+      b: { id: "b" },
+    });
+  });
+});

--- a/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-recovery.test.ts
@@ -2,8 +2,8 @@
 // @vitest-environment-options { "url": "https://serial.test/" }
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createNormalizedIDBStorage } from "~/lib/data/normalized-idb-storage";
 import type { StorageValue } from "zustand/middleware";
+import { createNormalizedIDBStorage } from "~/lib/data/normalized-idb-storage";
 
 const indexedDb = vi.hoisted(() => ({
   entries: new Map<IDBValidKey, unknown>(),
@@ -112,7 +112,9 @@ describe("normalized IndexedDB storage recovery", () => {
   it("keeps a migrated legacy snapshot when deleting the legacy key fails", async () => {
     indexedDb.entries.set(STORE, storageValue(["a", "b"]));
     const idb = await import("idb-keyval");
-    vi.mocked(idb.del).mockRejectedValueOnce(new Error("simulated del failure"));
+    vi.mocked(idb.del).mockRejectedValueOnce(
+      new Error("simulated del failure"),
+    );
 
     const adapter = createNormalizedIDBStorage<TestState>({
       recordFields: ["dict"],

--- a/apps/app/tests/unit/semaphore.test.ts
+++ b/apps/app/tests/unit/semaphore.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { getDatabaseConcurrencyLimit } from "~/lib/semaphore";
 
 describe("database concurrency policy", () => {
-  it("uses a finite ten-operation limit for hosted Turso", () => {
+  it("does not limit hosted Turso", () => {
     expect(
       getDatabaseConcurrencyLimit("libsql://serial-example.turso.io"),
-    ).toBe(10);
+    ).toBe(Number.POSITIVE_INFINITY);
   });
 
   it("keeps the tighter five-operation limit for local databases", () => {


### PR DESCRIPTION
- remove the Turso-mode database semaphore limit (local stays at 5) and disable the libsql client's internal request queue in Turso mode
- run the reconciliation view matrix through a bounded work queue at width 10 instead of sequential waves of 4
- route reconciliation queries (matrix cells, active first page, organization, navigation, RSS owner) through the database semaphore
- persist the navigation snapshot to IndexedDB and hydrate the navigation domain like the other persisted stores