### PR TITLE
Add atmosphere admin toggles and lockout accounting

### DIFF
--- a/apps/app/.env.test.self-hosted
+++ b/apps/app/.env.test.self-hosted
@@ -28,12 +28,20 @@ SENTRY_AUTH_TOKEN=
 VITE_PUBLIC_SENTRY_DSN_WEB=
 VITE_PUBLIC_SUPPORT_EMAIL_ADDRESS=
 
-OAUTH_PROVIDER_ID=
-OAUTH_PROVIDER_NAME=
-OAUTH_CLIENT_ID=
-OAUTH_CLIENT_SECRET=
+# Generic OAuth configured-but-inert (endpoints are never reached) so the
+# auth pages render the provider section with every button, keeping provider
+# ordering testable end to end.
+OAUTH_PROVIDER_ID=test-oauth
+OAUTH_PROVIDER_NAME=TestOAuth
+OAUTH_CLIENT_ID=test-oauth-client
+OAUTH_CLIENT_SECRET=test-oauth-secret
 OAUTH_DISCOVERY_URL=
-OAUTH_AUTHORIZATION_URL=
-OAUTH_TOKEN_URL=
+OAUTH_AUTHORIZATION_URL=http://127.0.0.1:1/authorize
+OAUTH_TOKEN_URL=http://127.0.0.1:1/token
 OAUTH_USER_INFO_URL=
 OAUTH_PKCE=
+
+# AT Protocol / Atmosphere: test-only key material, generated for this file
+# and used by nothing outside the e2e environments.
+ATPROTO_CLIENT_PRIVATE_KEYS=[{"kid":"serial-e2e-atproto","kty":"EC","x":"UaHzpE90u3BVVoZzsXddWOiIEezh9LiBPLp0p69ymZo","y":"V0feJobyiqI8CfdGqhmbFKaqTGEChO15vnjKW3T8A1s","crv":"P-256","d":"XZpTXlc8pfIIhj69noJs60BiOLSQyzXJcBn-zKBQ-HU"}]
+ATPROTO_STORE_ENCRYPTION_KEY=nFvS2nKvS15m2BjQCWvWZtimxKN5UJDTI9yb5Hm4ucA=

--- a/apps/app/src/components/admin/PublicSignupToggle.tsx
+++ b/apps/app/src/components/admin/PublicSignupToggle.tsx
@@ -125,6 +125,7 @@ export function PublicSignupToggle() {
   const signinProviders = data?.signinProviders ?? ["email"];
   const signupProviders = data?.signupProviders ?? ["email"];
   const oauthConfigured = data?.isOAuthConfigured ?? false;
+  const atprotoConfigured = data?.isAtprotoConfigured ?? false;
   const oauthProviderName = data?.oauthProviderName ?? "OAuth";
   const adminSigninMethods = data?.adminSigninMethods ?? ["email"];
 
@@ -175,6 +176,16 @@ export function PublicSignupToggle() {
                 isPending={signupProvidersMutation.isPending}
               />
             )}
+
+            {atprotoConfigured && (
+              <ProviderToggle
+                id="signup-atproto-toggle"
+                label="Atmosphere"
+                checked={signupProviders.includes("atproto")}
+                onToggle={(checked) => toggleSignup("atproto", checked)}
+                isPending={signupProvidersMutation.isPending}
+              />
+            )}
           </>
         )}
 
@@ -222,6 +233,17 @@ export function PublicSignupToggle() {
             onToggle={(checked) => toggleSignin("oauth", checked)}
             isPending={signinMutation.isPending}
             lockedTooltip={getSigninLockedTooltip("oauth")}
+          />
+        )}
+
+        {atprotoConfigured && (
+          <ProviderToggle
+            id="signin-atproto-toggle"
+            label="Atmosphere"
+            checked={signinProviders.includes("atproto")}
+            onToggle={(checked) => toggleSignin("atproto", checked)}
+            isPending={signinMutation.isPending}
+            lockedTooltip={getSigninLockedTooltip("atproto")}
           />
         )}
       </div>

--- a/apps/app/src/lib/constants.ts
+++ b/apps/app/src/lib/constants.ts
@@ -33,6 +33,63 @@ export type AuthProvider = z.infer<typeof authProviderSchema>;
 /** Better Auth provider ID stored in the `account` table for email/password users */
 export const CREDENTIAL_PROVIDER_ID = "credential";
 
+/** Better Auth provider ID stored in the `account` table for AT Protocol users */
+export const ATPROTO_PROVIDER_ID = "atproto";
+
+/**
+ * Per-admin sign-in methods derived from account rows, counting only
+ * providers this instance has configured (env-dependent, so supplied by
+ * the caller). Lockout accounting builds on this: a sign-in method may
+ * not be disabled while it is some admin's only way in. Pure so both
+ * admin config handlers share one accounting of which account rows count
+ * as which method.
+ */
+export function getAdminSigninMethods(options: {
+  adminUserIds: string[];
+  accountRows: Array<{ userId: string; providerId: string }>;
+  /** The instance's OAuth provider id, or undefined when OAuth is not fully configured. */
+  oauthProviderId: string | undefined;
+  atprotoConfigured: boolean;
+}): AuthProvider[][] {
+  return options.adminUserIds.map((adminId) => {
+    const rows = options.accountRows.filter((r) => r.userId === adminId);
+    const methods: AuthProvider[] = [];
+    if (rows.some((r) => r.providerId === CREDENTIAL_PROVIDER_ID)) {
+      methods.push("email");
+    }
+    if (
+      options.oauthProviderId &&
+      rows.some((r) => r.providerId === options.oauthProviderId)
+    ) {
+      methods.push("oauth");
+    }
+    if (
+      options.atprotoConfigured &&
+      rows.some((r) => r.providerId === ATPROTO_PROVIDER_ID)
+    ) {
+      methods.push("atproto");
+    }
+    return methods;
+  });
+}
+
+/**
+ * Whether enabling exactly `enabledProviders` would take away some admin's
+ * only working sign-in method. Admins with no working method at all are
+ * skipped: the setting can't lock them out further, and refusing on their
+ * behalf would reject every change, including widening ones.
+ */
+export function wouldDisableSoleAdminSigninMethod(
+  perAdminMethods: AuthProvider[][],
+  enabledProviders: AuthProvider[],
+): boolean {
+  const enabled = new Set(enabledProviders);
+  return perAdminMethods.some(
+    (methods) =>
+      methods.length > 0 && !methods.some((method) => enabled.has(method)),
+  );
+}
+
 const DEFAULT_AUTH_PROVIDERS: AuthProvider[] = ["email"];
 
 /**

--- a/apps/app/src/lib/constants.ts
+++ b/apps/app/src/lib/constants.ts
@@ -74,8 +74,8 @@ export function getAdminSigninMethods(options: {
 }
 
 /**
- * Whether enabling exactly `enabledProviders` would take away some admin's
- * only working sign-in method. Admins with no working method at all are
+ * Whether restricting the enabled set to `enabledProviders` would take away
+ * some admin's only working sign-in method. Admins with no working method at all are
  * skipped: the setting can't lock them out further, and refusing on their
  * behalf would reject every change, including widening ones.
  */

--- a/apps/app/src/server/api/routers/admin/config.ts
+++ b/apps/app/src/server/api/routers/admin/config.ts
@@ -6,15 +6,16 @@ import { adminProcedure } from "./base";
 import type { AuthProvider } from "~/lib/constants";
 import {
   authProviderSchema,
-  CREDENTIAL_PROVIDER_ID,
   getAvailableSignupProviders,
   getEnabledAuthProviders,
   isPublicSignupEnabled,
 } from "~/lib/constants";
 import {
   getConfiguredAuthProviders,
+  isAtprotoConfigured,
   isOAuthConfigured,
 } from "~/server/auth/constants";
+import { getAdminSigninMethods } from "~/server/auth/policy";
 import { validateInvitationToken } from "~/server/invitations";
 import { env } from "~/env";
 import { publicProcedure } from "~/server/orpc/base";
@@ -54,21 +55,14 @@ export const getPublicSignupSetting = adminProcedure.handler(async () => {
       )
       .all();
 
-    const oauthProviderId = env.OAUTH_PROVIDER_ID;
-
     // A method is "required" if any admin has it as their only sign-in method
-    for (const admin of adminUsers) {
-      const rows = adminAccountRows.filter((r) => r.userId === admin.id);
-      const methods: AuthProvider[] = [];
-      if (rows.some((a) => a.providerId === CREDENTIAL_PROVIDER_ID)) {
-        methods.push("email");
-      }
-      if (
-        oauthProviderId &&
-        rows.some((a) => a.providerId === oauthProviderId)
-      ) {
-        methods.push("oauth");
-      }
+    const perAdminMethods = getAdminSigninMethods({
+      adminUserIds: adminUsers.map((u) => u.id),
+      accountRows: adminAccountRows,
+      oauthProviderId: env.OAUTH_PROVIDER_ID,
+      atprotoConfigured: isAtprotoConfigured(),
+    });
+    for (const methods of perAdminMethods) {
       if (methods.length === 1) {
         requiredMethods.add(methods[0]!);
       }
@@ -80,6 +74,7 @@ export const getPublicSignupSetting = adminProcedure.handler(async () => {
     signinProviders: getEnabledAuthProviders(signinProvidersConfig?.value),
     signupProviders: getEnabledAuthProviders(signupProvidersConfig?.value),
     isOAuthConfigured: isOAuthConfigured(),
+    isAtprotoConfigured: isAtprotoConfigured(),
     oauthProviderName: env.OAUTH_PROVIDER_NAME ?? "OAuth",
     adminSigninMethods: [...requiredMethods],
   };
@@ -194,20 +189,14 @@ export const setEnabledSigninProviders = adminProcedure
         )
         .all();
 
-      const oauthProviderId = env.OAUTH_PROVIDER_ID;
       const enabledProviderSet = new Set(input.providers);
-      for (const admin of adminUsers) {
-        const methods: AuthProvider[] = [];
-        const rows = adminAccountRows.filter((r) => r.userId === admin.id);
-        if (rows.some((a) => a.providerId === CREDENTIAL_PROVIDER_ID)) {
-          methods.push("email");
-        }
-        if (
-          oauthProviderId &&
-          rows.some((a) => a.providerId === oauthProviderId)
-        ) {
-          methods.push("oauth");
-        }
+      const perAdminMethods = getAdminSigninMethods({
+        adminUserIds: adminUsers.map((u) => u.id),
+        accountRows: adminAccountRows,
+        oauthProviderId: env.OAUTH_PROVIDER_ID,
+        atprotoConfigured: isAtprotoConfigured(),
+      });
+      for (const methods of perAdminMethods) {
         const hasRemaining = methods.some((method) =>
           enabledProviderSet.has(method),
         );

--- a/apps/app/src/server/api/routers/admin/config.ts
+++ b/apps/app/src/server/api/routers/admin/config.ts
@@ -6,16 +6,17 @@ import { adminProcedure } from "./base";
 import type { AuthProvider } from "~/lib/constants";
 import {
   authProviderSchema,
+  getAdminSigninMethods,
   getAvailableSignupProviders,
   getEnabledAuthProviders,
   isPublicSignupEnabled,
+  wouldDisableSoleAdminSigninMethod,
 } from "~/lib/constants";
 import {
   getConfiguredAuthProviders,
   isAtprotoConfigured,
   isOAuthConfigured,
 } from "~/server/auth/constants";
-import { getAdminSigninMethods } from "~/server/auth/policy";
 import { validateInvitationToken } from "~/server/invitations";
 import { env } from "~/env";
 import { publicProcedure } from "~/server/orpc/base";
@@ -59,7 +60,7 @@ export const getPublicSignupSetting = adminProcedure.handler(async () => {
     const perAdminMethods = getAdminSigninMethods({
       adminUserIds: adminUsers.map((u) => u.id),
       accountRows: adminAccountRows,
-      oauthProviderId: env.OAUTH_PROVIDER_ID,
+      oauthProviderId: isOAuthConfigured() ? env.OAUTH_PROVIDER_ID : undefined,
       atprotoConfigured: isAtprotoConfigured(),
     });
     for (const methods of perAdminMethods) {
@@ -189,23 +190,19 @@ export const setEnabledSigninProviders = adminProcedure
         )
         .all();
 
-      const enabledProviderSet = new Set(input.providers);
       const perAdminMethods = getAdminSigninMethods({
         adminUserIds: adminUsers.map((u) => u.id),
         accountRows: adminAccountRows,
-        oauthProviderId: env.OAUTH_PROVIDER_ID,
+        oauthProviderId: isOAuthConfigured()
+          ? env.OAUTH_PROVIDER_ID
+          : undefined,
         atprotoConfigured: isAtprotoConfigured(),
       });
-      for (const methods of perAdminMethods) {
-        const hasRemaining = methods.some((method) =>
-          enabledProviderSet.has(method),
-        );
-        if (!hasRemaining) {
-          throw new ORPCError("BAD_REQUEST", {
-            message:
-              "Cannot disable sign-in methods — this would lock out an admin user",
-          });
-        }
+      if (wouldDisableSoleAdminSigninMethod(perAdminMethods, input.providers)) {
+        throw new ORPCError("BAD_REQUEST", {
+          message:
+            "Cannot disable sign-in methods — this would lock out an admin user",
+        });
       }
     }
 

--- a/apps/app/src/server/auth/atproto/config.ts
+++ b/apps/app/src/server/auth/atproto/config.ts
@@ -18,6 +18,7 @@ import { env } from "~/env";
  *   node -e "crypto.subtle.generateKey({name:'ECDSA',namedCurve:'P-256'},true,['sign']).then(async k=>console.log(JSON.stringify({kid:crypto.randomUUID(),...await crypto.subtle.exportKey('jwk',k.privateKey)})))"
  */
 
+// Canonical definition lives in ~/lib/constants, beside the other provider ids.
 export { ATPROTO_PROVIDER_ID } from "~/lib/constants";
 
 /** The identity-only v1 scope; broader grants arrive via upgrade(). */

--- a/apps/app/src/server/auth/atproto/config.ts
+++ b/apps/app/src/server/auth/atproto/config.ts
@@ -18,7 +18,7 @@ import { env } from "~/env";
  *   node -e "crypto.subtle.generateKey({name:'ECDSA',namedCurve:'P-256'},true,['sign']).then(async k=>console.log(JSON.stringify({kid:crypto.randomUUID(),...await crypto.subtle.exportKey('jwk',k.privateKey)})))"
  */
 
-export const ATPROTO_PROVIDER_ID = "atproto";
+export { ATPROTO_PROVIDER_ID } from "~/lib/constants";
 
 /** The identity-only v1 scope; broader grants arrive via upgrade(). */
 export const ATPROTO_SCOPE = "atproto";

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -7,7 +7,6 @@ import { appConfig, session, user } from "../db/schema";
 import type { AuthProvider } from "~/lib/constants";
 import NewUserNotificationEmail from "~/emails/new-user-notification";
 import {
-  CREDENTIAL_PROVIDER_ID,
   getAvailableSignupProviders,
   getEnabledAuthProviders,
   isPublicSignupEnabled,
@@ -34,41 +33,6 @@ const SIGN_IN_DISABLED_MESSAGES: Record<AuthProvider, string> = {
 };
 
 const SIGN_UPS_DISABLED_MESSAGE = "Sign ups are currently disabled";
-
-/**
- * Per-admin sign-in methods derived from account rows, counting only
- * providers this instance has configured. Lockout accounting builds on
- * this: a sign-in method may not be disabled while it is some admin's
- * only way in. Pure so both admin config handlers share one accounting
- * of which account rows count as which method.
- */
-export function getAdminSigninMethods(options: {
-  adminUserIds: string[];
-  accountRows: Array<{ userId: string; providerId: string }>;
-  oauthProviderId: string | undefined;
-  atprotoConfigured: boolean;
-}): AuthProvider[][] {
-  return options.adminUserIds.map((adminId) => {
-    const rows = options.accountRows.filter((r) => r.userId === adminId);
-    const methods: AuthProvider[] = [];
-    if (rows.some((r) => r.providerId === CREDENTIAL_PROVIDER_ID)) {
-      methods.push("email");
-    }
-    if (
-      options.oauthProviderId &&
-      rows.some((r) => r.providerId === options.oauthProviderId)
-    ) {
-      methods.push("oauth");
-    }
-    if (
-      options.atprotoConfigured &&
-      rows.some((r) => r.providerId === "atproto")
-    ) {
-      methods.push("atproto");
-    }
-    return methods;
-  });
-}
 
 export interface AuthAttempt {
   provider: AuthProvider;

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -7,6 +7,7 @@ import { appConfig, session, user } from "../db/schema";
 import type { AuthProvider } from "~/lib/constants";
 import NewUserNotificationEmail from "~/emails/new-user-notification";
 import {
+  CREDENTIAL_PROVIDER_ID,
   getAvailableSignupProviders,
   getEnabledAuthProviders,
   isPublicSignupEnabled,
@@ -33,6 +34,41 @@ const SIGN_IN_DISABLED_MESSAGES: Record<AuthProvider, string> = {
 };
 
 const SIGN_UPS_DISABLED_MESSAGE = "Sign ups are currently disabled";
+
+/**
+ * Per-admin sign-in methods derived from account rows, counting only
+ * providers this instance has configured. Lockout accounting builds on
+ * this: a sign-in method may not be disabled while it is some admin's
+ * only way in. Pure so both admin config handlers share one accounting
+ * of which account rows count as which method.
+ */
+export function getAdminSigninMethods(options: {
+  adminUserIds: string[];
+  accountRows: Array<{ userId: string; providerId: string }>;
+  oauthProviderId: string | undefined;
+  atprotoConfigured: boolean;
+}): AuthProvider[][] {
+  return options.adminUserIds.map((adminId) => {
+    const rows = options.accountRows.filter((r) => r.userId === adminId);
+    const methods: AuthProvider[] = [];
+    if (rows.some((r) => r.providerId === CREDENTIAL_PROVIDER_ID)) {
+      methods.push("email");
+    }
+    if (
+      options.oauthProviderId &&
+      rows.some((r) => r.providerId === options.oauthProviderId)
+    ) {
+      methods.push("oauth");
+    }
+    if (
+      options.atprotoConfigured &&
+      rows.some((r) => r.providerId === "atproto")
+    ) {
+      methods.push("atproto");
+    }
+    return methods;
+  });
+}
 
 export interface AuthAttempt {
   provider: AuthProvider;

--- a/apps/app/tests/e2e/fixtures/set-enabled-auth-providers.ts
+++ b/apps/app/tests/e2e/fixtures/set-enabled-auth-providers.ts
@@ -1,0 +1,41 @@
+import { createClient } from "@libsql/client";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import * as schema from "../../../src/server/db/schema";
+import type { AuthProvider } from "../../../src/lib/constants";
+
+export async function setEnabledAuthProviders(
+  tursoPort: number,
+  providers: AuthProvider[],
+) {
+  const client = createClient({ url: `http://127.0.0.1:${tursoPort}` });
+  const db = drizzle({ client, schema });
+  const value = JSON.stringify(providers);
+
+  for (const key of [
+    "enabled-signin-providers",
+    "enabled-signup-providers",
+  ] as const) {
+    await db
+      .insert(schema.appConfig)
+      .values({ key, value, updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: schema.appConfig.key,
+        set: { value, updatedAt: new Date() },
+      });
+
+    const row = await db
+      .select()
+      .from(schema.appConfig)
+      .where(eq(schema.appConfig.key, key))
+      .get();
+
+    if (row?.value !== value) {
+      throw new Error(
+        `setEnabledAuthProviders: expected "${value}" for ${key} but got "${row?.value}"`,
+      );
+    }
+  }
+
+  client.close();
+}

--- a/apps/app/tests/e2e/self-hosted/admin-signin-methods.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/admin-signin-methods.spec.ts
@@ -128,12 +128,10 @@ test.describe("admin sign-in method settings", () => {
     await clearQueryCache(page);
     await page.reload();
 
-    const signinSection = page
-      .locator("div")
-      .filter({ has: page.getByText("Sign-in methods", { exact: true }) })
-      .last();
+    // The row's label keeps its stable htmlFor id even when the switch is
+    // replaced by the locked indicator.
     await expect(
-      signinSection.getByText("Atmosphere", { exact: true }),
+      page.locator('label[for="signin-atproto-toggle"]'),
     ).toBeVisible({ timeout: 30000 });
     await expect(page.locator("#signin-atproto-toggle")).toHaveCount(0);
   });

--- a/apps/app/tests/e2e/self-hosted/admin-signin-methods.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/admin-signin-methods.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "@playwright/test";
+import { createClient } from "@libsql/client";
+import { createId } from "@paralleldrive/cuid2";
+import { signUpAsAdmin } from "../fixtures/auth";
+import { SELF_HOSTED_TURSO_PORT } from "../fixtures/ports";
+import { cleanupUser, generateTestEmail } from "../fixtures/seed-db";
+import { setEnabledAuthProviders } from "../fixtures/set-enabled-auth-providers";
+import type { Page } from "@playwright/test";
+
+/**
+ * Admin sign-in method settings for the Atmosphere provider: the toggle
+ * renders alongside email/OAuth, disabling it gates the authorize endpoint
+ * server-side, and lockout accounting locks the row while an admin's only
+ * sign-in method is an atproto DID.
+ */
+
+/** Seed an admin whose only account row is an atproto DID. */
+async function seedAtprotoOnlyAdmin(tursoPort: number, email: string) {
+  const client = createClient({ url: `http://127.0.0.1:${tursoPort}` });
+  const now = Math.floor(Date.now() / 1000);
+  const userId = createId();
+
+  await client.batch([
+    {
+      sql: `INSERT INTO serial_user (id, name, email, email_verified, image, created_at, updated_at, role)
+            VALUES (?, 'Atmosphere Admin', ?, 1, NULL, ?, ?, 'admin')`,
+      args: [userId, email, now, now],
+    },
+    {
+      sql: `INSERT INTO serial_account (id, account_id, provider_id, user_id, created_at, updated_at)
+            VALUES (?, ?, 'atproto', ?, ?, ?)`,
+      args: [createId(), `did:plc:e2e${userId}`, userId, now, now],
+    },
+  ]);
+
+  client.close();
+}
+
+async function clearQueryCache(page: Page) {
+  await page.evaluate(() => {
+    try {
+      localStorage.removeItem("REACT_QUERY_OFFLINE_CACHE");
+    } catch {
+      // localStorage may not be available in some contexts
+    }
+  });
+}
+
+test.describe("admin sign-in method settings", () => {
+  let adminEmail: string;
+  let atprotoAdminEmail: string;
+
+  test.afterEach(async () => {
+    // Restore the global-setup provider state for other specs.
+    await setEnabledAuthProviders(SELF_HOSTED_TURSO_PORT, [
+      "email",
+      "oauth",
+      "atproto",
+    ]);
+    if (atprotoAdminEmail) {
+      await cleanupUser(SELF_HOSTED_TURSO_PORT, atprotoAdminEmail);
+    }
+    if (adminEmail) {
+      await cleanupUser(SELF_HOSTED_TURSO_PORT, adminEmail);
+    }
+  });
+
+  test("atmosphere toggle gates sign-in server-side and locks for an atproto-only admin", async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    adminEmail = generateTestEmail();
+
+    await signUpAsAdmin({
+      page,
+      tursoPort: SELF_HOSTED_TURSO_PORT,
+      name: "Settings Admin",
+      email: adminEmail,
+      password: "testpassword123",
+    });
+    // seedAdmin resets the enabled providers to email only.
+    await setEnabledAuthProviders(SELF_HOSTED_TURSO_PORT, [
+      "email",
+      "oauth",
+      "atproto",
+    ]);
+
+    await page.goto("/admin/settings");
+    await clearQueryCache(page);
+    await page.reload();
+
+    // Atmosphere rows render in both method sections.
+    const signinToggle = page.locator("#signin-atproto-toggle");
+    await expect(signinToggle).toBeVisible({ timeout: 30000 });
+    await expect(page.locator("#signup-atproto-toggle")).toBeVisible();
+    await expect(signinToggle).toBeChecked();
+
+    // Disable Atmosphere sign-in.
+    await signinToggle.click();
+    await expect(page.getByText("Sign-in methods updated")).toBeVisible();
+    await expect(signinToggle).not.toBeChecked();
+
+    // The authorize endpoint is gated server-side, not just in the UI.
+    const disabled = await page.evaluate(async () => {
+      const response = await fetch("/api/auth/atproto/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier: "example.bsky.social" }),
+      });
+      return {
+        status: response.status,
+        body: (await response.json()) as { message?: string },
+      };
+    });
+    expect(disabled.status).toBe(400);
+    expect(disabled.body.message).toContain(
+      "Atmosphere sign in is currently disabled",
+    );
+
+    // Re-enable it.
+    await signinToggle.click();
+    await expect(signinToggle).toBeChecked();
+
+    // With an admin whose only method is an atproto DID, the row locks:
+    // the switch is replaced by the locked indicator.
+    atprotoAdminEmail = generateTestEmail();
+    await seedAtprotoOnlyAdmin(SELF_HOSTED_TURSO_PORT, atprotoAdminEmail);
+    await clearQueryCache(page);
+    await page.reload();
+
+    const signinSection = page
+      .locator("div")
+      .filter({ has: page.getByText("Sign-in methods", { exact: true }) })
+      .last();
+    await expect(
+      signinSection.getByText("Atmosphere", { exact: true }),
+    ).toBeVisible({ timeout: 30000 });
+    await expect(page.locator("#signin-atproto-toggle")).toHaveCount(0);
+  });
+});

--- a/apps/app/tests/global-setup.self-hosted.ts
+++ b/apps/app/tests/global-setup.self-hosted.ts
@@ -7,6 +7,7 @@ import {
 } from "./e2e/fixtures/ports";
 import { seedAdmin } from "./e2e/fixtures/auth";
 import { resetDb } from "./e2e/fixtures/reset-db";
+import { setEnabledAuthProviders } from "./e2e/fixtures/set-enabled-auth-providers";
 
 async function waitForApp(url: string, timeoutMs = 60000) {
   const deadline = Date.now() + timeoutMs;
@@ -32,6 +33,13 @@ export default async function globalSetup() {
     resetDb(SELF_HOSTED_BOOTSTRAP_TURSO_PORT),
   ]);
   await enablePublicSignups(SELF_HOSTED_TURSO_PORT);
+  // Every configured provider enabled, so the auth pages render the full
+  // provider section (email, Atmosphere, generic OAuth) for ordering specs.
+  await setEnabledAuthProviders(SELF_HOSTED_TURSO_PORT, [
+    "email",
+    "oauth",
+    "atproto",
+  ]);
   await seedAdmin({
     tursoPort: SELF_HOSTED_TURSO_PORT,
     name: "E2E Harness Admin",

--- a/apps/app/tests/unit/auth/admin-signin-lockout.test.ts
+++ b/apps/app/tests/unit/auth/admin-signin-lockout.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import {
+  getAdminSigninMethods,
+  wouldDisableSoleAdminSigninMethod,
+} from "~/lib/constants";
 
 /**
  * Lockout accounting for admin sign-in methods: getAdminSigninMethods is
@@ -8,13 +12,6 @@ import { describe, expect, it, vi } from "vitest";
  * atproto DID must count as atproto-only, so disabling Atmosphere for
  * them is refused rather than silently locking them out.
  */
-
-vi.mock("~/server/db", () => ({ db: undefined }));
-vi.mock("~/server/auth/constants", () => ({
-  getConfiguredAuthProviders: () => ["email", "oauth", "atproto"],
-}));
-
-const { getAdminSigninMethods } = await import("~/server/auth/policy");
 
 const OAUTH_PROVIDER_ID = "test-oauth";
 
@@ -93,5 +90,31 @@ describe("getAdminSigninMethods", () => {
       atprotoConfigured: true,
     });
     expect(methods).toEqual([]);
+  });
+});
+
+describe("wouldDisableSoleAdminSigninMethod", () => {
+  it("refuses to disable an admin's only method", () => {
+    expect(
+      wouldDisableSoleAdminSigninMethod([["atproto"]], ["email", "oauth"]),
+    ).toBe(true);
+  });
+
+  it("allows disabling a method every admin can do without", () => {
+    expect(
+      wouldDisableSoleAdminSigninMethod(
+        [["email", "atproto"], ["email"]],
+        ["email"],
+      ),
+    ).toBe(false);
+  });
+
+  it("skips admins with no working sign-in method", () => {
+    // A zero-method admin (their provider's env configuration is gone)
+    // can't be locked out further; refusing on their behalf would reject
+    // every change, including widening ones.
+    expect(wouldDisableSoleAdminSigninMethod([[], ["email"]], ["email"])).toBe(
+      false,
+    );
   });
 });

--- a/apps/app/tests/unit/auth/admin-signin-lockout.test.ts
+++ b/apps/app/tests/unit/auth/admin-signin-lockout.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Lockout accounting for admin sign-in methods: getAdminSigninMethods is
+ * the shared per-admin method derivation behind both the required-method
+ * read path (getPublicSignupSetting) and the disable guard
+ * (setEnabledSigninProviders). An admin whose only account row is an
+ * atproto DID must count as atproto-only, so disabling Atmosphere for
+ * them is refused rather than silently locking them out.
+ */
+
+vi.mock("~/server/db", () => ({ db: undefined }));
+vi.mock("~/server/auth/constants", () => ({
+  getConfiguredAuthProviders: () => ["email", "oauth", "atproto"],
+}));
+
+const { getAdminSigninMethods } = await import("~/server/auth/policy");
+
+const OAUTH_PROVIDER_ID = "test-oauth";
+
+describe("getAdminSigninMethods", () => {
+  it("counts credential, oauth, and atproto rows per admin", () => {
+    const methods = getAdminSigninMethods({
+      adminUserIds: ["a1", "a2", "a3"],
+      accountRows: [
+        { userId: "a1", providerId: "credential" },
+        { userId: "a2", providerId: OAUTH_PROVIDER_ID },
+        { userId: "a3", providerId: "atproto" },
+      ],
+      oauthProviderId: OAUTH_PROVIDER_ID,
+      atprotoConfigured: true,
+    });
+    expect(methods).toEqual([["email"], ["oauth"], ["atproto"]]);
+  });
+
+  it("gives an atproto-only admin a non-empty method list", () => {
+    // The regression this guards: an empty list made every provider-settings
+    // change throw the lockout error for such an admin.
+    const [methods] = getAdminSigninMethods({
+      adminUserIds: ["a1"],
+      accountRows: [{ userId: "a1", providerId: "atproto" }],
+      oauthProviderId: undefined,
+      atprotoConfigured: true,
+    });
+    expect(methods).toEqual(["atproto"]);
+  });
+
+  it("lists every method for a fully linked admin", () => {
+    const [methods] = getAdminSigninMethods({
+      adminUserIds: ["a1"],
+      accountRows: [
+        { userId: "a1", providerId: "credential" },
+        { userId: "a1", providerId: OAUTH_PROVIDER_ID },
+        { userId: "a1", providerId: "atproto" },
+      ],
+      oauthProviderId: OAUTH_PROVIDER_ID,
+      atprotoConfigured: true,
+    });
+    expect(methods).toEqual(["email", "oauth", "atproto"]);
+  });
+
+  it("ignores atproto rows when atproto is not configured", () => {
+    const [methods] = getAdminSigninMethods({
+      adminUserIds: ["a1"],
+      accountRows: [
+        { userId: "a1", providerId: "credential" },
+        { userId: "a1", providerId: "atproto" },
+      ],
+      oauthProviderId: undefined,
+      atprotoConfigured: false,
+    });
+    expect(methods).toEqual(["email"]);
+  });
+
+  it("ignores oauth rows when no oauth provider id is configured", () => {
+    const [methods] = getAdminSigninMethods({
+      adminUserIds: ["a1"],
+      accountRows: [
+        { userId: "a1", providerId: "credential" },
+        { userId: "a1", providerId: "some-oauth" },
+      ],
+      oauthProviderId: undefined,
+      atprotoConfigured: true,
+    });
+    expect(methods).toEqual(["email"]);
+  });
+
+  it("keeps admins with no account rows at an empty list", () => {
+    const [methods] = getAdminSigninMethods({
+      adminUserIds: ["a1"],
+      accountRows: [],
+      oauthProviderId: OAUTH_PROVIDER_ID,
+      atprotoConfigured: true,
+    });
+    expect(methods).toEqual([]);
+  });
+});


### PR DESCRIPTION
- extend admin sign-in/sign-up method settings with an Atmosphere toggle row, gated on instance configuration like the OAuth row
- extract shared per-admin sign-in method accounting into the auth policy service and use it for both the required-method read path and the disable guard
- count atproto DID accounts in lockout accounting so an atproto-only admin cannot be locked out (and can change provider settings at all)
- unit tests for the shared accounting; e2e spec covering the toggle, server-side authorize gating, and the locked row for an atproto-only admin
- mirror the atproto/oauth e2e env configuration from the auth-flows branch so both merge cleanly