### PR TITLE
Extract shared auth-policy service

### DIFF
--- a/apps/app/src/lib/constants.ts
+++ b/apps/app/src/lib/constants.ts
@@ -48,7 +48,8 @@ export function getEnabledAuthProviders(
     const parsed = JSON.parse(configValue);
     if (!Array.isArray(parsed)) return DEFAULT_AUTH_PROVIDERS;
     return parsed.filter(
-      (p: unknown): p is AuthProvider => p === "email" || p === "oauth",
+      (p: unknown): p is AuthProvider =>
+        authProviderSchema.safeParse(p).success,
     );
   } catch {
     return DEFAULT_AUTH_PROVIDERS;
@@ -58,22 +59,22 @@ export function getEnabledAuthProviders(
 /**
  * Single source of truth for computing which sign-up providers are currently
  * available, factoring in the public-signup toggle, the configured provider
- * list, whether OAuth env vars are present, and the first-user special case.
+ * list, which providers this instance has configured (env-dependent, so
+ * supplied by the caller), and the first-user special case.
  */
 export function getAvailableSignupProviders(opts: {
   isFirstUser: boolean;
   publicSignupEnabled: boolean;
   signupProvidersConfig: string | undefined | null;
-  oauthConfigured: boolean;
+  configuredProviders: AuthProvider[];
 }): AuthProvider[] {
   if (opts.isFirstUser) {
-    const providers: AuthProvider[] = ["email"];
-    if (opts.oauthConfigured) providers.push("oauth");
-    return providers;
+    return authProviderSchema.options.filter((p) =>
+      opts.configuredProviders.includes(p),
+    );
   }
   if (!opts.publicSignupEnabled) return [];
-  const providers = getEnabledAuthProviders(opts.signupProvidersConfig);
-  return opts.oauthConfigured
-    ? providers
-    : providers.filter((p) => p !== "oauth");
+  return getEnabledAuthProviders(opts.signupProvidersConfig).filter((p) =>
+    opts.configuredProviders.includes(p),
+  );
 }

--- a/apps/app/src/lib/constants.ts
+++ b/apps/app/src/lib/constants.ts
@@ -68,13 +68,12 @@ export function getAvailableSignupProviders(opts: {
   signupProvidersConfig: string | undefined | null;
   configuredProviders: AuthProvider[];
 }): AuthProvider[] {
+  const configured = new Set(opts.configuredProviders);
   if (opts.isFirstUser) {
-    return authProviderSchema.options.filter((p) =>
-      opts.configuredProviders.includes(p),
-    );
+    return authProviderSchema.options.filter((p) => configured.has(p));
   }
   if (!opts.publicSignupEnabled) return [];
   return getEnabledAuthProviders(opts.signupProvidersConfig).filter((p) =>
-    opts.configuredProviders.includes(p),
+    configured.has(p),
   );
 }

--- a/apps/app/src/server/api/routers/admin/config.ts
+++ b/apps/app/src/server/api/routers/admin/config.ts
@@ -281,9 +281,10 @@ export const getSigninConfig = publicProcedure.handler(async () => {
   const isFirstUser = (userCount?.count ?? 0) === 0;
   const oauthConfigured = isOAuthConfigured();
   const configuredProviders = getConfiguredAuthProviders();
+  const configuredProviderSet = new Set(configuredProviders);
 
   const signinProviders = getEnabledAuthProviders(signinConfig?.value).filter(
-    (p) => configuredProviders.includes(p),
+    (p) => configuredProviderSet.has(p),
   );
 
   const signupProviders = getAvailableSignupProviders({

--- a/apps/app/src/server/api/routers/admin/config.ts
+++ b/apps/app/src/server/api/routers/admin/config.ts
@@ -11,7 +11,10 @@ import {
   getEnabledAuthProviders,
   isPublicSignupEnabled,
 } from "~/lib/constants";
-import { isOAuthConfigured } from "~/server/auth/constants";
+import {
+  getConfiguredAuthProviders,
+  isOAuthConfigured,
+} from "~/server/auth/constants";
 import { validateInvitationToken } from "~/server/invitations";
 import { env } from "~/env";
 import { publicProcedure } from "~/server/orpc/base";
@@ -277,19 +280,17 @@ export const getSigninConfig = publicProcedure.handler(async () => {
   const userCount = await db.select({ count: count() }).from(user).get();
   const isFirstUser = (userCount?.count ?? 0) === 0;
   const oauthConfigured = isOAuthConfigured();
+  const configuredProviders = getConfiguredAuthProviders();
 
-  const filterOAuth = (providers: AuthProvider[]) =>
-    oauthConfigured ? providers : providers.filter((p) => p !== "oauth");
-
-  const signinProviders = filterOAuth(
-    getEnabledAuthProviders(signinConfig?.value),
+  const signinProviders = getEnabledAuthProviders(signinConfig?.value).filter(
+    (p) => configuredProviders.includes(p),
   );
 
   const signupProviders = getAvailableSignupProviders({
     isFirstUser,
     publicSignupEnabled: isPublicSignupEnabled(publicSignup?.value),
     signupProvidersConfig: signupConfig?.value,
-    oauthConfigured,
+    configuredProviders,
   });
 
   return {
@@ -337,7 +338,7 @@ export const getSignupConfig = publicProcedure
       isFirstUser,
       publicSignupEnabled: isPublicSignupEnabled(publicSignup?.value),
       signupProvidersConfig: signupConfig?.value,
-      oauthConfigured,
+      configuredProviders: getConfiguredAuthProviders(),
     });
 
     return {

--- a/apps/app/src/server/auth/constants.ts
+++ b/apps/app/src/server/auth/constants.ts
@@ -1,3 +1,5 @@
+import type { AuthProvider } from "~/lib/constants";
+import { authProviderSchema } from "~/lib/constants";
 import { env } from "~/env";
 
 const BASE_ORIGIN = new URL(env.PUBLIC_BASE_URL).origin;
@@ -64,4 +66,19 @@ export function isOAuthConfigured(): boolean {
     !!clientSecret &&
     (hasDiscovery || hasManualUrls)
   );
+}
+
+// Compile-enforced to cover every provider: adding one to authProviderSchema
+// without an entry here is a type error.
+const PROVIDER_CONFIGURED: Record<AuthProvider, () => boolean> = {
+  email: () => true,
+  oauth: isOAuthConfigured,
+};
+
+/**
+ * The auth providers this instance has configured (env-dependent), in
+ * schema order.
+ */
+export function getConfiguredAuthProviders(): AuthProvider[] {
+  return authProviderSchema.options.filter((p) => PROVIDER_CONFIGURED[p]());
 }

--- a/apps/app/src/server/auth/index.tsx
+++ b/apps/app/src/server/auth/index.tsx
@@ -3,15 +3,12 @@ import { betterAuth } from "better-auth";
 import { admin, emailOTP, genericOAuth } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
-import { APIError, createAuthMiddleware } from "better-auth/api";
+import { createAuthMiddleware } from "better-auth/api";
 import { createMiddleware } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import { redirect } from "@tanstack/react-router";
-import { asc, count, eq } from "drizzle-orm";
 import { checkout, polar, portal, webhooks } from "@polar-sh/better-auth";
-import { createElement } from "react";
 import { db } from "../db";
-import { appConfig, session, user } from "../db/schema";
 import {
   getPolarProductIds,
   IS_BILLING_ENABLED,
@@ -22,25 +19,20 @@ import {
   applySubscriptionSideEffects,
   syncPolarDataToKV,
 } from "../subscriptions/kv";
-import NewUserNotificationEmail from "~/emails/new-user-notification";
+import type { AuthAttempt } from "~/server/auth/policy";
 import ResetPasswordEmail from "~/emails/reset-password";
 import VerifyEmailEmail from "~/emails/verify-email";
 import VerifyEmailChangeEmail from "~/emails/verify-email-change";
-import {
-  BASE_SIGNED_OUT_URL,
-  getAvailableSignupProviders,
-  getEnabledAuthProviders,
-  isPublicSignupEnabled,
-} from "~/lib/constants";
+import { BASE_SIGNED_OUT_URL } from "~/lib/constants";
 import {
   isOAuthConfigured,
   TRUSTED_ORIGINS_SET,
 } from "~/server/auth/constants";
-import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
 import {
-  redeemInvitationToken,
-  validateInvitationToken,
-} from "~/server/invitations";
+  applyPostAuthPolicy,
+  enforceAuthAttemptPolicy,
+} from "~/server/auth/policy";
+import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
 import { setOtpCooldown } from "~/server/otp";
 import { captureException, logError, logMessage } from "~/server/logger";
 import { env } from "~/env";
@@ -218,6 +210,28 @@ function buildGenericOAuthPlugin() {
   ];
 }
 
+// Classify a Better Auth request path into the explicit provider identity
+// and intent the shared policy service consumes. OAuth gates as sign-in for
+// both the start and callback paths; disallowed auto-signups are rolled
+// back by the post-auth policy instead.
+function classifyAuthRequest(
+  path: string,
+): Pick<AuthAttempt, "provider" | "intent"> | undefined {
+  if (path.startsWith("/sign-up")) {
+    return { provider: "email", intent: "sign-up" };
+  }
+  if (path.startsWith("/sign-in/email")) {
+    return { provider: "email", intent: "sign-in" };
+  }
+  if (
+    path.startsWith("/sign-in/oauth2") ||
+    path.startsWith("/oauth2/callback/")
+  ) {
+    return { provider: "oauth", intent: "sign-in" };
+  }
+  return undefined;
+}
+
 export const auth = betterAuth({
   baseURL: env.PUBLIC_BASE_URL,
   database: drizzleAdapter(db, {
@@ -336,232 +350,35 @@ export const auth = betterAuth({
 
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
-      const isEmailSignUp = ctx.path.startsWith("/sign-up");
-      const isEmailSignIn = ctx.path.startsWith("/sign-in/email");
-      const isOAuth =
-        ctx.path.startsWith("/sign-in/oauth2") ||
-        ctx.path.startsWith("/oauth2/callback/");
+      const attempt = classifyAuthRequest(ctx.path);
+      if (!attempt) return;
 
-      if (!isEmailSignUp && !isEmailSignIn && !isOAuth) return;
-
-      // In demo mode, allow all sign-ups without gating so auto-provisioning
-      // can create users on demand.
-      if (IS_DEMO_INSTANCE && isEmailSignUp) return;
-
-      // Allow first user to use any available method
-      const userCount = await db.select({ count: count() }).from(user).get();
-      if ((userCount?.count ?? 0) === 0) return;
-
-      const configs = await db.select().from(appConfig).all();
-      const signinConfig = configs.find(
-        (c) => c.key === "enabled-signin-providers",
-      );
-      const signupConfig = configs.find(
-        (c) => c.key === "enabled-signup-providers",
-      );
-      const publicSignupConfig = configs.find(
-        (c) => c.key === "public-signup-enabled",
-      );
-      const signinProviders = getEnabledAuthProviders(signinConfig?.value);
-
-      // Sign-in gating
-      if (isEmailSignIn && !signinProviders.includes("email")) {
-        throw new APIError("BAD_REQUEST", {
-          message: "Email sign in is currently disabled",
-        });
-      }
-
-      if (isOAuth && !signinProviders.includes("oauth")) {
-        throw new APIError("BAD_REQUEST", {
-          message: "OAuth is currently disabled",
-        });
-      }
-
-      const oauthConfigured = isOAuthConfigured();
-      const availableSignupProviders = getAvailableSignupProviders({
-        isFirstUser: false,
-        publicSignupEnabled: isPublicSignupEnabled(publicSignupConfig?.value),
-        signupProvidersConfig: signupConfig?.value,
-        oauthConfigured,
+      await enforceAuthAttemptPolicy({
+        ...attempt,
+        invitationToken: ctx.body?.invitationToken,
       });
-
-      // Sign-up gating
-      if (isEmailSignUp && !availableSignupProviders.includes("email")) {
-        // Check for a valid invitation token before blocking.
-        // The invitationToken field is an extra body param passed through by
-        // Better Auth — not schema-validated, so we type-check manually.
-        const invitationToken = ctx.body?.invitationToken;
-        if (typeof invitationToken === "string") {
-          const validatedInvitationToken =
-            await validateInvitationToken(invitationToken);
-          if (validatedInvitationToken) {
-            // Token is valid — allow sign-up to proceed. The after hook
-            // atomically records the redemption (with a transaction) to
-            // prevent TOCTOU races with concurrent sign-ups.
-            return;
-          }
-        }
-
-        throw new APIError("BAD_REQUEST", {
-          message: "Sign ups are currently disabled",
-        });
-      }
-
-      // If neither OAuth sign-in nor sign-up is allowed, the isOAuth check
-      // above already blocked it. No additional gating needed here — the
-      // after hook handles the case where OAuth sign-in is enabled but
-      // sign-up is not (rolling back auto-created users).
     }),
     after: createAuthMiddleware(async (ctx) => {
       const isEmailSignUp = ctx.path.startsWith("/sign-up");
       const isOAuthCallback = ctx.path.startsWith("/oauth2/callback/");
       if (!(isEmailSignUp || isOAuthCallback)) return;
-      if (!ctx.context?.newSession?.user?.id) return;
 
-      const userId = ctx.context.newSession.user.id;
+      const newSession = ctx.context?.newSession;
+      if (!newSession?.user?.id) return;
 
-      // Atomically record the invitation redemption. The transaction in
-      // redeemInvitationToken re-checks the max-uses count so that two
-      // concurrent sign-ups can't both consume the last slot.
-      if (isEmailSignUp) {
-        const invitationToken = ctx.body?.invitationToken;
-        if (typeof invitationToken === "string") {
-          const redeemed = await redeemInvitationToken(invitationToken, userId);
-          if (!redeemed) {
-            // Another concurrent sign-up consumed the last use between the
-            // before hook and now. Roll back the newly created user via
-            // Better Auth's deleteUser API so all related records
-            // (accounts, sessions, plugin data) are properly cleaned up.
-            const headers = new Headers();
-            headers.set(
-              "Authorization",
-              `Bearer ${ctx.context.newSession.session.token}`,
-            );
-            await auth.api.deleteUser({ headers, body: {} });
-            throw new APIError("BAD_REQUEST", {
-              message: "Sign ups are currently disabled",
-            });
-          }
-        }
-      }
-
-      // Check if this user is the first user by creation time
-      const firstUser = await db
-        .select({ id: user.id })
-        .from(user)
-        .orderBy(asc(user.createdAt))
-        .limit(1)
-        .get();
-
-      if (firstUser?.id === userId && !IS_DEMO_INSTANCE) {
-        await db.update(user).set({ role: "admin" }).where(eq(user.id, userId));
-
-        // Set sign-in and sign-up methods to match how the first user signed up
-        const method: string = isOAuthCallback ? "oauth" : "email";
-        const providers = JSON.stringify([method]);
-        await db
-          .insert(appConfig)
-          .values({
-            key: "enabled-signin-providers",
-            value: providers,
-            updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: appConfig.key,
-            set: { value: providers, updatedAt: new Date() },
-          });
-        await db
-          .insert(appConfig)
-          .values({
-            key: "enabled-signup-providers",
-            value: providers,
-            updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: appConfig.key,
-            set: { value: providers, updatedAt: new Date() },
-          });
-      } else if (isOAuthCallback) {
-        // Non-first user arriving via OAuth callback — Better Auth may have
-        // auto-created a user. If this is a brand-new user (single session)
-        // and OAuth sign-ups aren't allowed, roll back the auto-created user.
-        const sessionCount = await db
-          .select({ count: count() })
-          .from(session)
-          .where(eq(session.userId, userId))
-          .get();
-
-        if ((sessionCount?.count ?? 0) <= 1) {
-          const configs = await db.select().from(appConfig).all();
-          const publicSignupConfig = configs.find(
-            (c) => c.key === "public-signup-enabled",
-          );
-          const signupConfig = configs.find(
-            (c) => c.key === "enabled-signup-providers",
-          );
-
-          const availableProviders = getAvailableSignupProviders({
-            isFirstUser: false,
-            publicSignupEnabled: isPublicSignupEnabled(
-              publicSignupConfig?.value,
-            ),
-            signupProvidersConfig: signupConfig?.value,
-            oauthConfigured: isOAuthConfigured(),
-          });
-
-          if (!availableProviders.includes("oauth")) {
-            // Roll back the auto-created user via Better Auth's deleteUser
-            // API so all related records are properly cleaned up.
-            const rollbackHeaders = new Headers();
-            rollbackHeaders.set(
-              "Authorization",
-              `Bearer ${ctx.context.newSession.session.token}`,
-            );
-            await auth.api.deleteUser({
-              headers: rollbackHeaders,
-              body: {},
-            });
-            throw new APIError("BAD_REQUEST", {
-              message: "Sign ups are currently disabled",
-            });
-          }
-        }
-      }
-
-      // Send admin notification email for non-first user sign-ups
-      if (firstUser?.id !== userId && IS_EMAIL_ENABLED) {
-        try {
-          const notifyConfig = await db
-            .select()
-            .from(appConfig)
-            .where(eq(appConfig.key, "admin-notify-on-signup"))
-            .get();
-          const emailConfig = await db
-            .select()
-            .from(appConfig)
-            .where(eq(appConfig.key, "admin-notify-email"))
-            .get();
-
-          if (notifyConfig?.value === "true" && emailConfig?.value) {
-            const newUser = ctx.context.newSession.user;
-            const html = await render(
-              createElement(NewUserNotificationEmail, {
-                userName: newUser.name,
-                userEmail: newUser.email,
-              }),
-            );
-
-            await sendEmail({
-              to: emailConfig.value,
-              subject: `New user signed up: ${newUser.name ?? newUser.email}`,
-              html,
-            });
-          }
-        } catch (err) {
-          // Don't block sign-up if notification email fails
-          captureException(err);
-        }
-      }
+      await applyPostAuthPolicy({
+        provider: isOAuthCallback ? "oauth" : "email",
+        flow: isOAuthCallback ? "callback" : "sign-up",
+        user: newSession.user,
+        invitationToken: ctx.body?.invitationToken,
+        rollbackNewUser: async () => {
+          // Delete via Better Auth's deleteUser API so all related records
+          // (accounts, sessions, plugin data) are properly cleaned up.
+          const headers = new Headers();
+          headers.set("Authorization", `Bearer ${newSession.session.token}`);
+          await auth.api.deleteUser({ headers, body: {} });
+        },
+      });
     }),
   },
 

--- a/apps/app/src/server/auth/index.tsx
+++ b/apps/app/src/server/auth/index.tsx
@@ -220,7 +220,7 @@ function classifyAuthRequest(
   if (path.startsWith("/sign-up")) {
     return { provider: "email", intent: "sign-up" };
   }
-  if (path.startsWith("/sign-in/email")) {
+  if (path === "/sign-in/email") {
     return { provider: "email", intent: "sign-in" };
   }
   if (

--- a/apps/app/src/server/auth/index.tsx
+++ b/apps/app/src/server/auth/index.tsx
@@ -19,7 +19,7 @@ import {
   applySubscriptionSideEffects,
   syncPolarDataToKV,
 } from "../subscriptions/kv";
-import type { AuthAttempt } from "~/server/auth/policy";
+import type { AuthAttempt, CompletedAuth } from "~/server/auth/policy";
 import ResetPasswordEmail from "~/emails/reset-password";
 import VerifyEmailEmail from "~/emails/verify-email";
 import VerifyEmailChangeEmail from "~/emails/verify-email-change";
@@ -232,6 +232,30 @@ function classifyAuthRequest(
   return undefined;
 }
 
+// Classify a Better Auth request path into the completed-flow identity the
+// post-auth policy consumes. Only sign-up-capable paths return a value:
+// email sign-up creates a user directly, and the OAuth callback may have
+// auto-created one.
+function classifyCompletedAuth(
+  path: string,
+): Pick<CompletedAuth, "provider" | "flow"> | undefined {
+  if (path.startsWith("/sign-up")) {
+    return { provider: "email", flow: "sign-up" };
+  }
+  if (path.startsWith("/oauth2/callback/")) {
+    return { provider: "oauth", flow: "callback" };
+  }
+  return undefined;
+}
+
+// ctx.body is unvalidated request input; only pass the token through when it
+// is actually a string.
+function getInvitationToken(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const token = (body as Record<string, unknown>).invitationToken;
+  return typeof token === "string" ? token : undefined;
+}
+
 export const auth = betterAuth({
   baseURL: env.PUBLIC_BASE_URL,
   database: drizzleAdapter(db, {
@@ -355,22 +379,20 @@ export const auth = betterAuth({
 
       await enforceAuthAttemptPolicy({
         ...attempt,
-        invitationToken: ctx.body?.invitationToken,
+        invitationToken: getInvitationToken(ctx.body),
       });
     }),
     after: createAuthMiddleware(async (ctx) => {
-      const isEmailSignUp = ctx.path.startsWith("/sign-up");
-      const isOAuthCallback = ctx.path.startsWith("/oauth2/callback/");
-      if (!(isEmailSignUp || isOAuthCallback)) return;
+      const completed = classifyCompletedAuth(ctx.path);
+      if (!completed) return;
 
       const newSession = ctx.context?.newSession;
       if (!newSession?.user?.id) return;
 
       await applyPostAuthPolicy({
-        provider: isOAuthCallback ? "oauth" : "email",
-        flow: isOAuthCallback ? "callback" : "sign-up",
+        ...completed,
         user: newSession.user,
-        invitationToken: ctx.body?.invitationToken,
+        invitationToken: getInvitationToken(ctx.body),
         rollbackNewUser: async () => {
           // Delete via Better Auth's deleteUser API so all related records
           // (accounts, sessions, plugin data) are properly cleaned up.

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -11,7 +11,7 @@ import {
   getEnabledAuthProviders,
   isPublicSignupEnabled,
 } from "~/lib/constants";
-import { isOAuthConfigured } from "~/server/auth/constants";
+import { getConfiguredAuthProviders } from "~/server/auth/constants";
 import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
 import {
   redeemInvitationToken,
@@ -36,11 +36,8 @@ const SIGN_UPS_DISABLED_MESSAGE = "Sign ups are currently disabled";
 export interface AuthAttempt {
   provider: AuthProvider;
   intent: "sign-in" | "sign-up";
-  /**
-   * Extra body param passed through by Better Auth — not schema-validated,
-   * so it is type-checked here.
-   */
-  invitationToken?: unknown;
+  /** Invitation token from the request body, if the adapter found one. */
+  invitationToken?: string;
 }
 
 /**
@@ -64,17 +61,11 @@ export async function enforceAuthAttemptPolicy(
   if ((userCount?.count ?? 0) === 0) return;
 
   const configs = await db.select().from(appConfig).all();
-  const signinConfig = configs.find(
-    (c) => c.key === "enabled-signin-providers",
-  );
-  const signupConfig = configs.find(
-    (c) => c.key === "enabled-signup-providers",
-  );
-  const publicSignupConfig = configs.find(
-    (c) => c.key === "public-signup-enabled",
-  );
 
   if (attempt.intent === "sign-in") {
+    const signinConfig = configs.find(
+      (c) => c.key === "enabled-signin-providers",
+    );
     const signinProviders = getEnabledAuthProviders(signinConfig?.value);
     if (!signinProviders.includes(attempt.provider)) {
       throw new APIError("BAD_REQUEST", {
@@ -84,16 +75,22 @@ export async function enforceAuthAttemptPolicy(
     return;
   }
 
+  const signupConfig = configs.find(
+    (c) => c.key === "enabled-signup-providers",
+  );
+  const publicSignupConfig = configs.find(
+    (c) => c.key === "public-signup-enabled",
+  );
   const availableSignupProviders = getAvailableSignupProviders({
     isFirstUser: false,
     publicSignupEnabled: isPublicSignupEnabled(publicSignupConfig?.value),
     signupProvidersConfig: signupConfig?.value,
-    oauthConfigured: isOAuthConfigured(),
+    configuredProviders: getConfiguredAuthProviders(),
   });
 
   if (!availableSignupProviders.includes(attempt.provider)) {
     // Check for a valid invitation token before blocking.
-    if (typeof attempt.invitationToken === "string") {
+    if (attempt.invitationToken !== undefined) {
       const validatedInvitationToken = await validateInvitationToken(
         attempt.invitationToken,
       );
@@ -112,12 +109,16 @@ export async function enforceAuthAttemptPolicy(
 export interface CompletedAuth {
   provider: AuthProvider;
   /**
-   * "sign-up" for explicit sign-up requests; "callback" for OAuth-style
-   * callbacks that may be either a sign-in or an auto-created sign-up.
+   * Deliberately a different axis from AuthAttempt.intent: before the
+   * request runs we know what the caller wants (sign in vs sign up); after
+   * it we only know which flow completed — "sign-up" for explicit sign-up
+   * requests, "callback" for OAuth-style callbacks that may be either a
+   * sign-in or an auto-created sign-up.
    */
   flow: "sign-up" | "callback";
   user: { id: string; name: string; email: string };
-  invitationToken?: unknown;
+  /** Invitation token from the request body, if the adapter found one. */
+  invitationToken?: string;
   /**
    * Deletes the just-created user and all related records (accounts,
    * sessions, plugin data). Supplied by the adapter because deletion goes
@@ -141,7 +142,7 @@ export async function applyPostAuthPolicy(
   // redeemInvitationToken re-checks the max-uses count so that two
   // concurrent sign-ups can't both consume the last slot.
   if (completed.flow === "sign-up") {
-    if (typeof completed.invitationToken === "string") {
+    if (completed.invitationToken !== undefined) {
       const redeemed = await redeemInvitationToken(
         completed.invitationToken,
         userId,
@@ -216,7 +217,7 @@ export async function applyPostAuthPolicy(
         isFirstUser: false,
         publicSignupEnabled: isPublicSignupEnabled(publicSignupConfig?.value),
         signupProvidersConfig: signupConfig?.value,
-        oauthConfigured: isOAuthConfigured(),
+        configuredProviders: getConfiguredAuthProviders(),
       });
 
       if (!availableProviders.includes(completed.provider)) {
@@ -252,7 +253,7 @@ export async function applyPostAuthPolicy(
 
         await sendEmail({
           to: emailConfig.value,
-          subject: `New user signed up: ${completed.user.name ?? completed.user.email}`,
+          subject: `New user signed up: ${completed.user.name}`,
           html,
         });
       }

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -1,0 +1,264 @@
+import { render } from "react-email";
+import { APIError } from "better-auth/api";
+import { asc, count, eq } from "drizzle-orm";
+import { createElement } from "react";
+import { db } from "../db";
+import { appConfig, session, user } from "../db/schema";
+import type { AuthProvider } from "~/lib/constants";
+import NewUserNotificationEmail from "~/emails/new-user-notification";
+import {
+  getAvailableSignupProviders,
+  getEnabledAuthProviders,
+  isPublicSignupEnabled,
+} from "~/lib/constants";
+import { isOAuthConfigured } from "~/server/auth/constants";
+import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
+import {
+  redeemInvitationToken,
+  validateInvitationToken,
+} from "~/server/invitations";
+import { captureException } from "~/server/logger";
+import { IS_DEMO_INSTANCE } from "~/lib/demo";
+
+/**
+ * Account policy shared by every auth method (email, generic OAuth, and
+ * future providers such as atproto). Callers identify the provider
+ * explicitly; nothing in here inspects request paths.
+ */
+
+const SIGN_IN_DISABLED_MESSAGES: Record<AuthProvider, string> = {
+  email: "Email sign in is currently disabled",
+  oauth: "OAuth is currently disabled",
+};
+
+const SIGN_UPS_DISABLED_MESSAGE = "Sign ups are currently disabled";
+
+export interface AuthAttempt {
+  provider: AuthProvider;
+  intent: "sign-in" | "sign-up";
+  /**
+   * Extra body param passed through by Better Auth — not schema-validated,
+   * so it is type-checked here.
+   */
+  invitationToken?: unknown;
+}
+
+/**
+ * Gate an incoming sign-in or sign-up attempt against the instance's
+ * enabled-provider configuration. Throws an APIError when the attempt is
+ * disallowed; returns silently when it may proceed.
+ *
+ * OAuth-style providers whose callback may auto-create a user should gate
+ * with intent "sign-in" and rely on applyPostAuthPolicy to roll back
+ * disallowed auto-signups.
+ */
+export async function enforceAuthAttemptPolicy(
+  attempt: AuthAttempt,
+): Promise<void> {
+  // In demo mode, allow all sign-ups without gating so auto-provisioning
+  // can create users on demand.
+  if (IS_DEMO_INSTANCE && attempt.intent === "sign-up") return;
+
+  // Allow first user to use any available method
+  const userCount = await db.select({ count: count() }).from(user).get();
+  if ((userCount?.count ?? 0) === 0) return;
+
+  const configs = await db.select().from(appConfig).all();
+  const signinConfig = configs.find(
+    (c) => c.key === "enabled-signin-providers",
+  );
+  const signupConfig = configs.find(
+    (c) => c.key === "enabled-signup-providers",
+  );
+  const publicSignupConfig = configs.find(
+    (c) => c.key === "public-signup-enabled",
+  );
+
+  if (attempt.intent === "sign-in") {
+    const signinProviders = getEnabledAuthProviders(signinConfig?.value);
+    if (!signinProviders.includes(attempt.provider)) {
+      throw new APIError("BAD_REQUEST", {
+        message: SIGN_IN_DISABLED_MESSAGES[attempt.provider],
+      });
+    }
+    return;
+  }
+
+  const availableSignupProviders = getAvailableSignupProviders({
+    isFirstUser: false,
+    publicSignupEnabled: isPublicSignupEnabled(publicSignupConfig?.value),
+    signupProvidersConfig: signupConfig?.value,
+    oauthConfigured: isOAuthConfigured(),
+  });
+
+  if (!availableSignupProviders.includes(attempt.provider)) {
+    // Check for a valid invitation token before blocking.
+    if (typeof attempt.invitationToken === "string") {
+      const validatedInvitationToken = await validateInvitationToken(
+        attempt.invitationToken,
+      );
+      if (validatedInvitationToken) {
+        // Token is valid — allow sign-up to proceed. The post-auth policy
+        // atomically records the redemption (with a transaction) to
+        // prevent TOCTOU races with concurrent sign-ups.
+        return;
+      }
+    }
+
+    throw new APIError("BAD_REQUEST", { message: SIGN_UPS_DISABLED_MESSAGE });
+  }
+}
+
+export interface CompletedAuth {
+  provider: AuthProvider;
+  /**
+   * "sign-up" for explicit sign-up requests; "callback" for OAuth-style
+   * callbacks that may be either a sign-in or an auto-created sign-up.
+   */
+  flow: "sign-up" | "callback";
+  user: { id: string; name: string; email: string };
+  invitationToken?: unknown;
+  /**
+   * Deletes the just-created user and all related records (accounts,
+   * sessions, plugin data). Supplied by the adapter because deletion goes
+   * through the Better Auth API with the new session's credentials.
+   */
+  rollbackNewUser: () => Promise<void>;
+}
+
+/**
+ * Apply post-authentication account policy after a new session was created
+ * by a sign-up-capable flow: invitation redemption, first-user admin
+ * promotion and initial provider recording, rollback of disallowed
+ * auto-signups, and admin signup notification.
+ */
+export async function applyPostAuthPolicy(
+  completed: CompletedAuth,
+): Promise<void> {
+  const userId = completed.user.id;
+
+  // Atomically record the invitation redemption. The transaction in
+  // redeemInvitationToken re-checks the max-uses count so that two
+  // concurrent sign-ups can't both consume the last slot.
+  if (completed.flow === "sign-up") {
+    if (typeof completed.invitationToken === "string") {
+      const redeemed = await redeemInvitationToken(
+        completed.invitationToken,
+        userId,
+      );
+      if (!redeemed) {
+        // Another concurrent sign-up consumed the last use between the
+        // attempt gate and now. Roll back the newly created user.
+        await completed.rollbackNewUser();
+        throw new APIError("BAD_REQUEST", {
+          message: SIGN_UPS_DISABLED_MESSAGE,
+        });
+      }
+    }
+  }
+
+  // Check if this user is the first user by creation time
+  const firstUser = await db
+    .select({ id: user.id })
+    .from(user)
+    .orderBy(asc(user.createdAt))
+    .limit(1)
+    .get();
+
+  if (firstUser?.id === userId && !IS_DEMO_INSTANCE) {
+    await db.update(user).set({ role: "admin" }).where(eq(user.id, userId));
+
+    // Set sign-in and sign-up methods to match how the first user signed up
+    const providers = JSON.stringify([completed.provider]);
+    await db
+      .insert(appConfig)
+      .values({
+        key: "enabled-signin-providers",
+        value: providers,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: appConfig.key,
+        set: { value: providers, updatedAt: new Date() },
+      });
+    await db
+      .insert(appConfig)
+      .values({
+        key: "enabled-signup-providers",
+        value: providers,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: appConfig.key,
+        set: { value: providers, updatedAt: new Date() },
+      });
+  } else if (completed.flow === "callback") {
+    // Non-first user arriving via a callback — the provider may have
+    // auto-created a user. If this is a brand-new user (single session)
+    // and sign-ups for this provider aren't allowed, roll back the
+    // auto-created user.
+    const sessionCount = await db
+      .select({ count: count() })
+      .from(session)
+      .where(eq(session.userId, userId))
+      .get();
+
+    if ((sessionCount?.count ?? 0) <= 1) {
+      const configs = await db.select().from(appConfig).all();
+      const publicSignupConfig = configs.find(
+        (c) => c.key === "public-signup-enabled",
+      );
+      const signupConfig = configs.find(
+        (c) => c.key === "enabled-signup-providers",
+      );
+
+      const availableProviders = getAvailableSignupProviders({
+        isFirstUser: false,
+        publicSignupEnabled: isPublicSignupEnabled(publicSignupConfig?.value),
+        signupProvidersConfig: signupConfig?.value,
+        oauthConfigured: isOAuthConfigured(),
+      });
+
+      if (!availableProviders.includes(completed.provider)) {
+        await completed.rollbackNewUser();
+        throw new APIError("BAD_REQUEST", {
+          message: SIGN_UPS_DISABLED_MESSAGE,
+        });
+      }
+    }
+  }
+
+  // Send admin notification email for non-first user sign-ups
+  if (firstUser?.id !== userId && IS_EMAIL_ENABLED) {
+    try {
+      const notifyConfig = await db
+        .select()
+        .from(appConfig)
+        .where(eq(appConfig.key, "admin-notify-on-signup"))
+        .get();
+      const emailConfig = await db
+        .select()
+        .from(appConfig)
+        .where(eq(appConfig.key, "admin-notify-email"))
+        .get();
+
+      if (notifyConfig?.value === "true" && emailConfig?.value) {
+        const html = await render(
+          createElement(NewUserNotificationEmail, {
+            userName: completed.user.name,
+            userEmail: completed.user.email,
+          }),
+        );
+
+        await sendEmail({
+          to: emailConfig.value,
+          subject: `New user signed up: ${completed.user.name ?? completed.user.email}`,
+          html,
+        });
+      }
+    } catch (err) {
+      // Don't block sign-up if notification email fails
+      captureException(err);
+    }
+  }
+}


### PR DESCRIPTION
- Extract the account policy embedded in the Better Auth `hooks.before`/`hooks.after` into a shared `src/server/auth/policy.ts` service
- Policy functions take an explicit provider identity (`email | oauth`, extensible to `atproto`) instead of inferring it from request paths
- Hooks are now thin adapters: classify the request path, then delegate to `enforceAuthAttemptPolicy` / `applyPostAuthPolicy`
- Pure refactor, no behavior change