### PR TITLE
Suppress release notifier on first visit

### DIFF
--- a/apps/app/src/components/feed/UserManagementButton.tsx
+++ b/apps/app/src/components/feed/UserManagementButton.tsx
@@ -23,6 +23,7 @@ import {
   SidebarMenuItem,
 } from "~/components/ui/sidebar";
 import { authClient, signOut } from "~/lib/auth-client";
+import { clearUserDataAfterSignOut } from "~/lib/auth/sign-out-cleanup";
 import { useClearAllUserData } from "~/lib/data/atoms";
 import { useSubscription } from "~/lib/data/subscription";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
@@ -142,8 +143,11 @@ export function UserManagementNavItem() {
                       setIsSigningOut(true);
                     },
                     onSuccess: () => {
-                      queryClient.clear();
-                      clearAllUserData();
+                      clearUserDataAfterSignOut({
+                        clearQueryCache: () => queryClient.clear(),
+                        clearPersistedUserData: clearAllUserData,
+                        localStorage: window.localStorage,
+                      });
                       void router.navigate({ to: "/auth/sign-in" });
                     },
                   },

--- a/apps/app/src/components/releases/ReleaseNotifierClient.tsx
+++ b/apps/app/src/components/releases/ReleaseNotifierClient.tsx
@@ -14,6 +14,11 @@ export function ReleaseNotifierClient({ slug }: { slug: string | undefined }) {
 
     const lastViewedSlug = window.localStorage.getItem(RELEASE_SLUG_KEY);
 
+    if (lastViewedSlug === null) {
+      window.localStorage.setItem(RELEASE_SLUG_KEY, slug);
+      return;
+    }
+
     if (lastViewedSlug !== slug) {
       window.localStorage.setItem(RELEASE_SLUG_KEY, slug);
 

--- a/apps/app/src/lib/auth/sign-out-cleanup.ts
+++ b/apps/app/src/lib/auth/sign-out-cleanup.ts
@@ -1,0 +1,15 @@
+type SignOutCleanupOptions = {
+  clearQueryCache: () => void;
+  clearPersistedUserData: () => void;
+  localStorage: Pick<Storage, "clear">;
+};
+
+export function clearUserDataAfterSignOut({
+  clearQueryCache,
+  clearPersistedUserData,
+  localStorage,
+}: SignOutCleanupOptions) {
+  clearQueryCache();
+  clearPersistedUserData();
+  localStorage.clear();
+}

--- a/apps/app/tests/unit/auth/sign-out-cleanup.test.ts
+++ b/apps/app/tests/unit/auth/sign-out-cleanup.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { clearUserDataAfterSignOut } from "~/lib/auth/sign-out-cleanup";
+
+describe("clearUserDataAfterSignOut", () => {
+  it("clears every account-specific browser store", () => {
+    const clearQueryCache = vi.fn();
+    const clearPersistedUserData = vi.fn();
+    const clearLocalStorage = vi.fn();
+
+    clearUserDataAfterSignOut({
+      clearQueryCache,
+      clearPersistedUserData,
+      localStorage: { clear: clearLocalStorage },
+    });
+
+    expect(clearQueryCache).toHaveBeenCalledOnce();
+    expect(clearPersistedUserData).toHaveBeenCalledOnce();
+    expect(clearLocalStorage).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/tests/unit/components/release-notifier.test.ts
+++ b/apps/app/tests/unit/components/release-notifier.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { toast } from "sonner";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReleaseNotifierClient } from "~/components/releases/ReleaseNotifierClient";
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { dismiss: vi.fn() }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const RELEASE_SLUG_KEY = "last-viewed-release";
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function renderNotifier(slug: string | undefined) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  roots.push(root);
+
+  act(() => {
+    root.render(createElement(ReleaseNotifierClient, { slug }));
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount());
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("ReleaseNotifierClient", () => {
+  it("stores the latest release without notifying on the first visit", () => {
+    renderNotifier("release-one");
+
+    expect(window.localStorage.getItem(RELEASE_SLUG_KEY)).toBe("release-one");
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the stored release is still current", () => {
+    window.localStorage.setItem(RELEASE_SLUG_KEY, "release-one");
+
+    renderNotifier("release-one");
+
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("stores and notifies for a later release", () => {
+    window.localStorage.setItem(RELEASE_SLUG_KEY, "release-one");
+
+    renderNotifier("release-two");
+
+    expect(window.localStorage.getItem(RELEASE_SLUG_KEY)).toBe("release-two");
+    expect(toast).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
- Seed the current release without notifying when browser release history is empty.
- Clear account-specific browser storage after a deliberate sign-out.
- Cover first-visit, later-release, and sign-out cleanup behavior.